### PR TITLE
Revision G edits

### DIFF
--- a/pcb/cap-charger.kicad_sch
+++ b/pcb/cap-charger.kicad_sch
@@ -905,7 +905,7 @@
 					)
 				)
 			)
-			(property "Footprint" "oe:TI_R-PDSS_B4_SMD"
+			(property "Footprint" "open-ephys:TI_R-PDSS_B4_SMD"
 				(at 0 -1.27 0)
 				(effects
 					(font

--- a/pcb/mcu-flash.kicad_sch
+++ b/pcb/mcu-flash.kicad_sch
@@ -2222,7 +2222,7 @@
 			(in_bom yes)
 			(on_board yes)
 			(property "Reference" "U"
-				(at -8.89 8.89 0)
+				(at -6.35 11.43 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2230,7 +2230,7 @@
 				)
 			)
 			(property "Value" "W25Q128JVS"
-				(at 7.62 8.89 0)
+				(at 7.62 11.43 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2238,7 +2238,7 @@
 				)
 			)
 			(property "Footprint" "Package_SO:SOIC-8_5.23x5.23mm_P1.27mm"
-				(at 0 0 0)
+				(at 0 22.86 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2246,8 +2246,8 @@
 					(hide yes)
 				)
 			)
-			(property "Datasheet" "http://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
-				(at 0 0 0)
+			(property "Datasheet" "https://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
+				(at 0 25.4 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -2256,7 +2256,7 @@
 				)
 			)
 			(property "Description" "128Mb Serial Flash Memory, Standard/Dual/Quad SPI, SOIC-8"
-				(at 0 0 0)
+				(at 0 27.94 0)
 				(effects
 					(font
 						(size 1.27 1.27)
@@ -9994,7 +9994,7 @@
 		(uuid "6d47248b-5da9-4a34-a166-8717d7a94cdf")
 	)
 	(hierarchical_label "LTC44_{CURR}"
-		(shape output)
+		(shape input)
 		(at 168.91 134.62 0)
 		(fields_autoplaced yes)
 		(effects
@@ -10192,7 +10192,7 @@
 				(hide yes)
 			)
 		)
-		(property "Datasheet" "http://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
+		(property "Datasheet" "https://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
 			(at 36.83 88.9 0)
 			(effects
 				(font
@@ -12738,7 +12738,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "C0402C0G500-220GNP-CT"
 			(at 60.96 107.95 0)
 			(effects
 				(font
@@ -14129,7 +14129,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "C0402C0G500-220GNP-CT"
 			(at 60.96 120.65 0)
 			(effects
 				(font

--- a/pcb/oe-commutator-controller.kicad_pcb
+++ b/pcb/oe-commutator-controller.kicad_pcb
@@ -9,7 +9,7 @@
 	(paper "A4")
 	(title_block
 		(title "Open Ephys Commutator Controller")
-		(rev "F")
+		(rev "G")
 		(company "Open Ephys, Inc")
 		(comment 1 "Cris Sharp")
 		(comment 2 "Jonathan P. Newman")
@@ -261,7 +261,7 @@
 		(property "Reference" "R30"
 			(at -0.05 -1.15 90)
 			(layer "F.SilkS")
-			(uuid "9668bd3b-77de-4dfb-99e2-2b163e961a47")
+			(uuid "ea1ca312-d2a9-42e4-b086-ef6aace1975e")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -273,7 +273,7 @@
 			(at 0 1.43 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "829e95cc-0ba8-4b6f-a2d0-bcdfb4856fd6")
+			(uuid "01712629-0b44-4f14-82ed-f85a03d93e36")
 			(effects
 				(font
 					(size 1 1)
@@ -286,7 +286,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2ccfd693-de6f-42ed-98f1-882cbd21cbcd")
+			(uuid "a6cfa32e-be67-4ee3-9e6f-55a26347b3f5")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -299,7 +299,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0b39ce64-6d20-43c2-93ad-65d3414608c4")
+			(uuid "cfd4100f-2126-4e93-82cd-5f29c96eada6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -312,7 +312,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a386a743-4538-4ea6-beb7-9248e30126e0")
+			(uuid "dce29f2c-f285-4aef-bbc4-f74dbd9c3655")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -333,7 +333,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "7a7e1f85-f2b8-4340-a3b8-f5298c0c76e7")
+			(uuid "f023109c-6a9f-4162-af8a-9125b33d1762")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -343,7 +343,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fb5accea-c12a-43c7-9bcd-dfa98d83eb1d")
+			(uuid "b30e36bd-70b1-479f-94c8-a370e584361b")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -353,7 +353,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b48e6f35-dd9d-441f-9276-151758c2532a")
+			(uuid "2b4f99c9-7199-4bd9-ac9f-06f633159f78")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -363,7 +363,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "76f8e5c7-249f-42ca-a37d-a6ac199c5ea4")
+			(uuid "db2fc73a-ba58-496c-89a2-3f4499312dc8")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -373,7 +373,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "35fa675f-c145-4564-be89-ffd673d68cf0")
+			(uuid "e8e2324d-74fb-40e6-9c26-3c8a4184cfc3")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -383,7 +383,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6877d4a4-57c3-4c07-81fe-adfcb23689df")
+			(uuid "6ce63cfa-eaf5-4c8d-9344-aaee4f27b0c3")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -393,7 +393,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ad875c28-e664-47fc-b905-5a2e1a5de931")
+			(uuid "cfb2edd9-73b3-408c-aa40-a55374dce9eb")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -403,7 +403,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "af462458-eeb2-4a23-a8ff-117dedc9aa14")
+			(uuid "10e2fb3b-1b58-4a31-aaa4-785dc7bd8e6f")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -413,7 +413,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "473a6d49-1f1d-4f93-bf33-6f933e771fb3")
+			(uuid "793aa0f4-7bce-45eb-9900-9a07b60586f1")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -423,12 +423,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d7882aa1-4d21-420b-882e-3c562ae36bf0")
+			(uuid "2ac84c87-4acd-43a6-becf-713be2e15124")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "5606f817-4969-4f56-97ff-ea5a8cb57bb9")
+			(uuid "6f759e48-609d-48a8-9278-615229605f5b")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -443,7 +443,7 @@
 			(roundrect_rratio 0.25)
 			(net 93 "/RGB Driver/SCL")
 			(pintype "passive")
-			(uuid "33657dee-5b18-4c67-b005-87ac494f481c")
+			(uuid "c90b9cba-2d56-40c0-8f19-64f8e9eff4e6")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -452,7 +452,7 @@
 			(roundrect_rratio 0.25)
 			(net 28 "/MCU/SCL")
 			(pintype "passive")
-			(uuid "fe34e2a4-2a0a-4bb3-b0bf-e46b39220d2b")
+			(uuid "0660dec7-4913-4bb3-827e-89b57df05d57")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -475,7 +475,7 @@
 		(property "Reference" "R4"
 			(at 2.2 -0.2 0)
 			(layer "F.SilkS")
-			(uuid "015799f5-c099-45de-ad58-cd0272fba8c5")
+			(uuid "033237ea-b66a-4255-9a12-608fd3adaabd")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -487,7 +487,7 @@
 			(at 0 1.17 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7a09d30b-b4ea-4fda-9ae6-72e4b13bef61")
+			(uuid "c0ac8367-19c9-461a-8912-ab1c205dccef")
 			(effects
 				(font
 					(size 1 1)
@@ -500,7 +500,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "429780ad-78cf-4d2b-a12e-0e3483a82981")
+			(uuid "e8175bdf-4ab2-44ed-bf6d-6d0e7e2a38fd")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -513,7 +513,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0f8c97b4-002a-4d65-9838-12a985024e55")
+			(uuid "5ec6d492-0a65-4198-8ecf-2dec16d0ce02")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -526,7 +526,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "96244774-7ce6-44cc-bb95-48e21d23517f")
+			(uuid "0df5da88-4477-405e-981a-d9b3086749e3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -547,7 +547,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a700ec24-5805-479f-8273-84de42cc5321")
+			(uuid "bbe2aeac-6daa-412a-af99-3bc4179c15f4")
 		)
 		(fp_line
 			(start -0.153641 0.38)
@@ -557,7 +557,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "bc65829f-2613-47c6-970d-ee80c0228e78")
+			(uuid "9f768974-8a11-42d3-9c02-d43d4cca6812")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -567,7 +567,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fbff0d9c-dc52-485c-9e26-647c51e8fa5e")
+			(uuid "1df4b3ee-bfef-4a50-9632-540c03001178")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -577,7 +577,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "610e80ec-8c67-4d13-946e-2cb851bd15e2")
+			(uuid "564afa66-8f67-455b-b162-ddfc0088a8fe")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -587,7 +587,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a2756fb5-bbde-4b91-9528-0069d1aa4383")
+			(uuid "a87f3091-acc7-4f26-b75d-bfc8d6d2fe5e")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -597,7 +597,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8991aab3-bac1-4987-82ee-cb5cc3484695")
+			(uuid "a5f5381d-6b3d-476c-94b6-42cc2bb45cd3")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -607,7 +607,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2a934e0a-1654-47f0-817f-c04d219eca8a")
+			(uuid "88cfb34b-a13a-4474-9a4d-7c2bf95879f9")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -617,7 +617,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f4fa1028-a2a1-4827-8c08-cc400cdd2403")
+			(uuid "7a0fdf3f-8f97-4f72-babc-7aa33dcb3706")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -627,7 +627,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b3c93c15-eea1-47e5-92e1-70bff60245c5")
+			(uuid "575b9dfe-0cc7-44a5-971e-38b67288d6d1")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -637,12 +637,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "dd87e112-3f5d-4002-a9dc-aeb99516424f")
+			(uuid "3a782e6c-88d1-4496-b3b0-d16d7565b67a")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "25cd6f4f-5b1c-440a-9239-84da3b7f5a2b")
+			(uuid "f574a42f-597b-4e9b-a531-e71ff9055921")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -657,7 +657,7 @@
 			(roundrect_rratio 0.25)
 			(net 30 "Net-(U2-USB_DP)")
 			(pintype "passive")
-			(uuid "e275a989-e7d3-47a2-8e25-f9ebb6e99ea1")
+			(uuid "21a4fd42-d1f9-4b50-9e0c-dffd29015abd")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0)
@@ -666,7 +666,7 @@
 			(roundrect_rratio 0.25)
 			(net 24 "/MCU/D_{+}")
 			(pintype "passive")
-			(uuid "8e0d7d58-a455-4785-939f-e071d18d6493")
+			(uuid "31e1bb95-aeba-4513-89a7-c3292bf3ce3e")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -689,7 +689,7 @@
 		(property "Reference" "J1"
 			(at 0.025 7.4 0)
 			(layer "F.SilkS")
-			(uuid "c24fee22-30a7-4739-906a-faa803b31440")
+			(uuid "083c398c-0351-483c-89cc-c7e33e5520d8")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -701,7 +701,7 @@
 			(at 0 7.41 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7a821349-3161-417f-bcd4-075a6c108294")
+			(uuid "dd0b0300-1d23-471f-812c-53f5cb1e20a9")
 			(effects
 				(font
 					(size 1 1)
@@ -714,7 +714,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "84dbf827-74d5-45a3-a93a-c5b57a9f0b2f")
+			(uuid "45d95e26-b79d-4166-a082-f15ec300d9bf")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -727,7 +727,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "196de875-42c9-4e75-8b78-4b7fcac408a4")
+			(uuid "a6ca4972-18b3-463d-9909-b4e3259db673")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -740,7 +740,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5ff4c8aa-21cc-4134-b6c4-acff4fa344f2")
+			(uuid "bc970190-8af2-464b-93ed-9a91b82e69da")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -761,7 +761,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cf64ade7-d95d-462a-80db-af228c15445e")
+			(uuid "5499c7ad-5045-4c11-a4b5-1b93dece29cd")
 		)
 		(fp_line
 			(start -2.6 5.84)
@@ -771,7 +771,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a3ebdeb8-c2d3-4b03-8b93-45ac4c14cfc0")
+			(uuid "ab9b8703-c76d-4b8f-8fa6-33192e375c7b")
 		)
 		(fp_line
 			(start 2.6 5.84)
@@ -781,7 +781,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "804c2c1b-a97f-4449-b1d6-903b06f1d711")
+			(uuid "1414e57d-877c-4b08-b6fd-74ecc43f0f79")
 		)
 		(fp_line
 			(start -2.6 3.3)
@@ -791,7 +791,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0215ba88-2be6-4a93-8520-4bf6065e79e2")
+			(uuid "f4214371-5844-42e9-a994-ff410b7d21e1")
 		)
 		(fp_line
 			(start 2.6 3.3)
@@ -801,7 +801,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "63cc0853-adcf-4bde-8eb3-9fa1194138fe")
+			(uuid "d715adf3-6aeb-4334-b15a-98933a90a7b5")
 		)
 		(fp_line
 			(start -2.6 0.76)
@@ -811,7 +811,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b18b6f72-7a7f-44c7-9f24-f51bf9d5687a")
+			(uuid "922d10c7-1ed8-4b6c-91f7-bfa1725937e2")
 		)
 		(fp_line
 			(start 2.6 0.76)
@@ -821,7 +821,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ac4b162d-66a9-4dca-b22b-9ac3bdd92090")
+			(uuid "b77b0c46-cfef-4d25-9ff3-6dc88cbea571")
 		)
 		(fp_line
 			(start -2.6 -1.78)
@@ -831,7 +831,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b3317cbd-e1d2-47ae-8dba-d62d8bf8a3a5")
+			(uuid "9a834406-3a4d-41e3-bbec-43fef9fd6fa2")
 		)
 		(fp_line
 			(start 2.6 -1.78)
@@ -841,7 +841,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c03ab087-1f08-4261-9a58-20827d588a00")
+			(uuid "fb8f50df-a759-4e9f-9728-06fadc1c01a8")
 		)
 		(fp_line
 			(start -2.6 -4.32)
@@ -851,7 +851,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d2b01750-6e1c-4b9f-a763-72fda47cf4d5")
+			(uuid "51735eec-cd04-4515-9b06-120f5c3ba869")
 		)
 		(fp_line
 			(start 2.6 -4.32)
@@ -861,7 +861,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e49ef50d-28d5-456b-be39-25f013d71fd5")
+			(uuid "70d3594f-8433-4bb8-b180-ff8413f8072e")
 		)
 		(fp_line
 			(start -4.04 -5.84)
@@ -871,7 +871,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "239db052-9fc6-45d9-9049-5efb400653f6")
+			(uuid "53e0df68-82a8-4291-a149-ca563c7e4c88")
 		)
 		(fp_line
 			(start -2.6 -6.41)
@@ -881,7 +881,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "67678b09-c914-4c98-b1fb-dbc15473b642")
+			(uuid "5b732462-806d-4949-a5b7-9a23d474432f")
 		)
 		(fp_line
 			(start -2.6 -6.41)
@@ -891,7 +891,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "32a83faa-4758-488d-a045-afdc37915bef")
+			(uuid "84e1ed09-33d5-487b-b3e3-e31c155b04b0")
 		)
 		(fp_line
 			(start 2.6 -6.41)
@@ -901,7 +901,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "799a751e-93ee-4dc5-b9c0-86419b87c93d")
+			(uuid "81f62c58-8283-4f21-a7b3-85b809b66097")
 		)
 		(fp_line
 			(start -5.9 6.85)
@@ -911,7 +911,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f61bba52-29a4-4248-b99e-b31cd8d2d89c")
+			(uuid "80242d65-7a8c-4c0f-9369-68fe97ef7fb4")
 		)
 		(fp_line
 			(start 5.9 6.85)
@@ -921,7 +921,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f13cd467-7f12-45cd-b909-1f7b023c1cca")
+			(uuid "e7c3684f-9c23-4105-b9b8-6fa08fa0a59a")
 		)
 		(fp_line
 			(start -5.9 -6.85)
@@ -931,7 +931,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ae70620b-9204-424e-9bf1-d688de925671")
+			(uuid "5a1dd2ae-705a-4100-8cae-7ff8e7b345bd")
 		)
 		(fp_line
 			(start 5.9 -6.85)
@@ -941,7 +941,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3a9a4f0f-01fc-4000-902f-82da42471dd4")
+			(uuid "cae5942b-2ccf-4046-8080-679329bfb1c6")
 		)
 		(fp_line
 			(start -2.54 6.35)
@@ -951,7 +951,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "05a9105b-f450-4255-a726-56f15524e728")
+			(uuid "579bfe08-06f3-4c69-9dc9-1c2092cb6bd7")
 		)
 		(fp_line
 			(start 2.54 6.35)
@@ -961,7 +961,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b142ffc3-173e-4961-862a-59b132b580c1")
+			(uuid "0a21e0a2-0489-46f4-897d-ed0d3b3ad4b7")
 		)
 		(fp_line
 			(start -3.6 5.4)
@@ -971,7 +971,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2a16f495-0094-43a5-bf06-f17e87ed281e")
+			(uuid "723de36d-877f-4027-9834-6a0088c40482")
 		)
 		(fp_line
 			(start 3.6 5.4)
@@ -981,7 +981,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5f49ff98-e102-47e0-951d-a20d7eeca544")
+			(uuid "97cd150d-a9b0-4169-855d-260ab1167b70")
 		)
 		(fp_line
 			(start -3.6 4.76)
@@ -991,7 +991,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3cec9b1a-4ef3-4395-acce-dad61ff600bb")
+			(uuid "da76320e-8d20-4b4b-8370-7af6833822db")
 		)
 		(fp_line
 			(start -2.54 4.76)
@@ -1001,7 +1001,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8ab0d140-1a1d-467a-9107-e8345ea79c1b")
+			(uuid "b7ed9c9f-cd7c-4c8e-b5bd-38d5152fbb7b")
 		)
 		(fp_line
 			(start 2.54 4.76)
@@ -1011,7 +1011,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d63140ad-c185-4040-a977-fc4da022da28")
+			(uuid "5aef7721-1bbe-4490-8051-eb233a1a515d")
 		)
 		(fp_line
 			(start 3.6 4.76)
@@ -1021,7 +1021,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e1ece893-c562-45ee-b127-5d03ba93e3b7")
+			(uuid "c8a74da0-e141-4eda-a634-30d6daeb9d93")
 		)
 		(fp_line
 			(start -3.6 2.86)
@@ -1031,7 +1031,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1c268be7-3b87-46f8-9c0f-32a15a8ffe0e")
+			(uuid "f3eca31d-54f3-486e-aa95-8c2f0c34654c")
 		)
 		(fp_line
 			(start 3.6 2.86)
@@ -1041,7 +1041,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2332b4c3-b476-4da0-a8ee-fac53ad7f134")
+			(uuid "00ed01d4-6db7-4550-ade0-293e6618a573")
 		)
 		(fp_line
 			(start -3.6 2.22)
@@ -1051,7 +1051,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2fda65d1-54ca-414d-a736-080fd8451650")
+			(uuid "59e90503-a47e-4d0d-83f3-79d75862259b")
 		)
 		(fp_line
 			(start -2.54 2.22)
@@ -1061,7 +1061,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8bb7f735-6db7-49d5-b7fe-64f920f0b756")
+			(uuid "c19e5375-b5f8-48f6-af52-fcf94fe81c5e")
 		)
 		(fp_line
 			(start 2.54 2.22)
@@ -1071,7 +1071,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5f92a289-89e3-40f7-b993-251f0dd3dc48")
+			(uuid "0a61c92f-c6ae-4c11-853d-cf326eb57b77")
 		)
 		(fp_line
 			(start 3.6 2.22)
@@ -1081,7 +1081,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6f406b71-f39f-4d30-b8a2-7e47256afbde")
+			(uuid "e8fe0270-0c1f-4a90-9d30-4f22338cf3f6")
 		)
 		(fp_line
 			(start -3.6 0.32)
@@ -1091,7 +1091,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "912f6ef3-c212-43fe-9d2a-bf2de9a11d21")
+			(uuid "7589b7c0-8a78-4445-a9bf-178a2afce387")
 		)
 		(fp_line
 			(start 3.6 0.32)
@@ -1101,7 +1101,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ebb7053a-6e8c-40ea-b699-0a3e9fe3b42a")
+			(uuid "fb5948fd-5780-4cf2-9d14-1a2a1316cc49")
 		)
 		(fp_line
 			(start -3.6 -0.32)
@@ -1111,7 +1111,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c21d1562-d988-4803-9186-54cab93bc4de")
+			(uuid "467b1e8b-c51a-4da4-9421-3028bd0e1ac1")
 		)
 		(fp_line
 			(start -2.54 -0.32)
@@ -1121,7 +1121,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4261d1c8-62be-495d-ae68-839c21719c3b")
+			(uuid "0c198120-64b6-40aa-9955-2e692055fc09")
 		)
 		(fp_line
 			(start 2.54 -0.32)
@@ -1131,7 +1131,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "377a1007-8960-4958-95df-4f7094773fe6")
+			(uuid "7c74108f-6f33-4c32-bad9-e6c11612e270")
 		)
 		(fp_line
 			(start 3.6 -0.32)
@@ -1141,7 +1141,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "67293a92-5cf2-42b3-8710-568fdd4a6bf6")
+			(uuid "f301b4c5-8b93-4ca2-8e0e-031407ff899b")
 		)
 		(fp_line
 			(start -3.6 -2.22)
@@ -1151,7 +1151,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ea0ad2d4-f919-4a1f-971b-cc6352ebfc27")
+			(uuid "fd89746f-9f49-4bf6-b2f5-9264db1f606e")
 		)
 		(fp_line
 			(start 3.6 -2.22)
@@ -1161,7 +1161,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "781096ec-d4a1-424e-aeab-9c7256fea6e5")
+			(uuid "5ca071f4-d89e-4d79-8fb1-57ebfa89713b")
 		)
 		(fp_line
 			(start -3.6 -2.86)
@@ -1171,7 +1171,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8b45cedc-bda7-4160-8450-6d1349b2e879")
+			(uuid "3bfdb942-8a59-4dd2-8985-cf9d9db9c811")
 		)
 		(fp_line
 			(start -2.54 -2.86)
@@ -1181,7 +1181,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5f4ca9b8-f5d9-44e7-8284-c0347748ed15")
+			(uuid "5ef9d2fd-b02e-4497-9eec-6d3efb25260b")
 		)
 		(fp_line
 			(start 2.54 -2.86)
@@ -1191,7 +1191,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3758aa52-ec56-45c5-a378-03b428179542")
+			(uuid "64c1a585-0feb-446c-b2f5-2192cde1965d")
 		)
 		(fp_line
 			(start 3.6 -2.86)
@@ -1201,7 +1201,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8ffae884-8a79-4d00-95c3-e77b21fc65bf")
+			(uuid "6ae1eca0-ac83-4506-b9fc-2bcdcdd8e610")
 		)
 		(fp_line
 			(start -3.6 -4.76)
@@ -1211,7 +1211,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "647a1514-accf-4b52-868b-6f8b5ae7ed18")
+			(uuid "1d193746-b8ea-4a60-a752-0850dfaf3e0e")
 		)
 		(fp_line
 			(start 3.6 -4.76)
@@ -1221,7 +1221,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9b49014b-6d4f-464f-a518-1b65653a8698")
+			(uuid "9013156e-23cd-4e54-84a8-8b171cffadf5")
 		)
 		(fp_line
 			(start -3.6 -5.4)
@@ -1231,7 +1231,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "87e46441-5e48-400e-98b3-82866ca35945")
+			(uuid "ec90f58f-494d-4e69-9db4-73289ef7e4e9")
 		)
 		(fp_line
 			(start -2.54 -5.4)
@@ -1241,7 +1241,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "33b95a53-feb9-4272-a39f-51ed1a63fead")
+			(uuid "2bf47d20-9735-4d2a-a321-4f3a07b1d02c")
 		)
 		(fp_line
 			(start -2.54 -5.4)
@@ -1251,7 +1251,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a25a41b4-1d47-4b9b-a0bf-c35432a84fe9")
+			(uuid "19a8fe37-8541-4aa9-864a-1483c1a13111")
 		)
 		(fp_line
 			(start 2.54 -5.4)
@@ -1261,7 +1261,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "460f3968-3f84-4abc-b5c3-2a95e8ed37e6")
+			(uuid "127af40e-06be-47b5-8f77-b148cf774e6f")
 		)
 		(fp_line
 			(start 3.6 -5.4)
@@ -1271,7 +1271,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0954efa4-c2ce-4b85-af14-dc8b590b33a0")
+			(uuid "7419e82e-e15b-43e6-9ee2-8654b38b38b1")
 		)
 		(fp_line
 			(start -1.59 -6.35)
@@ -1281,7 +1281,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f979b6c9-72f1-4236-a3bc-1f642d30ce12")
+			(uuid "dec0d968-02ea-4790-9eb5-814e2f4f4fb8")
 		)
 		(fp_line
 			(start 2.54 -6.35)
@@ -1291,12 +1291,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "712bec68-a5bd-4d7d-ad67-b60d0ad02b66")
+			(uuid "44ec8f89-9b94-4586-9915-f0d7798f4e30")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "3dad1f48-ab02-4476-9f59-76f8dda9edc5")
+			(uuid "5f791a53-07bb-4274-b664-b4cc06b5f943")
 			(effects
 				(font
 					(size 1 1)
@@ -1311,7 +1311,7 @@
 			(net 9 "VBUS")
 			(pinfunction "Pin_1")
 			(pintype "passive")
-			(uuid "45838cef-2686-46bf-b3ab-dcef76e89b20")
+			(uuid "e93a6a8e-fbb8-460a-9a88-e9eee5795f9d")
 		)
 		(pad "2" smd rect
 			(at 2.525 -5.08 270)
@@ -1320,7 +1320,7 @@
 			(net 18 "Net-(J1-Pin_2)")
 			(pinfunction "Pin_2")
 			(pintype "passive")
-			(uuid "8ca6441f-9f3c-4f50-800a-9f1eb383a8fd")
+			(uuid "829ab610-2cf3-4b6b-8563-cec1205f74f8")
 		)
 		(pad "3" smd rect
 			(at -2.525 -2.54 270)
@@ -1329,7 +1329,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "Pin_3")
 			(pintype "passive")
-			(uuid "0cc3c955-d2e0-42e9-b936-51372fd2c405")
+			(uuid "493a9b89-be11-41d3-8d99-e75c4f89f08b")
 		)
 		(pad "4" smd rect
 			(at 2.525 -2.54 270)
@@ -1338,7 +1338,7 @@
 			(net 19 "Net-(J1-Pin_4)")
 			(pinfunction "Pin_4")
 			(pintype "passive")
-			(uuid "de5fc2c8-2ff9-4f37-a155-025d80dfb516")
+			(uuid "4a4e9be0-60c3-4d75-a74e-1dec136b0b5b")
 		)
 		(pad "5" smd rect
 			(at -2.525 0 270)
@@ -1347,7 +1347,7 @@
 			(net 1 "GND")
 			(pinfunction "Pin_5")
 			(pintype "passive")
-			(uuid "f62dbd7b-e108-41e9-9122-5849ed7d4229")
+			(uuid "c4192862-3659-47d9-be28-38f5bca526b3")
 		)
 		(pad "6" smd rect
 			(at 2.525 0 270)
@@ -1356,7 +1356,7 @@
 			(net 20 "/MCU/~{RESET}")
 			(pinfunction "Pin_6")
 			(pintype "passive")
-			(uuid "4dc248d3-3498-4e20-a089-9a9e13daedb7")
+			(uuid "83b5c1f4-2282-45f9-a4f6-02706c458a3f")
 		)
 		(pad "7" smd rect
 			(at -2.525 2.54 270)
@@ -1365,7 +1365,7 @@
 			(net 1 "GND")
 			(pinfunction "Pin_7")
 			(pintype "passive")
-			(uuid "40479a09-c89d-47e4-b688-34475ae9f490")
+			(uuid "e78db9b9-948d-4524-9d78-0b46ab5a71f0")
 		)
 		(pad "8" smd rect
 			(at 2.525 2.54 270)
@@ -1374,7 +1374,7 @@
 			(net 86 "/MCU/UART0_TX")
 			(pinfunction "Pin_8")
 			(pintype "passive")
-			(uuid "fc7dbb0c-df4e-4df0-9bb4-dccad12e7d19")
+			(uuid "5ca2adce-49f7-404d-b932-a4094690411f")
 		)
 		(pad "9" smd rect
 			(at -2.525 5.08 270)
@@ -1383,7 +1383,7 @@
 			(net 1 "GND")
 			(pinfunction "Pin_9")
 			(pintype "passive")
-			(uuid "516277e7-042a-420f-991a-7337e7adec60")
+			(uuid "beb467eb-e86a-425c-a8e0-29159533545d")
 		)
 		(pad "10" smd rect
 			(at 2.525 5.08 270)
@@ -1392,7 +1392,7 @@
 			(net 85 "/MCU/UART0_RX")
 			(pinfunction "Pin_10")
 			(pintype "passive")
-			(uuid "40631531-be43-486e-a58d-02a816183118")
+			(uuid "1ff189c0-6d48-432e-9a8b-256c5fc5500d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_2x05_P2.54mm_Vertical_SMD.wrl"
 			(offset
@@ -1415,7 +1415,7 @@
 		(property "Reference" "C39"
 			(at -3 0 90)
 			(layer "F.SilkS")
-			(uuid "b18bd6e2-2524-4090-801a-82a20792b523")
+			(uuid "e2d460b4-36d7-4be2-b32a-38072e7f3b7a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -1427,7 +1427,7 @@
 			(at 0 1.43 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "51a066fb-9fd8-4c3c-8961-d3ed8e2f4605")
+			(uuid "15f259ea-7c38-4eed-a783-bc6e4bc07194")
 			(effects
 				(font
 					(size 1 1)
@@ -1440,7 +1440,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b331d829-0505-44b5-afc1-56125cbdc25a")
+			(uuid "9e04c6c8-3149-4855-98b0-31babed3500e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1453,7 +1453,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dec68653-b1be-4481-95a5-6955a53ca2f5")
+			(uuid "db78fa4c-bf37-41c9-aaa1-48e6b3fe96cb")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1466,7 +1466,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "00b781ad-63e8-4703-8bcd-62b16c898bda")
+			(uuid "3f25c812-8c0c-4647-b93d-ffc2de135fcf")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1487,7 +1487,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fd21d394-94fd-4b9d-8ba2-900682c268c5")
+			(uuid "737eaf72-c9ad-4b4f-b647-75066ce5e989")
 		)
 		(fp_line
 			(start -0.14058 -0.51)
@@ -1497,7 +1497,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "dfdeedaf-93b9-4120-bc03-e386df09e815")
+			(uuid "1a1e55d7-d87f-4b71-8b22-a30d0017c57d")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -1507,7 +1507,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "578c7bd1-d29d-42fd-adcb-467041129ba3")
+			(uuid "a6571138-67cf-4bfc-bfc0-1470eb4bead0")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -1517,7 +1517,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5b2f16a6-5c5a-4ed6-b838-213da1eeb35c")
+			(uuid "2e92682e-52a6-4a0f-b025-3d4ecd69cdc7")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -1527,7 +1527,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4931bba0-0a2b-41a9-b1c1-85422885c2e4")
+			(uuid "109ca3ec-0cb5-4c10-afb8-d387909125a4")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -1537,7 +1537,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d868c226-07c1-4999-9889-86e0caad06d8")
+			(uuid "aa65c119-2811-4338-97ec-93e4abf09af5")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -1547,7 +1547,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ce5d7063-c73c-4039-8e99-07173bb49c15")
+			(uuid "568b724b-6f91-475c-94f7-27654b788edd")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -1557,7 +1557,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2ac01faf-b7aa-4eed-bb30-ede4b79c06b7")
+			(uuid "fb6cb243-1f81-4f40-a23a-d79ffacc897b")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -1567,7 +1567,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9d3a8148-b25f-49a7-88b4-2b6db4e2c48e")
+			(uuid "f99172ba-559e-4c15-98e9-7abc18b1c9b0")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -1577,12 +1577,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4c1602a4-8e02-4786-a7fe-5d891cf8268f")
+			(uuid "82d6250d-1161-4824-804b-43377b220042")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "2758693b-40a0-45fb-a6e0-d3ba3b06c14b")
+			(uuid "f73a8009-0b38-4fb7-8011-ca53c84c8f72")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -1597,7 +1597,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "9b35cd61-2f79-4d87-8def-c20a647b808c")
+			(uuid "5172cbc4-861f-438f-8066-6d77ce4e7550")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0 270)
@@ -1606,7 +1606,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "0b635900-4088-4f07-96b9-9b6dcdb87959")
+			(uuid "0c292376-b31a-4b8b-894c-e4e538619622")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -1629,7 +1629,7 @@
 		(property "Reference" "R9"
 			(at -2 0 0)
 			(layer "F.SilkS")
-			(uuid "43763c3e-7ca3-4114-abe4-3176ec831067")
+			(uuid "88932c42-4a5c-4a20-a303-e03400748e31")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -1641,7 +1641,7 @@
 			(at 0 1.17 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "656c2fde-9bb3-4d81-95bb-5a0346f5e480")
+			(uuid "38a1deee-3f87-4ca9-b823-88b861e9fca5")
 			(effects
 				(font
 					(size 1 1)
@@ -1654,7 +1654,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ad000f69-6fd7-43e8-896d-b5681d6f8fa7")
+			(uuid "226b3e81-33ad-46e6-bdb3-0a9a96e75c30")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1667,7 +1667,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d8418f58-20b9-42e5-ae92-bdbf0b4ea45f")
+			(uuid "1b055822-a9e2-4021-a430-e43c497385bc")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1680,7 +1680,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9bab4bcd-333a-4057-b1ac-3409bba6265d")
+			(uuid "d4818f34-9489-41d5-8697-29e071b79763")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1701,7 +1701,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1620c6dc-a5b8-4bd6-ada9-bf65fedee723")
+			(uuid "0902e1df-b4b2-46b7-86ec-588e11f63fa7")
 		)
 		(fp_line
 			(start -0.153641 0.38)
@@ -1711,7 +1711,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "f26ac08b-f21a-480e-b990-1ae452b923d0")
+			(uuid "6a0f343c-871d-448e-88a8-3ff804c2da7e")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -1721,7 +1721,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "355bfccb-8a77-420f-bfa7-14064d639a71")
+			(uuid "86318409-b935-4ed3-8ebe-9cce83a6e55b")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -1731,7 +1731,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "80b819dd-44ea-493c-a9c2-0d39ee02a725")
+			(uuid "25ee2c2f-8144-4a3b-bef4-db43e9142d8b")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -1741,7 +1741,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "7e4217b4-a869-41ea-8ef8-4196c88f5cd8")
+			(uuid "10f02016-1146-4dc1-b906-c21cf10e5fe2")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -1751,7 +1751,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "017601e1-4bf5-4082-81bc-27342e0eea05")
+			(uuid "790de21c-e3bd-40ea-9553-9e40df3afd4e")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -1761,7 +1761,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f28b6759-e397-4d8a-8759-1d4f6f79ed2b")
+			(uuid "95f29039-ba38-4698-b53a-5fe4bee1f0fc")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -1771,7 +1771,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "fc163569-12c2-41d9-8bc2-01ef62d2f446")
+			(uuid "a69d1759-c44c-4b61-b19e-4e21de0cf159")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -1781,7 +1781,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7f8c1d2b-f08e-4539-a849-b286d825e11a")
+			(uuid "40591692-8f34-406c-8330-d7eb2d7447d4")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -1791,12 +1791,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a0b42b9a-f8e3-478a-9b28-6322dc0401d6")
+			(uuid "630d11da-694e-4872-a4bf-81d81b7eeb1b")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "dc29fbaf-8af9-4f1d-931f-f4d4c00ec45e")
+			(uuid "d6d9c32b-32c5-4d57-a4fd-c755c2c368cf")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -1811,7 +1811,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "2409e0af-366b-40fe-aaf8-bda0637c53e9")
+			(uuid "5c6cb59e-d124-4389-aed4-c37a7df05f8b")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0)
@@ -1820,7 +1820,7 @@
 			(roundrect_rratio 0.25)
 			(net 25 "Net-(J2-CC2)")
 			(pintype "passive")
-			(uuid "d76ffc9e-4868-4f84-9eb1-8a138ab317ba")
+			(uuid "a669ebff-0886-4b12-960b-da89f5a952e7")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -1843,7 +1843,7 @@
 		(property "Reference" "C15"
 			(at 2.3 0 90)
 			(layer "F.SilkS")
-			(uuid "33b14ea7-8054-49c2-8d5f-493c752d8630")
+			(uuid "651b8cc5-01b2-47d5-824e-e16704351a53")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -1851,11 +1851,11 @@
 				)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "C0402C0G500-220GNP-CT"
 			(at 0 1.16 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3fba5222-bf21-4525-ac19-3486510b5fc7")
+			(uuid "ecfdd247-2c16-4833-9119-34b8ee56421d")
 			(effects
 				(font
 					(size 1 1)
@@ -1868,7 +1868,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ff55ea29-bd89-48aa-af20-159bcedf281e")
+			(uuid "ad4ff030-3af7-4c67-be51-fff710f09f36")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1881,7 +1881,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "af333d40-2db7-407e-8722-29bc830d7f9a")
+			(uuid "636826ae-f684-4743-b400-88ee3be083d5")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1894,7 +1894,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "388ec363-0ba3-41d6-bcb5-228f4cbfe30d")
+			(uuid "492fcb94-4b2b-499e-9451-ccbe5883f7a4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -1928,7 +1928,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2078f416-9211-4df9-8721-4d3c69b025b6")
+			(uuid "7f4f97f7-0b7c-4d2c-abd4-147b74fc8ddd")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -1938,7 +1938,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "f9d45d1e-1ed1-478a-a7bb-640cbf8fd8b2")
+			(uuid "82db7186-8586-4798-8946-d00f9f271459")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -1948,7 +1948,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e7b71bfa-f560-4ddf-a424-89141201c406")
+			(uuid "5961c04f-b492-4403-b29d-ce60cd28c7fe")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -1958,7 +1958,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "cf0eb00d-4c1f-411a-99c2-d1b0d6c06e6e")
+			(uuid "006da590-68d2-481b-b5e6-881416817118")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -1968,7 +1968,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "34b38de9-af2c-4ad5-830e-91b3f1d65d12")
+			(uuid "b2899e89-8478-47ae-bfb6-4b79c412add0")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -1978,7 +1978,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "072da8fa-75bb-4642-8528-6e80bf02cf87")
+			(uuid "94a99a81-818a-4811-ac4b-8951f2839121")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -1988,7 +1988,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8054040c-6590-4b69-8390-b4631bcf1045")
+			(uuid "3927897b-3b1c-4334-bc3c-59b7742ae3c4")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -1998,7 +1998,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "450c2376-bedf-48d2-8e09-9d91490bd2a5")
+			(uuid "07e4af24-fb05-4fd7-b43e-ce2f8c6a8761")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -2008,7 +2008,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "809558fa-347e-4174-80fc-78abe8596fa7")
+			(uuid "140f5500-cbeb-4a1b-b61c-f9208422a777")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -2018,12 +2018,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "71cc5b63-b459-4950-94ec-3be2964d6450")
+			(uuid "b8631da6-3409-4786-bc56-093c877be2ce")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "b475852e-18db-4fbc-b210-50f14f2f4700")
+			(uuid "447f1cad-1da1-4aed-b9f4-a6288b5e13e1")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -2038,7 +2038,7 @@
 			(roundrect_rratio 0.25)
 			(net 11 "Net-(C15-Pad1)")
 			(pintype "passive")
-			(uuid "9f601a16-825c-4fb7-9fe1-a40f4f5e5e27")
+			(uuid "633e06cd-92d4-4251-a16e-106f12c82700")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -2047,7 +2047,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "ca977bee-2a1e-4914-9f9f-77a66e1cd0d8")
+			(uuid "8b52d278-fe6b-40c0-8a79-812fc12efb1b")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -2070,7 +2070,7 @@
 		(property "Reference" "C6"
 			(at 1.6 0 180)
 			(layer "F.SilkS")
-			(uuid "6076a002-2fa1-4006-8d50-981c2373dd9e")
+			(uuid "ba8f7f12-6adb-4206-84f6-372891624f08")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2082,7 +2082,7 @@
 			(at 0 1.16 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "fa2c536b-f442-43d2-9c0d-e3eb37110010")
+			(uuid "e4211ee4-0221-4afc-b31f-fab9a48eab68")
 			(effects
 				(font
 					(size 1 1)
@@ -2095,7 +2095,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9850a82e-68bd-48cd-b010-053bffb285e5")
+			(uuid "408fa499-5135-413f-8299-aa123b843b8d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2108,7 +2108,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "10901246-e8a5-4aa5-b5f0-0f7605ff55ee")
+			(uuid "e1cc16b8-7518-46b4-b57a-87da536207ad")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2121,7 +2121,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6430d908-705a-4055-a64a-c64671935693")
+			(uuid "73bc445d-bd41-4bcf-905c-a11e08f79b27")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2142,7 +2142,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4b15f42f-0a40-4511-884f-f7d580ab0cbf")
+			(uuid "446b8477-562a-4210-aa19-42aa2c04203d")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -2152,7 +2152,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a91a5029-c26c-4f29-8efa-be9e199e07b4")
+			(uuid "3a909b66-de3c-45ff-8394-83c737d3e1d9")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -2162,7 +2162,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6f8c86e4-ff01-463d-b71e-c382ee4570ce")
+			(uuid "6bf6a3d3-18c7-4f8e-84bd-29ca45e9b729")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -2172,7 +2172,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fae046e0-aad1-4987-8fdd-54c548efb49f")
+			(uuid "033daddc-f2da-4476-ab3b-cb442f8eca28")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -2182,7 +2182,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f8de0590-a4aa-4183-9057-7a9b945eb772")
+			(uuid "fe462a57-d29c-498a-a3a2-54cf0e62e959")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -2192,7 +2192,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ba6c2c18-7a5a-472d-ac8f-2b0ca47b5921")
+			(uuid "25f4edc4-ed8b-404a-b127-555aa81a3e74")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -2202,7 +2202,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "10e696e4-15d6-4c22-aa45-4f8466e1af16")
+			(uuid "5e5ebf47-e6fa-45e4-a610-d6de225276ba")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -2212,7 +2212,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ef2b4aab-4ddc-4705-a359-6f6fc870fda1")
+			(uuid "2eaa2d60-72e1-473b-947b-c270674ed919")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -2222,7 +2222,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d82908fc-220e-4298-900b-4e4467d967d4")
+			(uuid "c1f4475b-fb85-4471-831b-0025156b668a")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -2232,12 +2232,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1ffc6364-2f38-4e2a-8405-02f44e339152")
+			(uuid "40d40942-ee15-4fa6-8297-d0d6c00d847f")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "a8d96e64-e42f-421d-9ce2-816606265c44")
+			(uuid "e322f89c-3831-4cd7-b56a-f7e5e39f53cb")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -2252,7 +2252,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "bb9be9a6-d83b-4322-b417-b327a91983c7")
+			(uuid "018e5224-f2da-455a-b39b-878ce7d582b3")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -2261,7 +2261,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "bac7a2ed-e54c-4c86-95f0-4c9e9330d7d1")
+			(uuid "a483d342-83bc-40d6-9459-a81c48cba9a9")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -2285,7 +2285,7 @@
 		(property "Reference" "TP1"
 			(at -3 -0.5 0)
 			(layer "F.SilkS")
-			(uuid "3c56a757-ff9a-4704-912d-c76afb1ef9c5")
+			(uuid "7ee598df-bcf2-4ab4-a4d1-dc4e53e6ff78")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2297,7 +2297,7 @@
 			(at 0 2.05 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "21005e7a-af25-427e-851f-239d4f9d2a42")
+			(uuid "168412f0-5fc1-4300-b63a-373e896780f2")
 			(effects
 				(font
 					(size 1 1)
@@ -2310,7 +2310,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c662694a-f2d5-406a-bdbe-9d5909ed82e5")
+			(uuid "1b3b95d0-42a8-495a-a7e7-c1cfe317ca71")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2323,7 +2323,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5889a82b-eb18-4810-a43c-7d5b6eed9303")
+			(uuid "54aa9452-bf49-4845-b452-7e92d37d81b7")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2336,7 +2336,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "42ce93a2-f5f4-4d97-924d-94e3055b28a2")
+			(uuid "f3102db1-f4a3-4202-8090-ef882eb483d4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2358,7 +2358,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "ae6dbfba-c923-45e5-9c5b-24371e37b1ef")
+			(uuid "8c30bf3c-473d-49ef-b4e8-58d39fa4fc38")
 		)
 		(fp_circle
 			(center 0 0)
@@ -2369,7 +2369,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "130cadad-2217-41ec-8622-c0a19b36951c")
+			(uuid "d141586a-f37f-45cc-9a81-ce52ffdecc42")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 0)
+			(layer "F.Fab")
+			(uuid "cfd92c39-e22c-4b51-87f9-85c4ec02116e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0)
@@ -2378,7 +2389,7 @@
 			(net 9 "VBUS")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "e08a9720-7c60-4937-a59e-8e8818e5c95e")
+			(uuid "0243cec3-8be9-4343-be95-40b0563772b9")
 		)
 	)
 	(footprint "MountingHole:MountingHole_2.7mm_M2.5_ISO7380"
@@ -2392,7 +2403,7 @@
 			(at 0 -3.25 0)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "33783ad1-67ca-4c6b-b571-88aeaf1d05f4")
+			(uuid "b6f2c4d7-9403-417f-8673-dd619e687970")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2404,7 +2415,7 @@
 			(at 0 3.25 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "775e0a2c-8973-4b07-bd8d-0a3b290eb226")
+			(uuid "d8ac7daf-612c-41b3-9503-1ed45d8e9e18")
 			(effects
 				(font
 					(size 1 1)
@@ -2417,7 +2428,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "95dfe212-a625-4019-bfc3-c040941e9e4c")
+			(uuid "1604a92e-04ce-4357-bf19-d4d2cd7ecc9d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2430,7 +2441,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d8d9f5e8-84d6-4170-9490-dfbe9df0a577")
+			(uuid "cbdf9b06-3de3-48ad-a06a-4dee9afb8c28")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2443,7 +2454,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "50050734-a650-4c30-b1bd-81e4bf05691b")
+			(uuid "0af5d5a1-d0db-47ba-8887-1ba6089de5d0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2465,7 +2476,7 @@
 			)
 			(fill none)
 			(layer "Cmts.User")
-			(uuid "9f640952-95ba-4578-a70d-ca8c87a58b7c")
+			(uuid "c1b61c29-ec42-411e-915d-ed0a0c2b2339")
 		)
 		(fp_circle
 			(center 0 0)
@@ -2476,13 +2487,13 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "669e2f35-a10c-4b35-8bf3-2e34291b1b1d")
+			(uuid "20cff7c5-b2d2-47d0-ace2-c82d69e98c7c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "40ed6f71-c79b-46de-8144-13e008448636")
+			(uuid "2d9130ba-7027-4924-963c-d5af4a56fae3")
 			(effects
 				(font
 					(size 1 1)
@@ -2495,7 +2506,7 @@
 			(size 2.7 2.7)
 			(drill 2.7)
 			(layers "*.Cu" "*.Mask")
-			(uuid "a042b42f-de5a-4e81-b6b4-d49921c2c18e")
+			(uuid "cf1cef63-b0d5-467f-8bea-fe63747f7f40")
 		)
 	)
 	(footprint "Resistor_SMD:R_0603_1608Metric"
@@ -2507,7 +2518,7 @@
 		(property "Reference" "R1"
 			(at -2 0.1 0)
 			(layer "F.SilkS")
-			(uuid "5a615f4c-9649-4be7-a537-d3efa3fa2323")
+			(uuid "6baaf794-e8ad-4110-8ab5-9426242e11f5")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2519,7 +2530,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "52cc3d3a-21f7-47dc-b6f7-71593854d752")
+			(uuid "48a0b8fa-dc07-4e34-b005-aef8c0ddaf73")
 			(effects
 				(font
 					(size 1 1)
@@ -2532,7 +2543,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ba243d02-7955-442d-99da-a286536aa92e")
+			(uuid "e456fd11-2165-4bf4-82a6-3fd0895e6277")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2545,7 +2556,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f7d17e9b-50c8-4249-887c-e067de4104be")
+			(uuid "f2476826-af05-403c-a967-d7191de1c7d8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2558,7 +2569,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "751b0b52-42b3-4710-aec7-8712420c3b11")
+			(uuid "cf677e1c-8162-4808-9578-9ba71c27ca19")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2591,7 +2602,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fb6daad8-c2ee-434c-97d0-f3d8b34eee81")
+			(uuid "3305421f-3f95-4c4f-8125-2417ad967d1b")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -2601,7 +2612,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "303059a8-33e5-4da8-8043-00b8a8bc39b1")
+			(uuid "7c9ab7da-1217-480e-9e4a-b1cd7e920aeb")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -2611,7 +2622,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0c726b9e-3a49-453d-ad10-4e5b0cba3e2c")
+			(uuid "9b8d38d1-40f3-408a-8751-82396566060a")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -2621,7 +2632,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1eaf60ab-71f8-445b-9f3e-c1f6d564f12d")
+			(uuid "c662d7fe-df48-4e8a-a8e3-c6fa4021e5e8")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -2631,7 +2642,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "784f312e-c448-4c70-abe2-e586d8330083")
+			(uuid "ab15875c-090b-404b-8eb4-9d4331e0637f")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -2641,7 +2652,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "06302069-9e3f-44e8-bdad-c20a834e94f8")
+			(uuid "3a459943-8d88-4ca3-a138-9f6572b9594c")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -2651,7 +2662,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1c3d2068-354e-4fc8-90f8-a067db5a1184")
+			(uuid "bd46a104-5efb-4ab8-97b6-bb5277ba5945")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -2661,7 +2672,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ef4424b6-eaeb-438b-848d-9cddcfc55d72")
+			(uuid "fbe5722b-1855-48a8-90a3-05c9db965bdd")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -2671,7 +2682,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b903ef2e-d6b6-46b0-b20d-710c9a397627")
+			(uuid "a3e057e4-0596-4b87-893f-98372d4dd93e")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -2681,12 +2692,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "148c62d1-c6e2-4733-9f35-fc7df14c6953")
+			(uuid "166957db-ee6a-486c-a71b-7f7e7350dc24")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "93bfdb70-c63a-41c5-aedc-26681d7354f6")
+			(uuid "373200cc-ec2c-4688-acc3-a43065c1490d")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -2701,7 +2712,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "75184204-cc23-4b45-9096-e1075e6c4ef2")
+			(uuid "0330f71d-e53d-432f-a92c-4cb53454b757")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -2710,7 +2721,7 @@
 			(roundrect_rratio 0.25)
 			(net 93 "/RGB Driver/SCL")
 			(pintype "passive")
-			(uuid "ea6e110b-ffef-4775-9efd-f91383917c0e")
+			(uuid "b5f25e0a-5292-42b1-931e-0d67f2ae4259")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -2733,7 +2744,7 @@
 		(property "Reference" "C16"
 			(at -1.8 -0.2 180)
 			(layer "F.SilkS")
-			(uuid "6065742e-1fc0-49ea-bb3e-354cb7e14261")
+			(uuid "870f5562-d8cc-4785-bdca-78f6b8b7b47c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2745,7 +2756,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c06424e5-5ce3-489f-bce1-181e6f76dd78")
+			(uuid "dc17a8dc-3773-480e-baf9-23c4851e8b01")
 			(effects
 				(font
 					(size 1 1)
@@ -2758,7 +2769,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2b1b2d54-1ca3-4a17-b72b-b62abb5da46f")
+			(uuid "1230ceb0-189c-4e5e-aaa7-39d41dfb962a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2771,7 +2782,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1e8895d3-aabd-4156-ad0d-98964c4724fe")
+			(uuid "b8762bae-6b2b-4ba3-8dbd-aaaa20c19e85")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2784,7 +2795,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "14404b61-44bc-4ff3-be0a-4ff13136e78c")
+			(uuid "ef8f9595-f2a4-4399-8ea2-ab924af81834")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2805,7 +2816,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0c38db36-996d-45c1-bc8e-4f67ac1fa943")
+			(uuid "f77a902f-030a-41bf-84af-9c35b594b7cb")
 		)
 		(fp_line
 			(start -0.14058 0.51)
@@ -2815,7 +2826,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "65a90da5-a28b-4ed1-9060-790adb217095")
+			(uuid "352908be-6cac-4e33-b507-01335d8ed409")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -2825,7 +2836,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0fe75d2c-3512-4733-9cb7-0be54ad975fb")
+			(uuid "ab07fc86-19e0-4002-a425-f178f988aa50")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -2835,7 +2846,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "303afce6-0dc5-4d78-9d62-c50efb39799f")
+			(uuid "2ca7ea18-f5a6-4fe9-be07-02de9fbccfa6")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -2845,7 +2856,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b8f64531-bfd3-482c-ab85-a7bcd59cb926")
+			(uuid "54e4609e-19a5-48e5-859d-adaf30df6975")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -2855,7 +2866,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b4b53ac1-dd45-4f6b-964e-0e7f557c2da1")
+			(uuid "211a5f9b-8ba4-40ff-9612-2b519ade9d3a")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -2865,7 +2876,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "bd1d1c2f-1c2b-4efa-944e-4ed5dcd02818")
+			(uuid "02323c1f-4bf1-46d7-a272-cde019b33328")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -2875,7 +2886,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "37aa5ea9-1d48-4915-9c75-0f631218a80d")
+			(uuid "72d14155-028f-4a15-ba9c-f95dd2a7c576")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -2885,7 +2896,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "557103ff-aa8e-4805-b593-b585dc1d4245")
+			(uuid "43a83f49-76dd-4f1e-9528-c118558f4a62")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -2895,12 +2906,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "85d80ddf-661f-4a85-a568-af96626c536b")
+			(uuid "8b4748a8-921f-4360-939b-5010d48b8223")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "dc8d9d65-b7d3-45f2-812f-ca644649dee9")
+			(uuid "fb4c78ce-d32e-4950-a7d6-0574dacb142d")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -2915,7 +2926,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "a9bc6804-47c4-45ea-8a9e-a5815a043a22")
+			(uuid "6783b034-da05-4d78-bbe4-1dcea1a0b5da")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0 90)
@@ -2924,7 +2935,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "4562c722-0d8f-4691-8778-6aaf892d5c9b")
+			(uuid "3d806328-5a42-43f2-9150-bdae15216a2c")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -2947,7 +2958,7 @@
 		(property "Reference" "C30"
 			(at -1.6 -2.1 0)
 			(layer "F.SilkS")
-			(uuid "e8cc04f8-4790-4e9a-9f87-3f5cd7127da8")
+			(uuid "0dbe9b51-da69-48fe-bce4-13e883dd3f36")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -2959,7 +2970,7 @@
 			(at 0 1.68 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "73195051-6e83-4310-9fd1-a37374dc0bd0")
+			(uuid "e14d3ac9-d87d-41cd-9331-bac64fa880ff")
 			(effects
 				(font
 					(size 1 1)
@@ -2972,7 +2983,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2f5d6c02-5edb-4258-9715-0637143f1205")
+			(uuid "625acdd9-1865-40ab-830c-f77df3d67ee7")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2985,7 +2996,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d12b6d03-09af-4e0e-822d-59cc36314683")
+			(uuid "72922f4b-98a6-49bb-89b7-c15c56780e96")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -2998,7 +3009,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "95b7baaa-a4c0-49bc-bd5d-b6612ac50c17")
+			(uuid "ae384973-18f6-495b-a8eb-4704733fe93c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3032,7 +3043,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "7d160c95-a26f-4d3f-9f27-47f4cc6e9156")
+			(uuid "6e65ce6c-c0d4-498b-b8a3-ccffa24979cb")
 		)
 		(fp_line
 			(start -0.261252 -0.735)
@@ -3042,7 +3053,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0b71587a-7176-4893-9d26-6ae75f8c7a8c")
+			(uuid "8f329499-a833-4ba4-99c1-2be1cc9c0cb6")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -3052,7 +3063,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "595b8271-8156-454b-be7d-98465a18e27a")
+			(uuid "c09b22ad-f9a4-471c-a8be-f891798d029c")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -3062,7 +3073,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b87517c2-13ec-4f48-963c-8eb503f4c791")
+			(uuid "31bf6715-cfd0-480e-be04-3fe38cdde408")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -3072,7 +3083,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ef9d02f9-1806-4992-9a61-0e37b00d7298")
+			(uuid "15efe883-d059-423a-a8c7-277e83bff181")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -3082,7 +3093,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "334d3a2f-be51-48c1-9fd9-2ad3dff42aa3")
+			(uuid "c710ab82-7109-4e24-a155-4ef3e4d1023b")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -3092,7 +3103,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9b4f17de-5deb-4e03-a811-14242ed545c2")
+			(uuid "a1fd6171-5ac2-4b4d-b5f8-93e13c92b26c")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -3102,7 +3113,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d34bffa3-20be-45bb-85db-4966975aed9f")
+			(uuid "03a4ae3d-6378-402d-af36-4399d2f2c204")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -3112,7 +3123,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1dd15a9a-254f-4f33-b188-1844b4a6e5e1")
+			(uuid "b91ff04a-2be3-41da-9563-56f478d274d2")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -3122,12 +3133,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "316d65b6-1ecb-486e-bc81-4bd9baee2d41")
+			(uuid "f8b1d155-291d-431f-90ee-0a10b74851a0")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "ee06e823-2c65-4128-ae7e-4a85139c060b")
+			(uuid "15405b39-5a56-4a81-ba52-4036fcf5b3b0")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -3142,7 +3153,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "d95d602c-5223-4be8-802d-a125dab4712a")
+			(uuid "3d3266da-63ff-4bd1-8bee-d6d3fc679cef")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 270)
@@ -3151,7 +3162,7 @@
 			(roundrect_rratio 0.25)
 			(net 15 "/Motor Driver/TMC_{5V}")
 			(pintype "passive")
-			(uuid "2a38f0a8-5461-43b6-a536-6bf6e6fe63da")
+			(uuid "c646b284-92da-4299-8030-f5426cddcd0d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -3174,7 +3185,7 @@
 		(property "Reference" "R11"
 			(at 0 1.3 0)
 			(layer "F.SilkS")
-			(uuid "12bbcb02-80dc-4b45-a485-5402794aea08")
+			(uuid "1311172d-a2a0-4431-ac78-8183ba669d42")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -3186,7 +3197,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "88d0fb81-d2f4-4e72-945e-188568b77a6d")
+			(uuid "081c3465-d80f-4d59-8d21-82b9684bebba")
 			(effects
 				(font
 					(size 1 1)
@@ -3199,7 +3210,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3eee8217-906d-4b7c-b61c-bbee4bde5d1f")
+			(uuid "a593a08d-36f7-4eb4-951b-44857170ace0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3212,7 +3223,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9e8b5fe9-36f0-49ea-b558-f773fd3f7077")
+			(uuid "30934196-b6f7-4f23-9c12-82e3f11a34aa")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3225,7 +3236,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "43ba47b6-93f1-436f-96b8-289283503c3d")
+			(uuid "bfc8f01f-e769-4572-b01a-de9edf0c1354")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3258,7 +3269,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cd54f20e-2243-40da-a60c-387acce85886")
+			(uuid "bb71dc38-d2e8-4efd-86c4-faf94f632086")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -3268,7 +3279,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1e81b2f4-5e6a-45b1-8e21-b686d363bae5")
+			(uuid "1808fc11-d8c2-483e-8a50-7d96a29f73d6")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -3278,7 +3289,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e83ff0f3-ce91-49b9-b395-96457d9c67a3")
+			(uuid "1d796497-e11a-4d74-9878-ceff670267b6")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -3288,7 +3299,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "25e43d11-276d-48c4-bb39-1b8bc339a965")
+			(uuid "8643d5ff-a3df-4939-80e6-48290ad69bff")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -3298,7 +3309,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d0904093-a7db-4f49-a890-c04ce3ebb0df")
+			(uuid "c43ebbca-7f9f-4eb2-a02f-023136e9e5f0")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -3308,7 +3319,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f6ed6f97-e6fa-4157-b51f-8ff4bc005b3b")
+			(uuid "0415e0cd-b33c-40f4-9a1d-0102c5ea2f8b")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -3318,7 +3329,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7ef7891b-5c37-43ff-a055-9b251cd2eabb")
+			(uuid "f09a3983-0e35-443a-bfd3-e68ad8904c0b")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -3328,7 +3339,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "17223124-aad4-497c-bf1d-be904a4648ec")
+			(uuid "f30c1419-df2f-4d79-9bbe-92695a924e3f")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -3338,7 +3349,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b97ffca3-b67f-4fb9-9d1d-1a2db617ae58")
+			(uuid "b1d9b935-70e7-45be-91cb-e11a1c8d1209")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -3348,12 +3359,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "690c8e35-6856-440f-9631-8caf7eb105d8")
+			(uuid "172f1c50-a39d-4b43-8600-c06dfd38710c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "bb73a2a5-f805-4f4a-8c4e-8d5440aab99b")
+			(uuid "7cb6a495-fb4a-4887-afb7-8f49f61b3628")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -3368,7 +3379,7 @@
 			(roundrect_rratio 0.25)
 			(net 2 "+5V")
 			(pintype "passive")
-			(uuid "a7c31065-5856-4127-9dc1-1e66a8748c8a")
+			(uuid "3029e44a-a4ec-4cb1-8954-946136edb4fd")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -3377,7 +3388,7 @@
 			(roundrect_rratio 0.25)
 			(net 35 "Net-(U6-FB)")
 			(pintype "passive")
-			(uuid "a9255a9a-d12b-4a03-86ac-fd509e5829fe")
+			(uuid "dcae152c-da4d-4ba9-a657-56e284e84ed2")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -3400,7 +3411,7 @@
 		(property "Reference" "R35"
 			(at -2.6 0.65 180)
 			(layer "F.SilkS")
-			(uuid "77ab27bd-af53-4d3e-8d99-7e54d0d5259e")
+			(uuid "e8c1e462-307e-40bd-8415-c849a7e1a4c5")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -3411,7 +3422,7 @@
 		(property "Value" "0"
 			(at 0 1.65 180)
 			(layer "F.Fab")
-			(uuid "48bba9d1-c166-40e8-a104-ff7b895449f2")
+			(uuid "d20c2830-9682-4887-9e4d-71359b52a19a")
 			(effects
 				(font
 					(size 1 1)
@@ -3424,7 +3435,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b4e7ca8b-cd3c-47c2-a213-c758659d6dbd")
+			(uuid "2c1a100f-605b-4883-8503-a9dceb9d468c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3437,7 +3448,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5450c15f-12e3-4564-8ddd-9678e849d759")
+			(uuid "db00e04d-d776-4a39-acf4-b26ecd147205")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3450,7 +3461,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d5691cce-b3e2-44da-9a9c-0d8e0448ac10")
+			(uuid "99c97e3f-08fa-442d-ad64-707d2447045e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3471,7 +3482,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b201acd5-5026-4c11-b52c-a3ae4bbf576a")
+			(uuid "89faee77-9374-478a-a0a0-1f15a151aab8")
 		)
 		(fp_line
 			(start -0.227064 -0.735)
@@ -3481,7 +3492,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cb25080c-d287-48d3-82bb-521ab0563774")
+			(uuid "852085c6-7d34-4db3-aa65-eefaf84d195f")
 		)
 		(fp_line
 			(start 1.68 0.95)
@@ -3491,7 +3502,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "50f54da1-be8c-44ed-9a9e-f3b95d95296b")
+			(uuid "4f301813-9a73-48e7-835e-6d4b6e4decee")
 		)
 		(fp_line
 			(start 1.68 -0.95)
@@ -3501,7 +3512,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3107e9c0-9341-4351-8fa1-f5c3daaace09")
+			(uuid "83ba68f0-a950-43f8-9051-3b222598a91f")
 		)
 		(fp_line
 			(start -1.68 0.95)
@@ -3511,7 +3522,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e05d0db3-ebce-4681-8394-9a5f696a42b2")
+			(uuid "3e83f84e-7861-4873-baf2-4bd9bf5c62ba")
 		)
 		(fp_line
 			(start -1.68 -0.95)
@@ -3521,7 +3532,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a2dc691f-b2ca-4b2c-82c9-d930b5e83c05")
+			(uuid "c2b72fd3-110d-4207-b773-baae88934ee9")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -3531,7 +3542,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d8ef4e31-cafb-4322-b1e4-d464faa290d8")
+			(uuid "b96fd5e1-02fe-4bac-bcc2-d77fff60dad7")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -3541,7 +3552,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "de740b95-e734-49dc-b9ce-e6a9f1e0e9cf")
+			(uuid "7b8e6f43-5e60-4ac7-b71c-33f2519eeb05")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -3551,7 +3562,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "72b66344-6095-43cb-920c-47c1969f54d8")
+			(uuid "58abcfea-def2-4d2e-9fbe-15536b82f1e0")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -3561,12 +3572,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1669883a-52d8-49eb-94f1-184950ce27d9")
+			(uuid "bcfe2038-fccc-42a1-9472-03d2e87ec142")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "2ff42c49-ebac-419f-8589-3d0595c7475c")
+			(uuid "a3cee80f-098d-4484-bc59-ec4b6619076c")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -3581,7 +3592,7 @@
 			(roundrect_rratio 0.243902)
 			(net 49 "/Touch Sensors/CW")
 			(pintype "passive")
-			(uuid "87cf8cb3-4aed-48fa-88a1-7ba6dd791518")
+			(uuid "8426c553-cacc-4361-9f68-6f5412b3a9ed")
 		)
 		(pad "2" smd roundrect
 			(at 0.9125 0 180)
@@ -3590,7 +3601,7 @@
 			(roundrect_rratio 0.243902)
 			(net 97 "Net-(U4-CS4)")
 			(pintype "passive")
-			(uuid "ffadc485-645a-4e60-8076-c98ba5424435")
+			(uuid "cd0e5220-b5a7-4bb2-ad59-063ff4618bef")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.wrl"
 			(offset
@@ -3613,7 +3624,7 @@
 		(property "Reference" "R32"
 			(at 0 1.35 90)
 			(layer "F.SilkS")
-			(uuid "a5fe8151-8813-41f1-bdc4-79089173ef5c")
+			(uuid "4c1d73bb-a807-45ba-abf2-462bac716c0d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -3624,7 +3635,7 @@
 		(property "Value" "0"
 			(at 0 1.65 90)
 			(layer "F.Fab")
-			(uuid "365df880-4ca1-4add-83bb-b1d4da40b5e5")
+			(uuid "d5647a42-a2f2-4c78-bdb0-2bf091ff7a91")
 			(effects
 				(font
 					(size 1 1)
@@ -3637,7 +3648,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5e86180e-c660-4eca-b751-b323a9a36a62")
+			(uuid "65793144-0ff1-4cc8-8a02-3a63a61c975d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3650,7 +3661,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "04a149c0-e2f8-4c1a-9f9e-a2c527839522")
+			(uuid "9a1211f9-4683-416b-9962-ba5925b74712")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3663,7 +3674,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e0c24201-5bf8-4f83-be42-e6400b29e894")
+			(uuid "bc363117-03d4-42b5-b65e-7dcd7488e7fb")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3684,7 +3695,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "378aedb9-22a7-4d19-83df-8a30dbad50c7")
+			(uuid "04b511a3-b679-41b3-a5bc-1ec96e77996e")
 		)
 		(fp_line
 			(start -0.227064 -0.735)
@@ -3694,7 +3705,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "7d00dbd6-985e-4d33-b4cb-bb06d34f6516")
+			(uuid "9ba7b832-d0e5-4ee2-8d96-df811a7605a4")
 		)
 		(fp_line
 			(start -1.68 0.95)
@@ -3704,7 +3715,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "384dfa58-41de-4cad-970a-444b152c5d92")
+			(uuid "6b9376b3-51a9-4af2-81ba-760e6b6819f2")
 		)
 		(fp_line
 			(start 1.68 0.95)
@@ -3714,7 +3725,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8d0ce553-2d05-4f5b-9793-ea7ceb7543d0")
+			(uuid "c3ba786d-68e6-42c3-a267-44534d394281")
 		)
 		(fp_line
 			(start -1.68 -0.95)
@@ -3724,7 +3735,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f3a7ac3e-6be6-497d-8604-f022be6cd90b")
+			(uuid "4015b819-39d3-45d0-b1ea-528297c473bc")
 		)
 		(fp_line
 			(start 1.68 -0.95)
@@ -3734,7 +3745,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "547f92f4-709e-41eb-8b88-5a5162a5d722")
+			(uuid "620786d8-6225-43cf-a4b7-a1a3c1d07794")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -3744,7 +3755,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a27b2201-9db6-4cfa-ad11-206a49ba1247")
+			(uuid "02ff0398-1ce9-487c-bde5-9ab3e56b7f1d")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -3754,7 +3765,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7d56486f-dcce-43f9-9dd5-d7732988c093")
+			(uuid "a70acc08-c26e-4b8c-aecc-2e923341525d")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -3764,7 +3775,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a196bed7-8fad-4ab4-a19e-4b7aeebdc13e")
+			(uuid "dd0578c0-a471-4d11-9bc2-f0a46cfc4bb7")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -3774,12 +3785,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0a7e0390-1239-46e9-9f48-0a2facef7bd7")
+			(uuid "9b74adde-e64e-4e2e-b7c9-3fd32bcc1c03")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "b7bc22ea-109f-42ef-a867-585820679c92")
+			(uuid "bd89b603-3f78-4a52-badb-22b914912e15")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -3794,7 +3805,7 @@
 			(roundrect_rratio 0.243902)
 			(net 47 "/Touch Sensors/CCW")
 			(pintype "passive")
-			(uuid "b0395036-bcdf-4a7d-8d89-5f1405fe68b6")
+			(uuid "fc49f121-81cb-48c9-8017-07408b883c7b")
 		)
 		(pad "2" smd roundrect
 			(at 0.9125 0 270)
@@ -3803,7 +3814,7 @@
 			(roundrect_rratio 0.243902)
 			(net 94 "Net-(U4-CS1)")
 			(pintype "passive")
-			(uuid "758f81ac-1214-45b9-956c-a5df9bf2a109")
+			(uuid "dac9525c-91b4-4981-a469-5a3842efb55d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.wrl"
 			(offset
@@ -3826,7 +3837,7 @@
 		(property "Reference" "R14"
 			(at -2.9 0 180)
 			(layer "F.SilkS")
-			(uuid "acc3b7a1-8d1a-45fb-b1d2-d9492da59b89")
+			(uuid "8f2c6ef4-5e83-44dd-9980-a45e7ca91b4a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -3838,7 +3849,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1634fc6a-d7fd-4493-9863-30cb5d2b93c1")
+			(uuid "6d110b6d-edcc-4722-ac6d-477a7692ac4d")
 			(effects
 				(font
 					(size 1 1)
@@ -3851,7 +3862,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4ce04f8d-6d51-466e-9c7c-5628fd2eae37")
+			(uuid "0f0f6e88-2b3a-4b98-8524-18f68498a905")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3864,7 +3875,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f82dfa58-83a6-4f17-a3d6-f964e3d95572")
+			(uuid "159918f4-45c6-41e2-8c6c-aa785b74178a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3877,7 +3888,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d0ece257-4b4b-45b1-a37e-f4f426ef5c73")
+			(uuid "be0341b4-4e9b-42dc-a22e-b72f2d0e40e9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -3910,7 +3921,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "9b07504c-1b62-40aa-b51e-bdeb4772ed9b")
+			(uuid "0b3991be-5ee1-4510-b594-f974b26d3bbb")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -3920,7 +3931,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e8bbcff2-1d6a-4d51-8cc4-c6c28ff0fdea")
+			(uuid "cdff0cec-d873-4383-8105-bc34821182d4")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -3930,7 +3941,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5ebdd0d6-ee4d-4413-be6a-3708b611a9ab")
+			(uuid "6ead4122-aa4c-40c6-99a9-1f2eb9eff34c")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -3940,7 +3951,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d2a0e468-67df-4c95-b644-53a22c2a50c4")
+			(uuid "94cb91d2-f06a-44d1-ad2b-4c7e39e03f50")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -3950,7 +3961,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6595d4b4-29f3-4e18-9b6c-aad74af45efc")
+			(uuid "614f069f-9203-4940-9168-cf3061eaa202")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -3960,7 +3971,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "78219180-f57b-4a7b-8a90-bc17f54133a5")
+			(uuid "a693f75e-9a6f-4aa6-9887-ab69aeaf9137")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -3970,7 +3981,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7489a049-b509-46ce-9e02-6304b6e10ef7")
+			(uuid "fe9354b5-193b-4aad-916b-f1e2a9f8db83")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -3980,7 +3991,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "77cfbb07-dd99-49dd-9b10-21ed75b80deb")
+			(uuid "0e013a7e-c7a5-4c7a-97e4-19d2cf79f0da")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -3990,7 +4001,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2a6a78b6-c862-43ad-9044-1c9ffeb86667")
+			(uuid "9fd45fa6-22c2-49eb-8d16-2b3ba077dff3")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -4000,12 +4011,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "208fde05-3906-4dcc-861c-a6083f0844cf")
+			(uuid "acfeeb1e-5e63-444d-b030-ddecca5b917b")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "0477d8f8-39f8-4ce7-84ed-d42e60ab4c2a")
+			(uuid "710d5057-b613-49f2-b090-0aeda2c35fc5")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -4020,7 +4031,7 @@
 			(roundrect_rratio 0.25)
 			(net 38 "/MCU/LTC44_{~{PFO}}")
 			(pintype "passive")
-			(uuid "0983037d-9e23-4031-8291-99c7f5e37e4a")
+			(uuid "f729c50e-c60b-449a-9ab1-3075d80648d8")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 180)
@@ -4029,7 +4040,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "d0fafae6-21ca-4aa0-9bbd-a606a769a4d1")
+			(uuid "f569120e-877f-413f-841a-c4c6fe71f7be")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -4052,7 +4063,7 @@
 		(property "Reference" "R24"
 			(at -3 0 -90)
 			(layer "F.SilkS")
-			(uuid "8417370f-02f5-4002-9381-e729790805f4")
+			(uuid "745acb95-3336-490c-8335-41c74768f215")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -4064,7 +4075,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c7ac5362-65d9-4967-9f96-d676054ca757")
+			(uuid "633ab2ec-58e8-4fd4-9b89-ac377ad4f68c")
 			(effects
 				(font
 					(size 1 1)
@@ -4077,7 +4088,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f85b0958-4a00-42e3-957c-336095f51fd3")
+			(uuid "5d193ee5-77e0-4da7-8b05-faba8619aff8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4090,7 +4101,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "567d0cda-7561-41e1-b695-58f33dca5b48")
+			(uuid "1214f297-c416-48b6-a32c-e4d43f4a32d2")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4103,7 +4114,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d6742271-f382-4dd0-a711-3148f85e268d")
+			(uuid "a6aac87d-3bb5-483c-b443-c7ee64c0dc81")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4124,7 +4135,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cbc0f0a7-81e6-4a5e-bba4-0dbef65a0c6d")
+			(uuid "42a08b68-23f1-4362-b6ee-451bb6d4ad24")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -4134,7 +4145,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "026bbf6a-1faf-43e4-b0f8-a1a6655f4b37")
+			(uuid "71355a3d-4c1c-4427-a556-a1c61e9359e1")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -4144,7 +4155,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6afdbef7-837b-4e74-b034-7c5d49041055")
+			(uuid "631a6738-c115-45d3-a42d-5143a040f90a")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -4154,7 +4165,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d64b1d06-47c4-4091-87c2-3369d09036ef")
+			(uuid "4a36807c-ca5f-49a4-95aa-27f5e08ce9ad")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -4164,7 +4175,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "cd364269-7c69-41fa-a6a2-54dbb8487e61")
+			(uuid "588c6086-bb1d-4a64-b113-61bbd10e2867")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -4174,7 +4185,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "342705b7-4c7c-4d6c-8eae-1c8378de1da1")
+			(uuid "b3448e96-9f04-4766-bf1b-1eb70a4cfe2b")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -4184,7 +4195,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "63131844-9737-4805-8766-262415403fc2")
+			(uuid "35f28b11-abee-4791-92ba-f4aa72e4346e")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -4194,7 +4205,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e1b3018a-d1d6-4a50-b8a2-1b49bbae48b7")
+			(uuid "bea38f39-c3cd-4256-a9fc-ba920b24a0cc")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -4204,7 +4215,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ac31b195-850e-460f-bca8-86b5de26cf55")
+			(uuid "7a22f511-65cc-463a-a3e5-89fc7be897fc")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -4214,12 +4225,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4a8a8f07-2e01-44ab-ba84-15b2d2f15ed9")
+			(uuid "d071ec0a-bb93-4158-ae7e-59fe751d72e6")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "e70cc9e8-edb4-4231-a185-145fa20cc869")
+			(uuid "3a96d92a-5119-40d4-b546-6b4eacf38b35")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -4234,7 +4245,7 @@
 			(roundrect_rratio 0.25)
 			(net 46 "/MCU/IS31_{EN}")
 			(pintype "passive")
-			(uuid "b6a6152d-d2f9-436c-8524-c3e95bd67ab9")
+			(uuid "dd276dcc-1b70-4cdf-985d-182164c155a1")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -4243,7 +4254,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "a724f0cb-10d1-48e3-a946-b790cccc1db0")
+			(uuid "6c2f5fa6-8061-4524-88f9-9550a28b1d32")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -4264,9 +4275,9 @@
 		(descr "Resistor SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf), generated with kicad-footprint-generator")
 		(tags "resistor")
 		(property "Reference" "R13"
-			(at 0 -1.5 90)
+			(at -2.6 0 90)
 			(layer "F.SilkS")
-			(uuid "2b6da719-c7d4-4c7c-b813-97bed5e7581e")
+			(uuid "cdd17784-c815-4c83-ad6f-3357321c542a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -4278,7 +4289,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "31ff0883-ba79-48c7-8727-c5bd3c57f2ea")
+			(uuid "e6e17d54-349d-4028-966c-5606938b151d")
 			(effects
 				(font
 					(size 1 1)
@@ -4291,7 +4302,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2b49a919-3167-4612-99ef-4d951f743d3a")
+			(uuid "da6b7848-0b03-4cde-953d-72dfc9897231")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4304,7 +4315,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "53b3a1fd-8418-44b6-839a-e13cb7b7d862")
+			(uuid "97dc9754-9bcd-44d5-9f3d-0730eb45404a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4317,7 +4328,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "75f9bf49-1b18-4871-bd85-22ef85de9ece")
+			(uuid "36c4d3e4-608c-4bd2-a599-c49bf78f9357")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4338,7 +4349,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fde4f0f9-3afe-4ede-a74d-5673f53a0510")
+			(uuid "fc489eaa-91b1-4769-bdb5-37ece8793d96")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -4348,7 +4359,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "3087766e-2613-450d-9ad2-8d6181028834")
+			(uuid "61e5987c-b45a-4710-b026-3eb7e2470029")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -4358,7 +4369,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "aaab0558-4f04-4138-8bd9-d2cb8a549bce")
+			(uuid "f44a2125-a419-49b5-8dd9-9f7a0c54aec5")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -4368,7 +4379,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "943bc98d-9814-471f-a6e1-e194408a4a7d")
+			(uuid "66e08612-3abf-4237-ace6-3950132461f7")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -4378,7 +4389,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "61347eb7-9172-43bd-9c76-84c6e8b3d7a6")
+			(uuid "93aa10b5-04cb-4152-b0e0-bc672a0cb847")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -4388,7 +4399,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f8ffa182-80c0-4c0d-a683-512fdb3777a1")
+			(uuid "2590c713-6413-4cab-9c62-62613b209d90")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -4398,7 +4409,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9aa5b7fb-b89a-4867-81fc-f617179566e4")
+			(uuid "4ae497e4-353b-447c-a643-43b2a0b7a348")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -4408,7 +4419,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "af524670-e04f-4f3b-bb1b-5897bdb98147")
+			(uuid "71a83d94-bd93-4522-8476-abc43f6af479")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -4418,7 +4429,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2aa2b964-d788-4637-8677-19dccf523c2e")
+			(uuid "0ab38d6e-f554-4566-8001-3bec0d27afd1")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -4428,12 +4439,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "55d92234-5c81-4180-9357-2b11dcd11302")
+			(uuid "a204a9a4-8a6d-4142-be77-7ed07132d833")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "c0eaf33d-f886-4ae4-b9cf-d1426385abd6")
+			(uuid "413832f1-7fec-4af7-be33-b0c1b8d83b5c")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -4448,7 +4459,7 @@
 			(roundrect_rratio 0.25)
 			(net 34 "Net-(U6-PFI)")
 			(pintype "passive")
-			(uuid "23570d50-5e28-41ed-9d45-ae23b839307c")
+			(uuid "c6148b60-5f45-41bc-af09-25091d7eade0")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -4457,7 +4468,7 @@
 			(roundrect_rratio 0.25)
 			(net 37 "Net-(U6-PFI_RET)")
 			(pintype "passive")
-			(uuid "d1031b96-a2d1-4166-bf73-b56748423ba6")
+			(uuid "147164be-784b-4ae2-a6f2-b1b5d4e588ff")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -4482,7 +4493,7 @@
 			(at 0 -3.25 0)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "8e55fd94-9e77-42e8-9680-dce4f5b1a2c1")
+			(uuid "ef25d771-d7d6-4ddb-bd42-dfb25a33f633")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -4494,7 +4505,7 @@
 			(at 0 3.25 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "cec24463-dd1c-4ad6-bf8d-ba1a68a93dbd")
+			(uuid "6b1a89b1-a019-4c76-9588-460b6933d5a1")
 			(effects
 				(font
 					(size 1 1)
@@ -4507,7 +4518,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7b5cee43-ede5-433d-9f82-50324c9b9b50")
+			(uuid "dfbf14f7-3175-4d18-a679-3c87184fb6ba")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4520,7 +4531,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "59a1d253-0ae0-40e3-9cbd-c3da33c7b4ab")
+			(uuid "8c00fee8-3595-4b7a-ae51-8754d988748d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4533,7 +4544,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b040f648-c96e-4f92-8923-dfb2e20998c5")
+			(uuid "81f0980d-b461-424a-8620-f34ff02f73d0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4555,7 +4566,7 @@
 			)
 			(fill none)
 			(layer "Cmts.User")
-			(uuid "627dcbb1-980b-48ac-b457-20e1aef07318")
+			(uuid "923d5d83-8a00-44b0-aabc-d9b687f6178b")
 		)
 		(fp_circle
 			(center 0 0)
@@ -4566,13 +4577,13 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "49de5a47-5feb-434e-9b53-0625c8478b8b")
+			(uuid "881eb206-be9e-4cd0-b2bc-af7e26582767")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2c1b3274-2bc6-4473-bece-35a843054023")
+			(uuid "1a72a4b8-c760-4e1b-ae64-cc9682b5fb06")
 			(effects
 				(font
 					(size 1 1)
@@ -4585,7 +4596,7 @@
 			(size 2.7 2.7)
 			(drill 2.7)
 			(layers "*.Cu" "*.Mask")
-			(uuid "1a832f55-38cc-4722-8ef6-29faa99a95e7")
+			(uuid "56a64cf6-3c8b-4150-a635-d952a1d3527f")
 		)
 	)
 	(footprint "Resistor_SMD:R_0805_2012Metric"
@@ -4597,7 +4608,7 @@
 		(property "Reference" "R34"
 			(at -1.97 0.17 -90)
 			(layer "F.SilkS")
-			(uuid "6625e635-9e40-4efe-a458-8108f7851467")
+			(uuid "2e6eaa98-c91e-4ae5-9017-03e98531f796")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -4606,9 +4617,9 @@
 			)
 		)
 		(property "Value" "0"
-			(at 0 1.65 360)
+			(at 0 1.65 0)
 			(layer "F.Fab")
-			(uuid "93b160c3-c359-4b54-9144-6d87778e2301")
+			(uuid "96e08be0-6621-43ce-ae30-170f75bd5e42")
 			(effects
 				(font
 					(size 1 1)
@@ -4621,7 +4632,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3ba442d6-160b-4ade-bdb1-8862aa6a740a")
+			(uuid "4db19bd9-6d58-4c82-94fe-671841a7da74")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4634,7 +4645,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "95ac1c69-974a-4224-b6fa-2bcaee408025")
+			(uuid "9af31ffb-f7ae-4c6e-8445-8d7ee094bbc4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4647,7 +4658,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "19808942-2ceb-44fd-9577-abfdcb44ed5f")
+			(uuid "d7860013-847a-4ca1-81af-94477c62c3c4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4668,7 +4679,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5f7bbf69-5e6c-4c94-8dbe-4e1cf90f7a66")
+			(uuid "3b8fd031-7b1e-469e-b390-5b390659c38a")
 		)
 		(fp_line
 			(start -0.227064 0.735)
@@ -4678,7 +4689,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8c937850-101c-4f50-95b8-efddc3714806")
+			(uuid "2fe03fb7-2d07-41d4-b0bc-4243a5babbe4")
 		)
 		(fp_line
 			(start -1.68 -0.95)
@@ -4688,7 +4699,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d872b0ac-7c92-4874-9c3c-6c0a87ade13e")
+			(uuid "b3bba1ab-668d-4e2d-a762-46677bc8c27c")
 		)
 		(fp_line
 			(start -1.68 0.95)
@@ -4698,7 +4709,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "72c4d1b1-b67a-4d3a-b683-98629ea0cd67")
+			(uuid "3ad0a1a0-da1d-4da1-88ff-a7beded2257c")
 		)
 		(fp_line
 			(start 1.68 -0.95)
@@ -4708,7 +4719,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f667f456-08e0-4af7-b3a5-12be4756d940")
+			(uuid "734bbd7b-6ace-4c39-9252-1630702b36f1")
 		)
 		(fp_line
 			(start 1.68 0.95)
@@ -4718,7 +4729,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5b6d092c-fb4e-48d5-8546-447f65a8adf8")
+			(uuid "a2df391b-66ed-4824-b4e6-220095396c01")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -4728,7 +4739,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a357f566-fae0-42cf-b8bf-c55796ebf634")
+			(uuid "9d776267-c3de-4093-a5c3-eb3af2bf4169")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -4738,7 +4749,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a320958c-adbe-4f3a-a8b5-d2aeafe8b020")
+			(uuid "f40de82b-eb51-4004-8242-df75a6293d1b")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -4748,7 +4759,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "de4775f6-0afc-489c-829d-ea7365857f3c")
+			(uuid "b00671c2-2ba9-4855-bb7d-db9d9f2e53cb")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -4758,12 +4769,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d85d5924-e476-4db9-b533-e1cfdd7f6962")
+			(uuid "0c376d7f-3277-4b59-9d9e-9cb54e28a656")
 		)
 		(fp_text user "${REFERENCE}"
-			(at 0 0 360)
+			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "5e49c9df-bce6-4d13-9699-be8fcafda10c")
+			(uuid "cb7e3f2e-0bcf-4452-9a78-23bcfde4336f")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -4778,7 +4789,7 @@
 			(roundrect_rratio 0.243902)
 			(net 48 "/Touch Sensors/MODE")
 			(pintype "passive")
-			(uuid "afd9c7da-547a-441c-a97f-fb77c4e1c65b")
+			(uuid "a41f872e-0bcf-4e4e-874a-fee8020fc291")
 		)
 		(pad "2" smd roundrect
 			(at 0.9125 0)
@@ -4787,7 +4798,7 @@
 			(roundrect_rratio 0.243902)
 			(net 96 "Net-(U4-CS3)")
 			(pintype "passive")
-			(uuid "c32ea36d-7a01-41d4-ac51-ba8216d7c8bc")
+			(uuid "054ce7c9-7593-4995-8b3e-a92e089d5d41")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.wrl"
 			(offset
@@ -4810,7 +4821,7 @@
 		(property "Reference" "R15"
 			(at 0 1.3 0)
 			(layer "F.SilkS")
-			(uuid "30f71f08-7213-4ad2-a961-48e0dcbf4787")
+			(uuid "766e3620-a882-46d1-9d43-3f26fd5c7072")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -4822,7 +4833,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7d9da0bf-c75b-4ea4-8059-577d663c8380")
+			(uuid "fe073d38-dfe7-48bf-b28e-d2ddae61dfa8")
 			(effects
 				(font
 					(size 1 1)
@@ -4835,7 +4846,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "04a8756b-dc8c-4a0d-8060-67eeef9e1c48")
+			(uuid "e41c91a7-8c36-4c37-af6a-d8b4883e3f9e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4848,7 +4859,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2246bf31-99f6-49de-bb70-c13029693c6a")
+			(uuid "a15045d6-38f5-48b9-9d92-22dbada16476")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4861,7 +4872,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e54e7f3a-08c7-4ba7-87bb-af92720c70dc")
+			(uuid "795d350f-db6a-47ec-85ca-b6c5048dc0c0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -4895,7 +4906,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e266bbb3-557d-4fec-80d7-7449c37e5e6a")
+			(uuid "fa4c0609-da56-4068-babc-189db1273a7e")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -4905,7 +4916,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "341a6d61-d6af-49c4-afd9-e3f2ad1b5d36")
+			(uuid "a2be21bd-cd8a-40c1-a2e2-b9bbecaee43e")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -4915,7 +4926,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "eadafbdf-ae75-4789-b3fd-ec51d49f0450")
+			(uuid "df303dd6-908f-4060-8173-51b0cc42f652")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -4925,7 +4936,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "82bac7cd-c394-4488-a98e-7c3c3ada73d6")
+			(uuid "93035b9c-f3ab-4cf5-b187-de7e5d404b7b")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -4935,7 +4946,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "08c243a9-2033-41b9-a8d4-f2845de496cb")
+			(uuid "dbd7999b-f5d2-4866-9503-e69c5c0ae78f")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -4945,7 +4956,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2d54610d-a80a-4358-b889-f8a4b886ad19")
+			(uuid "22dcebf6-ae18-4e06-b11a-050c8c1802c0")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -4955,7 +4966,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "333e1635-fa58-4b8c-8704-a3dfe4bd06ab")
+			(uuid "f6936602-3376-4ba1-8c5f-cb813a1d4d7f")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -4965,7 +4976,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5687225a-b5f2-4318-8cf8-1a939f66d9a7")
+			(uuid "2da93271-e2b1-433e-8311-142de9ce8ecd")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -4975,7 +4986,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "462dbf24-9e9b-4d63-a6a7-afcffd49fe13")
+			(uuid "175c3503-0d84-4c79-834e-f4d33f72c4d2")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -4985,12 +4996,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ad001391-8979-43b9-9563-ce05330c0691")
+			(uuid "a11ef006-22e2-4a62-b7ba-97809a324600")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "fc3a0233-4217-4d7e-848e-b66b7be7d955")
+			(uuid "8443c539-8926-4add-a40e-a712748d12eb")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -5005,7 +5016,7 @@
 			(roundrect_rratio 0.25)
 			(net 35 "Net-(U6-FB)")
 			(pintype "passive")
-			(uuid "e31f1a8f-9769-40a8-9e8a-46c0b0ce9bbf")
+			(uuid "d3c5826b-d98e-44ac-83a0-162bea9d768b")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -5014,7 +5025,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "f2290f9a-a3da-484d-98e1-5f8cd75df51c")
+			(uuid "2d84a10e-c015-4336-8d22-54091aa03e72")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -5037,7 +5048,7 @@
 		(property "Reference" "J4"
 			(at -2.3 1.9 180)
 			(layer "F.SilkS")
-			(uuid "cec87810-0b59-45ec-9f32-156777672e2e")
+			(uuid "603d8054-c167-4d78-a44d-d28359b9d80f")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -5049,7 +5060,7 @@
 			(at 0 3.3 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "873942a9-b315-4b53-a71e-ede1103770d1")
+			(uuid "047f9fb1-b4ba-4116-8d23-232fa2ef5f88")
 			(effects
 				(font
 					(size 1 1)
@@ -5062,7 +5073,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ef3703b6-f6e1-4b4e-a460-a04a735a1c50")
+			(uuid "add3aac6-c054-46b1-98e8-807fc2c88749")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5075,7 +5086,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bb79d080-b768-4be1-902c-73b0dad155b7")
+			(uuid "153955ee-6e93-458e-964f-ef30b67522f9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5088,7 +5099,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5b88880d-cdd4-4dc0-8c1c-17691790479f")
+			(uuid "b0207749-4bd0-4eb3-b5e8-124a00881d45")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5109,7 +5120,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6deba185-62ed-46a9-a77c-bbffc49459b2")
+			(uuid "00d70c6a-1ed8-4a58-b1a4-4c74c343137d")
 		)
 		(fp_line
 			(start 2.61 -0.04)
@@ -5119,7 +5130,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "80cbb82d-2b34-444c-8b29-ea627886eab5")
+			(uuid "d6db10ed-5e27-4ace-8226-5193da38b9fb")
 		)
 		(fp_line
 			(start -2.61 -0.04)
@@ -5129,7 +5140,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "3bd1020c-20ba-49b5-9683-b86776c60a0d")
+			(uuid "509f381c-0db2-4017-8cf9-fa692e866dbe")
 		)
 		(fp_line
 			(start 2.61 1.11)
@@ -5139,7 +5150,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e40d5892-9aab-49b9-aede-fbb95287e40d")
+			(uuid "8fdd9119-3a64-47f0-85c6-85c5cbb2d22e")
 		)
 		(fp_line
 			(start -1.56 1.11)
@@ -5149,7 +5160,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4730faef-9284-43d4-a543-132ad9539fd6")
+			(uuid "27dc74e3-8507-49ae-b5fd-f584c1bab76d")
 		)
 		(fp_line
 			(start -2.61 1.11)
@@ -5159,7 +5170,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a7f30ee8-fa44-43b2-9f98-d1e0a21e7f14")
+			(uuid "3cb5e468-b0b4-4e34-ad9c-a8f8c1377869")
 		)
 		(fp_line
 			(start 3.4 -2.6)
@@ -5169,7 +5180,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4f0f9fb2-9bcd-4ae4-905a-40c09e82d52b")
+			(uuid "1f247e18-c558-4dd7-8104-78ce99cb68d5")
 		)
 		(fp_line
 			(start -3.4 -2.6)
@@ -5179,7 +5190,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6382660d-96c8-4af1-a85f-08b1b936da38")
+			(uuid "c1326702-96a5-406b-b2c4-4d88fe480cf4")
 		)
 		(fp_line
 			(start 3.4 2.6)
@@ -5189,7 +5200,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c6c9eb31-5690-4a4b-8065-49476ffe2395")
+			(uuid "518dda9a-dcf1-4497-9f43-0b27f175762f")
 		)
 		(fp_line
 			(start -3.4 2.6)
@@ -5199,7 +5210,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ed69d056-eae6-4da3-8b3a-ffeab036013b")
+			(uuid "1a651bba-e273-4c08-a3f3-56b15351b2a9")
 		)
 		(fp_line
 			(start -2.5 -1.9)
@@ -5209,7 +5220,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "82a81838-db71-404f-96a6-cd918b804061")
+			(uuid "aeb0219c-2d8f-4eef-b951-986d403990e1")
 		)
 		(fp_line
 			(start 1.15 -1.55)
@@ -5219,7 +5230,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c5edce59-c9b3-4fd5-b23d-726b4c82b87c")
+			(uuid "7dd0cf21-e65d-42ba-a82f-3c4eb44bd8f5")
 		)
 		(fp_line
 			(start 0.85 -1.55)
@@ -5229,7 +5240,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c7d8289f-10fb-4950-85d9-c4848b4f7713")
+			(uuid "4b7b75ec-60c3-4f68-bcb6-622d22a1d434")
 		)
 		(fp_line
 			(start 0.15 -1.55)
@@ -5239,7 +5250,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c739da9c-79fc-471d-8326-db7bdd707436")
+			(uuid "2e181da4-1767-4ba7-913d-52056e5e8c3e")
 		)
 		(fp_line
 			(start -0.15 -1.55)
@@ -5249,7 +5260,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d88e72fb-a10a-4e4e-a488-4069db1d2d5d")
+			(uuid "e2efa1cc-ac87-42f7-8707-ff8bc97f6b7a")
 		)
 		(fp_line
 			(start -0.85 -1.55)
@@ -5259,7 +5270,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1f192ef1-0eba-43ed-bd60-d56cc6e20271")
+			(uuid "3763acc5-c433-44c5-942b-d31e24a3c362")
 		)
 		(fp_line
 			(start -1.15 -1.55)
@@ -5269,7 +5280,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7bfe65a5-c0cb-4808-bedf-8e82e411705b")
+			(uuid "a7cecd93-f369-4c60-be49-9f22f3fe578a")
 		)
 		(fp_line
 			(start 1.15 -0.95)
@@ -5279,7 +5290,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b011d570-bb8d-46e7-86ee-4cafe901d76b")
+			(uuid "d23b89be-ecc8-4056-8772-2965d5d39c87")
 		)
 		(fp_line
 			(start 0.85 -0.95)
@@ -5289,7 +5300,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2f9ccf4b-95e1-4965-9ee2-40ee3aba297a")
+			(uuid "813a5fae-fb4a-4e15-9753-b7bdfb6fc383")
 		)
 		(fp_line
 			(start 0.15 -0.95)
@@ -5299,7 +5310,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5d0eff77-0119-49dc-b7f8-5d3c8a8e9e94")
+			(uuid "d289e7aa-0a0e-44a2-8b81-b581de5bff0f")
 		)
 		(fp_line
 			(start -0.15 -0.95)
@@ -5309,7 +5320,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "10cf46de-1c49-4078-8a82-61e4a5c30685")
+			(uuid "9eb10fcf-bb47-4dc2-994c-07d7d0eeedf3")
 		)
 		(fp_line
 			(start -0.85 -0.95)
@@ -5319,7 +5330,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "bc720c12-ccbc-4864-9c78-0e47cb8cd51b")
+			(uuid "6c988fc3-4a37-428b-824b-544996fdd288")
 		)
 		(fp_line
 			(start -1.15 -0.95)
@@ -5329,7 +5340,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e5f53f7a-54d2-464d-8d20-cb0d697b8f3e")
+			(uuid "b435fe01-b6b8-447d-b50a-9360f411399c")
 		)
 		(fp_line
 			(start -1 0.292893)
@@ -5339,7 +5350,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "448ab14d-212a-4816-81e7-6bb77c72661f")
+			(uuid "9556a9ff-90e7-4ac4-8b29-18923659f2d4")
 		)
 		(fp_line
 			(start 2.5 1)
@@ -5349,7 +5360,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "193e1c79-a0ef-4dda-b415-fb3c28a92cc8")
+			(uuid "f1a91c5c-34c5-4063-a315-31afe50b8f64")
 		)
 		(fp_line
 			(start -1.5 1)
@@ -5359,7 +5370,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3ef09074-1b78-41c7-916b-7d90fff9633f")
+			(uuid "d2702162-ed70-4171-9ba3-53a1d828cf49")
 		)
 		(fp_line
 			(start -2.5 1)
@@ -5369,7 +5380,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "63e93721-2ace-40b3-afca-16df639ad24a")
+			(uuid "47276e32-2a40-4d4d-8698-2deeb3af3646")
 		)
 		(fp_line
 			(start -2.5 1)
@@ -5379,12 +5390,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a823f70a-a269-4231-b21f-1b743002c697")
+			(uuid "a4bbc61d-2a34-4147-bf68-b1f332f81ca2")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 -0.25 -90)
 			(layer "F.Fab")
-			(uuid "210e1abd-efb3-465f-acbb-53107afdd68d")
+			(uuid "101d4859-ee07-47e4-be1b-8a81a1c34eb9")
 			(effects
 				(font
 					(size 1 1)
@@ -5400,7 +5411,7 @@
 			(net 19 "Net-(J1-Pin_4)")
 			(pinfunction "Pin_1")
 			(pintype "passive")
-			(uuid "2d5a28a2-618c-466d-b3bb-588eca2ec130")
+			(uuid "5f444fc8-8488-4e6d-bede-4e75b5910de9")
 		)
 		(pad "2" smd roundrect
 			(at 0 1.325 90)
@@ -5410,7 +5421,7 @@
 			(net 1 "GND")
 			(pinfunction "Pin_2")
 			(pintype "passive")
-			(uuid "3eeb1fa9-52b1-4a2c-8dbf-57044799afe7")
+			(uuid "e3101381-d306-4544-b770-bc24b7d73534")
 		)
 		(pad "3" smd roundrect
 			(at 1 1.325 90)
@@ -5420,21 +5431,21 @@
 			(net 18 "Net-(J1-Pin_2)")
 			(pinfunction "Pin_3")
 			(pintype "passive")
-			(uuid "74f6fd65-375f-4b62-a6b7-72bd417e576f")
+			(uuid "08c9028e-96ad-4e54-abaa-15f5e4df0c11")
 		)
 		(pad "MP" smd roundrect
 			(at -2.3 -1.2 90)
 			(size 1.2 1.8)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(roundrect_rratio 0.208333)
-			(uuid "2788982b-16a4-436c-a0e2-8c589e6cb5ce")
+			(uuid "d4a27a0f-130d-4fb2-9245-c6f4214667ad")
 		)
 		(pad "MP" smd roundrect
 			(at 2.3 -1.2 90)
 			(size 1.2 1.8)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(roundrect_rratio 0.208333)
-			(uuid "925d8571-a88a-43cc-8d74-576a75aeaa28")
+			(uuid "01d4384c-60eb-4fdc-a4cb-7f15803e5d4d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Connector_JST.3dshapes/JST_SH_BM03B-SRSS-TB_1x03-1MP_P1.00mm_Vertical.wrl"
 			(offset
@@ -5457,7 +5468,7 @@
 		(property "Reference" "R31"
 			(at -2.6 0.07 0)
 			(layer "F.SilkS")
-			(uuid "55798820-b71f-41b2-a216-100476ef832c")
+			(uuid "0216cdbc-38d7-44eb-9b55-27afe02a0248")
 			(effects
 				(font
 					(size 1 1)
@@ -5469,7 +5480,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b28aa21e-da33-430f-ba31-94355be789ae")
+			(uuid "9e3018ec-5abc-4c47-bc66-581cbbe107cc")
 			(effects
 				(font
 					(size 1 1)
@@ -5482,7 +5493,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d48557f7-97f9-4bad-8349-b8584638dbca")
+			(uuid "dda499f4-a30a-419e-81c2-55883a78cdb9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5495,7 +5506,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4df9ebae-fb76-4b6d-b845-d42e647bba15")
+			(uuid "83ee6d2f-6909-4b2b-9f40-1803f6f9a28b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5508,7 +5519,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c8b50dd7-3958-4bca-b834-595b0fb73580")
+			(uuid "1be3347d-4ea4-44bb-91bf-dd1e717d8a47")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5529,7 +5540,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4bd83bd4-4ad5-4869-907b-5d04b1322bb5")
+			(uuid "83afeef1-6c83-4f2d-95d2-c9f69c51dc68")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -5539,7 +5550,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ba106248-d601-4cea-9f95-30d231dc0e8e")
+			(uuid "ae980001-3bf2-4dc3-92af-897d84075a9b")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -5549,7 +5560,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9c745efb-cd42-4513-a90f-87468928cfcc")
+			(uuid "5cdb08cf-2a5a-4237-9015-20f25679ee5e")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -5559,7 +5570,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "358736bd-eba7-4beb-a5db-8b042d8f7dcd")
+			(uuid "f76f4bab-45d8-46f7-87ca-009cf7ef7bef")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -5569,7 +5580,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e65b236a-1484-4e49-83de-af6648a39cf0")
+			(uuid "992f35a9-b785-475a-a4e4-0059b70f6bba")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -5579,7 +5590,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5af6307d-d111-4675-8858-1297e5346758")
+			(uuid "dd2ca147-0060-40c9-af97-08317f87b602")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -5589,7 +5600,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8fb4c8be-eed0-4c4e-b44f-192afbd6234c")
+			(uuid "69150da3-c878-467f-95ce-7841126fb852")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -5599,7 +5610,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c5c5197f-b90d-4c83-98c3-a8460afa8b37")
+			(uuid "f6fa0c76-f3b4-40a3-874b-d27b7e2c9ef0")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -5609,7 +5620,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0b569cfe-808b-4063-a117-2ab6f34d89c7")
+			(uuid "b03ea19b-368c-4370-8287-81356a946cd4")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -5619,12 +5630,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "43be08d8-1d95-45a6-86d7-7a3236b794e5")
+			(uuid "f53bb145-054a-4b6f-ac18-7fb2219e11fe")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "155881b2-f025-47cf-922b-eb7f4a50b722")
+			(uuid "d01a5941-71ef-4394-a930-666565d3b060")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -5639,7 +5650,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "40c26879-c2bf-4573-8263-f3fda9c95468")
+			(uuid "f1bd9e12-7b35-4733-8a1e-227c307a8433")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -5648,7 +5659,7 @@
 			(roundrect_rratio 0.25)
 			(net 68 "/MCU/TMC_{~{EN}}")
 			(pintype "passive")
-			(uuid "489d5295-dc8b-4fea-ad88-a7f6018be154")
+			(uuid "88e98b5e-67fc-4acc-adc7-7d7721f55853")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -5671,7 +5682,7 @@
 		(property "Reference" "C4"
 			(at 1.8 0 0)
 			(layer "F.SilkS")
-			(uuid "e3fde22a-0e52-4403-98b2-8b529593ecf5")
+			(uuid "ee1fce1f-aaf1-49df-a678-c5b48839cc8a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -5683,7 +5694,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e6a7429b-bbdc-4b41-9348-b4c2d9c3ede9")
+			(uuid "eed994a3-e25b-44ba-bd95-78dd77a54b62")
 			(effects
 				(font
 					(size 1 1)
@@ -5696,7 +5707,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "abe57658-4233-4091-bb72-a45097b4d0a7")
+			(uuid "6cedefc4-79f9-44e4-aa57-f4daafdf5490")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5709,7 +5720,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a36d1337-b7a4-4928-ab7a-e37596ae4bfb")
+			(uuid "124b9b84-9082-4f72-b266-8ccfd34ed713")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5722,7 +5733,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "45604727-dc7a-46ff-a594-87b9f5bbdf56")
+			(uuid "84d71e95-54ca-4f74-9c04-d6dc3846d349")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5755,7 +5766,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "21edfbe8-6499-4dd9-a60c-80623be62db6")
+			(uuid "fd65772b-87db-49ac-9a68-ecd60403f576")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -5765,7 +5776,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "31f26a78-4dd5-4ec2-b707-b4761bdd48e9")
+			(uuid "999278a4-bef8-4a0d-ab35-e6100ca53145")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -5775,7 +5786,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "25143217-454d-4ad2-a81d-5e90e13bdd13")
+			(uuid "b84597fd-3e5c-4974-afc8-7321a5bdd412")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -5785,7 +5796,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ef2e9537-9bdf-4a7f-a2b8-7d57e4d074ec")
+			(uuid "14b876a0-ef51-4f5a-9e93-d9b66fc9419d")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -5795,7 +5806,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "abeaecae-b866-4da7-81d6-58ba2bf408e9")
+			(uuid "80dd680c-8806-453c-9fca-700f360434a1")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -5805,7 +5816,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d80dffbf-4aa7-4b3e-82d2-adfe9112c67b")
+			(uuid "965bf376-11f5-41b1-bd8d-9a4bd3266ff2")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -5815,7 +5826,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "37e9f223-0ab6-4013-b90b-b11ce8e899f3")
+			(uuid "6e3af8f5-f79c-4259-bb90-d3722d9abd23")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -5825,7 +5836,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f4c73bd5-aab4-4df7-9607-62aee0752c2b")
+			(uuid "e3844d02-3eae-4d2c-b356-dd7f362fa8f5")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -5835,7 +5846,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b9a7e31a-8755-4a3f-b8a8-958518b1209e")
+			(uuid "feb2e0de-835d-44f9-afc4-d72ff3ef8d77")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -5845,12 +5856,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "89cc1151-2c8a-4fe9-bcee-f1372f00d217")
+			(uuid "4cdd09ad-9eb0-4057-a6a0-3a8e9d559696")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "72549c1e-1024-4bc1-a7dd-50b23ee0529d")
+			(uuid "aa77196d-9be3-4fbf-abea-e1ce738cf010")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -5865,7 +5876,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "ffd04e5a-fb3e-410a-92e2-e3eaed788490")
+			(uuid "d6e0854c-3330-4c3c-92a8-8e2ff0ad2a9e")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0)
@@ -5874,7 +5885,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "2b89170d-9fa8-4f02-9a32-9901cb773c0c")
+			(uuid "956e6d5c-309b-47ca-bd39-48eb33324103")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -5897,7 +5908,7 @@
 		(property "Reference" "C11"
 			(at 2.2 0 0)
 			(layer "F.SilkS")
-			(uuid "7a9a968c-14ce-4ad2-abfc-22f02453b6dc")
+			(uuid "32e53c06-674c-49ad-80db-aa7162a0fb35")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -5909,7 +5920,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8c63a671-e47b-43b8-841e-c15d1ffa0646")
+			(uuid "951690a1-e7db-4f2d-a83b-0d43b53264fa")
 			(effects
 				(font
 					(size 1 1)
@@ -5922,7 +5933,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4a0a61c8-3194-408a-a03e-e1426495a947")
+			(uuid "04acf775-c488-4229-a8d2-1f4b4cb29345")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5935,7 +5946,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0fea1adf-554a-4c63-ab8e-17e0afc832c7")
+			(uuid "4d31ed6b-72b9-45d1-9b87-9975add43e07")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5948,7 +5959,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "22950324-7f8b-4bc4-8014-911381c7329d")
+			(uuid "3ccfb445-f4c7-45a4-8f02-f8a56bd9225b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5969,7 +5980,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6b531748-be0d-4331-b759-ea1fa8362124")
+			(uuid "631b3f46-048e-43df-ad8d-2baa6fa90105")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -5979,7 +5990,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "56db5dd3-e7ca-4197-ab60-8468deb32797")
+			(uuid "89834ea1-7755-4415-858c-bbb7c29fe556")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -5989,7 +6000,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "704c3c95-3c06-4f0a-86c1-cb80abf00770")
+			(uuid "49b206b6-5f52-41f0-900c-d4ddf0b7207f")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -5999,7 +6010,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "58db88dd-5691-49b0-81d1-c2542495b66c")
+			(uuid "c3a0b2c4-c96a-4235-99d3-6e2bb98c6d19")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -6009,7 +6020,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e600220e-96df-42db-8d7c-5771f41e142c")
+			(uuid "443a7bdc-ccde-4a7a-9fdd-af4788f80f4c")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -6019,7 +6030,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0cdb8bac-fad3-44e8-b011-a0d8cce5ccbc")
+			(uuid "66770147-b290-4773-a719-6897c2c953b3")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -6029,7 +6040,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "146c4bfd-b00f-47d6-b8a4-790a65710a43")
+			(uuid "02867bae-02d3-4254-b33b-a814c9457fa5")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -6039,7 +6050,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "cd0e866f-4c43-43c0-a70b-2f170d4dd9eb")
+			(uuid "4c225abd-8ecc-42d2-9db8-ead9f750cfa8")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -6049,7 +6060,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8158b623-8320-4b0a-b827-39faa846d9b6")
+			(uuid "e141d27f-00a3-4c06-a154-7b3da83e639d")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -6059,12 +6070,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "035b5e9e-6269-4be2-9212-71667ae6c8b4")
+			(uuid "622e45c6-e6ab-42cb-96b8-48323a3fb5e4")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "7a8c257d-688b-4644-aaa1-21126bbe3466")
+			(uuid "af74b02e-04c2-487c-b937-8f673d5eda29")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -6079,7 +6090,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "4ceb8b8f-4331-4a71-abec-cda4522686a8")
+			(uuid "e3ed9e7c-8bc6-408b-b5e3-88f41e4534eb")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0)
@@ -6088,7 +6099,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "1f801b39-749b-4c17-8178-73f619125210")
+			(uuid "24f4565c-f46e-4833-a0e9-493a82791f8d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -6111,7 +6122,7 @@
 		(property "Reference" "R28"
 			(at -2.19 -0.51 90)
 			(layer "F.SilkS")
-			(uuid "ded38e36-4410-465a-bcf3-a80fa5b080af")
+			(uuid "56b975a3-cdd7-439a-ac53-ab47868c9007")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -6123,7 +6134,7 @@
 			(at 0 1.17 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "17077367-85ff-4f2f-91be-eae5a0a9e9e5")
+			(uuid "efb2613a-d2ce-4a57-9c2d-33c135fa8bd0")
 			(effects
 				(font
 					(size 1 1)
@@ -6136,7 +6147,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "473b0305-9afb-4e26-b664-a9a3ea982d19")
+			(uuid "500ab6a7-6dc2-4e03-a93b-632c62a7271a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6149,7 +6160,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "efb57a85-7ee9-4278-a47a-4bd32f99c43c")
+			(uuid "9a8d3c91-00cb-401d-8a00-b32990f97fc1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6162,7 +6173,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c4b40f00-0e08-4f88-b3dc-4e1e776f83f2")
+			(uuid "99062378-c6ca-4d66-b640-8c6f0bc1f315")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6183,7 +6194,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fca402c2-2afa-472b-a036-a999d1cffa22")
+			(uuid "999f15b2-0667-4e1b-9496-06be0c03704a")
 		)
 		(fp_line
 			(start -0.153641 -0.38)
@@ -6193,7 +6204,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c73be042-f8ed-435e-8788-d555deae8e7d")
+			(uuid "f53d185f-1fcb-4b32-adb4-72ccba02896c")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -6203,7 +6214,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b9a2ea5a-d84f-4d21-a529-b4050d14830a")
+			(uuid "faeb7ebf-cbf1-485e-840a-6307adf7d2fb")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -6213,7 +6224,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "cc2397d1-abee-4de3-b668-9f90d86b5d5c")
+			(uuid "6c059b3e-43eb-4552-a100-fe819a2102f6")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -6223,7 +6234,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e2ed1419-f894-4149-9a88-d9dc14d2e861")
+			(uuid "1f211a5b-6f7e-49ac-86ae-abb13bbf8d6f")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -6233,7 +6244,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c6123461-a640-4eb5-9b3c-2287df32c303")
+			(uuid "69b672f5-ff04-4fb8-9bea-a83088c8c32c")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -6243,7 +6254,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "111654e1-980e-4c6a-b5e5-b81c23b2595c")
+			(uuid "a9fcb74c-34d2-4f3b-9f8c-99fed70dfddd")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -6253,7 +6264,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ca661f47-3f8a-468e-bde5-67f50bbd91ca")
+			(uuid "51f0baac-7681-422a-b500-1ddf64bbc35a")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -6263,7 +6274,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "312a8cc1-9318-4441-b524-02ece6078d96")
+			(uuid "73f875b1-8c29-4158-856c-1959d961a5ee")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -6273,12 +6284,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "62e3ffc2-dd13-488a-8991-95e504495cb8")
+			(uuid "40edb18a-ee67-4140-b0e2-09a1c0be548a")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "54187088-177a-438a-a9de-c9d2e157ffe0")
+			(uuid "cdfd85ae-5c2a-4598-bf45-5801d6cc5d26")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -6293,7 +6304,7 @@
 			(roundrect_rratio 0.25)
 			(net 86 "/MCU/UART0_TX")
 			(pintype "passive")
-			(uuid "355408f1-f268-4060-9878-c4f9d47c4f22")
+			(uuid "33f4b77c-4bdf-4570-a49c-e5ab483b1939")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0 270)
@@ -6302,7 +6313,7 @@
 			(roundrect_rratio 0.25)
 			(net 91 "Net-(U2-GPIO0)")
 			(pintype "passive")
-			(uuid "a7ee17e6-94b4-4006-846e-0e3312be2b59")
+			(uuid "68174022-ea37-4d53-af7d-0fbad364aaf1")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -6325,7 +6336,7 @@
 		(property "Reference" "C5"
 			(at 1.7 0 0)
 			(layer "F.SilkS")
-			(uuid "bece7420-75c7-4e25-8c12-9e00374e7a9f")
+			(uuid "6481c488-ac9f-4968-899a-dfa33e7627c1")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -6337,7 +6348,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "770668ca-4612-4d2f-81c2-5aecc81dfc60")
+			(uuid "9b3c6e0c-3827-4f9f-9e92-32fa9b315775")
 			(effects
 				(font
 					(size 1 1)
@@ -6350,7 +6361,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a1b7f130-c680-428f-918f-bbc7695983fe")
+			(uuid "fb3d2cc1-e76b-4dd1-a03c-e1d8d2f01092")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6363,7 +6374,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "18701812-67f0-4f6c-be7e-7899810d5396")
+			(uuid "75a32f34-11e8-4eb1-80a2-7eafbfbf2241")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6376,7 +6387,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "cd4892eb-6602-43b1-b4c7-99c369338313")
+			(uuid "25f3fd67-d8fa-4783-a177-9e730123152c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6409,7 +6420,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "98b89382-6beb-448a-a861-d3e84799585b")
+			(uuid "cf482a4e-f8f9-43ef-b829-c8073b79ef2a")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -6419,7 +6430,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d3e646ef-dfeb-4eb6-9e06-166e0872f2c0")
+			(uuid "807f5a57-0e2b-4189-bc51-e3cfbd7ef425")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -6429,7 +6440,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f6fb8a09-dc52-479c-9b8e-d94574f223b6")
+			(uuid "186745bf-012f-4321-872c-bec91860c60c")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -6439,7 +6450,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "276408ae-d494-4103-96da-0e79ef05710c")
+			(uuid "9b5c0409-8277-410a-b3df-befee00bd29a")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -6449,7 +6460,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d96fef45-2bcb-407b-87e3-f5ba5f9410f6")
+			(uuid "b886e4d2-81d9-4c04-9db7-8ecf43e426c7")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -6459,7 +6470,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f1b67251-6d83-46dd-8ab2-d4ac9d947a49")
+			(uuid "ad78821e-f294-4168-aa86-2340ed2a086f")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -6469,7 +6480,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "54be575c-b1b1-495c-88c4-e91c6b42b940")
+			(uuid "8feba71f-9c2a-4698-8c50-59b5544a2ad8")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -6479,7 +6490,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "42e0e91a-c5d6-4581-944e-f0f6a0ac914a")
+			(uuid "9cbc0a4d-9cb6-4555-9d4f-857bf61d2867")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -6489,7 +6500,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9e4ad80e-43f1-4d1a-b95d-d2948ccfe4c4")
+			(uuid "9c71e2b2-5fe9-4e30-895a-1afd01a1d31c")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -6499,12 +6510,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "38d1e40e-5333-4be9-b766-35e72c583244")
+			(uuid "b527c542-60c1-4ae7-9e96-7b9ed6f17b46")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "73b51ecc-38d7-482d-b173-3743bf39b01b")
+			(uuid "d0846bff-8989-4f86-922a-1b7d63ded0fd")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -6519,7 +6530,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "e8bbf559-f907-48c8-b9b0-7369bfd30435")
+			(uuid "9d2b3809-00e0-413d-8b48-1cefc601e48a")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -6528,7 +6539,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "aa6e79e1-1210-49de-b55f-e9644884048d")
+			(uuid "53b47785-ade0-4c21-99e8-7bcc462b4c9c")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -6551,7 +6562,7 @@
 		(property "Reference" "C26"
 			(at 0 -1.85 90)
 			(layer "F.SilkS")
-			(uuid "40c9ac4b-eaed-4dea-9eea-0b5431b87770")
+			(uuid "35ecbe45-d370-4227-a0bc-0b4bdbd539bd")
 			(effects
 				(font
 					(size 1 1)
@@ -6563,7 +6574,7 @@
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e7c376c6-790d-48c1-8874-ccf4d76390cd")
+			(uuid "ca349f6b-2c9c-47ee-8c8b-55521b755027")
 			(effects
 				(font
 					(size 1 1)
@@ -6576,7 +6587,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3a924a93-eadf-4f89-9c31-39787ab992cd")
+			(uuid "ca017b8d-cdf8-4d22-b5e1-0b13e4e42b69")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6589,7 +6600,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c9bd75ff-8237-4924-a7ff-189bec9f875c")
+			(uuid "ba3bb867-89c0-4942-a019-8b519d8f021e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6602,7 +6613,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d90e6786-f38d-40cd-8c70-952401299268")
+			(uuid "f51cb117-b079-40df-aa9c-db78e8f64775")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6623,7 +6634,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ceddca42-17a2-49bc-aeda-d6e8fcaae776")
+			(uuid "e53b0944-050e-49cc-b48b-8839b2aeb91f")
 		)
 		(fp_line
 			(start -0.711252 0.91)
@@ -6633,7 +6644,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "44f15592-0368-421d-ba6a-ca884c7666c7")
+			(uuid "f8c6dc53-f479-4c00-bc3f-301e2569e004")
 		)
 		(fp_line
 			(start 2.3 -1.15)
@@ -6643,7 +6654,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c1e47a12-7203-4a5b-9f0a-c80bfb344a43")
+			(uuid "d2a332b0-4009-44d6-9020-bbea397f3d4c")
 		)
 		(fp_line
 			(start -2.3 -1.15)
@@ -6653,7 +6664,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ca5e580b-2edf-4d08-9e13-e553810fe0f6")
+			(uuid "bd1b5a26-7dc6-450f-a38e-7655d9a36c83")
 		)
 		(fp_line
 			(start 2.3 1.15)
@@ -6663,7 +6674,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3846ec10-4500-4a1e-9a9f-d3c41c246a2d")
+			(uuid "25596d34-e086-482b-9132-a673ea7c3d14")
 		)
 		(fp_line
 			(start -2.3 1.15)
@@ -6673,7 +6684,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c24a95a0-bdd7-4c32-a8db-fb368c94830a")
+			(uuid "46c2a741-579e-4539-8578-c62cfa49d479")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -6683,7 +6694,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2ffb1618-239c-47a6-b605-e840ad10f4d7")
+			(uuid "db37603f-a9f0-4563-a72e-9278eb6bb03a")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -6693,7 +6704,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "48c087e3-5add-4d75-aa65-d9e837a2238c")
+			(uuid "42f35dd4-97c1-471e-b25c-c4da100dd2e1")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -6703,7 +6714,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c1b3915b-2491-41d9-8873-02d6c4fe5f27")
+			(uuid "249349a4-29da-4502-a2ea-471aef41ed16")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -6713,12 +6724,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "46a0b187-5482-454d-a3cc-fbf58ac4afaa")
+			(uuid "4f5c49d3-ceda-41dc-bfa5-d44aafd347cf")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "a549ebda-f238-41dc-82ba-7d4f22447fab")
+			(uuid "4425a4a4-915d-49d1-b8db-60760965874d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -6733,7 +6744,7 @@
 			(roundrect_rratio 0.217391)
 			(net 12 "Net-(U6-VMID)")
 			(pintype "passive")
-			(uuid "2c4cde8e-5db6-4d05-a087-2ebec524db54")
+			(uuid "0dd39e83-5149-4d99-a2a8-414f74b33b25")
 		)
 		(pad "2" smd roundrect
 			(at 1.475 0 90)
@@ -6742,7 +6753,7 @@
 			(roundrect_rratio 0.217391)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "e80c37d2-ee1a-4c6a-9314-74a1c76de810")
+			(uuid "8174312b-bb3b-4326-9666-77296016f72b")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_1206_3216Metric.wrl"
 			(offset
@@ -6765,7 +6776,7 @@
 		(property "Reference" "C9"
 			(at 1.5 -0.5 0)
 			(layer "F.SilkS")
-			(uuid "e7855ed2-ba8b-464a-8963-c143159c2958")
+			(uuid "56e8f722-eb94-4612-bc5e-fdaa5598f3f2")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -6777,7 +6788,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6bfa35f0-d91d-4951-9234-5755158a0186")
+			(uuid "749aeb3f-8f86-46a4-9281-1bf6dde505b3")
 			(effects
 				(font
 					(size 1 1)
@@ -6790,7 +6801,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "cbc9e4a1-6bae-4c46-9af7-8a544f962399")
+			(uuid "e77fcb0e-c1df-4a44-9072-84a0a8fd66ce")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6803,7 +6814,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "fc2a6e6b-6a93-46e8-b44e-47fa9c42e2a1")
+			(uuid "77302830-d86d-48e0-9e24-6e748ca21fa6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6816,7 +6827,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "18c6de80-f511-4e2b-a99a-a982ee96a8d8")
+			(uuid "9c6d6b5f-1a09-4517-aed9-90d39d631e4c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6849,7 +6860,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1a46f440-c150-4f60-a93d-80f0504441a3")
+			(uuid "548f10ad-1dab-4ec7-b5e3-7349a8c07e9f")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -6859,7 +6870,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a20eb8fb-119d-4fbb-89be-c5eeb7523bc8")
+			(uuid "ec2fa64e-f6e9-467a-bb66-f1e4476d4653")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -6869,7 +6880,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1d4acb65-6448-4781-881d-503432ce52a5")
+			(uuid "e8a9b1fd-e546-4f32-aaae-cda8fc375f0e")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -6879,7 +6890,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6129abac-5d71-4bd8-a0d6-1687dd2de545")
+			(uuid "9a22412b-dbe1-461e-8c32-2997792f3a65")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -6889,7 +6900,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "91551f09-b85b-43c0-bcb7-2b2d24e6676f")
+			(uuid "a2453dba-41c5-408d-b919-90604885b7e4")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -6899,7 +6910,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "54e44246-2a8a-46ac-afd7-4266d4763007")
+			(uuid "b7373999-6287-444c-ad94-6b2cfd46c21e")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -6909,7 +6920,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a5c54077-678c-48dc-9877-19bd63eda174")
+			(uuid "5d76621b-906d-4e73-81d8-60748893ac43")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -6919,7 +6930,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "614a5806-85aa-44a4-b12e-3685ddff55be")
+			(uuid "9325443d-3c0b-4e01-8339-b301242cb2de")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -6929,7 +6940,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ec413ff9-145a-4d9a-b070-9c472b478481")
+			(uuid "0672f54c-1ef3-46ae-9b36-32a7bc264137")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -6939,12 +6950,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e3d83819-eb02-4a0b-b10e-1fd7fc3095ba")
+			(uuid "cfb3f6b8-402f-4660-b9cc-2e67e547504c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "39c91977-41c9-4cda-8001-4ba15ba8b64f")
+			(uuid "53915fdb-ba9b-405f-a1a8-375263cc85c2")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -6959,7 +6970,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "70abb6c4-c5de-4232-90ca-b3f5ca1e6ec9")
+			(uuid "afa8324f-c975-4350-bb5a-61074fabf5b5")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -6968,7 +6979,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "960b94d7-4e86-4710-87cc-a7fd63f9e553")
+			(uuid "7bec5e5e-c9d8-4bc6-b4c2-7acaa8a49506")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -6991,7 +7002,7 @@
 		(property "Reference" "C14"
 			(at 0.1 -1 90)
 			(layer "F.SilkS")
-			(uuid "e8cf2d36-0b12-4618-a2f5-c7f93de3095f")
+			(uuid "7748a93a-b556-4733-8a93-b66864e41a78")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -6999,11 +7010,11 @@
 				)
 			)
 		)
-		(property "Value" "22pF"
+		(property "Value" "C0402C0G500-220GNP-CT"
 			(at 0 1.16 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8e2f5824-1d05-44fc-a9eb-faa4d390c8a5")
+			(uuid "d70bd5b8-1230-4539-8964-03913146ad02")
 			(effects
 				(font
 					(size 1 1)
@@ -7016,7 +7027,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2e242989-eaa4-4b25-976e-6dd771629485")
+			(uuid "194e20ca-2d2b-4424-8b4a-2b8f50177d89")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7029,7 +7040,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "39a7cc5e-c00f-4754-a094-3e7f56ccd1ec")
+			(uuid "33d9239d-61d4-4816-b336-632af6b6cbe2")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7042,7 +7053,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e37b50d3-ca7d-439a-a842-29dcb35fe39a")
+			(uuid "aee8260d-2410-4068-854c-b3bdb54fe5d9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7076,7 +7087,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4491a1b4-f33e-4317-ad3c-2fc6acfc725b")
+			(uuid "f7638fa3-f69e-45a3-b922-350d39cb22a1")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -7086,7 +7097,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b9b5e139-f784-4117-b626-3250aa599ebf")
+			(uuid "a1cd3d50-5284-43ff-b67e-4efcbe7eb2f2")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -7096,7 +7107,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0b0b187d-82e3-465d-bb81-219ac0b85fee")
+			(uuid "5789fd69-39a8-4955-b688-50ef9e2d813f")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -7106,7 +7117,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0cfe0e01-1171-4c58-abcd-c292ef26d229")
+			(uuid "fba6fab1-7898-4523-b4b7-3988cc8fe25b")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -7116,7 +7127,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1b05cc66-d968-4b90-a601-9b6d40c6f52a")
+			(uuid "1cdb40ec-1f97-48b2-aa00-a37db1bfbac9")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -7126,7 +7137,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ce764061-52dd-49a3-b0e5-cb5b412e8bd4")
+			(uuid "b1271fe3-7727-4f96-a73e-d95bda3c55dc")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -7136,7 +7147,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e744d6db-4cc0-4e44-99ed-ad3dba7b4c14")
+			(uuid "5becb179-cbff-40eb-89ec-47fbd8722c3d")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -7146,7 +7157,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "290ab00e-7148-43b2-bab7-173d7ae18ed5")
+			(uuid "3b957587-cc37-4108-9d0b-5dc004d72105")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -7156,7 +7167,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f58dfd55-596a-4506-a2f7-baa4d6396cd0")
+			(uuid "52e1849c-5355-4c5f-a03d-aa4fcf3a3491")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -7166,12 +7177,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "51749a86-8786-4422-9268-21e9e1239e07")
+			(uuid "b454a010-66d8-49ec-8502-c8beafbc6db9")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "54469875-e3c3-4729-a010-28c0124f6c1b")
+			(uuid "e0f368cd-edf6-4295-b3c3-e4ad10d33bf0")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -7186,7 +7197,7 @@
 			(roundrect_rratio 0.25)
 			(net 10 "Net-(U2-XIN)")
 			(pintype "passive")
-			(uuid "78150333-b8f8-44e1-9c4f-6d9c1daf3dc2")
+			(uuid "90fddf52-29ba-437b-9e35-5bddd8953b38")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -7195,7 +7206,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "e7d54ab7-8721-4de4-a4b8-ab7de52bdf14")
+			(uuid "5b2eebb4-25a1-49e0-8e97-4745ebf5e815")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -7218,7 +7229,7 @@
 		(property "Reference" "C8"
 			(at 1.5 0.5 0)
 			(layer "F.SilkS")
-			(uuid "70f17244-0b44-4f9a-a29e-709294e1da63")
+			(uuid "514ab8cf-c9fd-4c63-a2c0-8af3e3116d9e")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -7230,7 +7241,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6db6897b-b02d-4b1d-9c8b-702a52230541")
+			(uuid "fa85b5ac-4adc-48b6-a050-974e6d111122")
 			(effects
 				(font
 					(size 1 1)
@@ -7243,7 +7254,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "adc5b9bd-4d76-4799-8dee-ea21b2dc7c1d")
+			(uuid "dcfb5888-5c16-4982-b156-d7d7d313c260")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7256,7 +7267,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "036d1813-b48d-4962-9994-47432c45f9d8")
+			(uuid "7ca431f8-92aa-4f83-a06b-96756a352d3f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7269,7 +7280,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "67607317-fb51-423e-b61b-40cfe809b72c")
+			(uuid "dc02cd9b-832b-4174-84cf-fd72a4f06d1b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7302,7 +7313,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "65d66840-80cc-4afb-92bc-8d4c9ac6c9e9")
+			(uuid "8bb35551-361f-42aa-a79c-13943b475a44")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -7312,7 +7323,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e33ad873-7ee4-4b80-acee-ca85cce9e8d0")
+			(uuid "b0a5a959-d6f2-4ceb-8a47-6201def40882")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -7322,7 +7333,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f18ebd69-801b-4cee-b9ac-d93b06c614ad")
+			(uuid "8034a9fe-2def-48fd-9385-fe4c5f14e8ef")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -7332,7 +7343,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5e4d152d-75e4-4b2f-a953-a1ec1c42599e")
+			(uuid "635aaaf1-7eb5-4e4f-b49f-f51900305f1a")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -7342,7 +7353,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9293e4bb-6994-4687-847e-45758f19ac5a")
+			(uuid "2c64a088-bad6-4f21-8370-213ff2b4caa4")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -7352,7 +7363,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8798179e-5f93-4861-ba12-8c4a8ab3a056")
+			(uuid "38dd37f2-0a9d-44c1-93f9-cbfd93112571")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -7362,7 +7373,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "521b432e-b927-4d1a-8e32-b7f70e2d1ea4")
+			(uuid "42e268b4-99b9-480f-a8b5-16684a372538")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -7372,7 +7383,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "07306e47-fa7d-4953-9162-4c8d5d02d1cb")
+			(uuid "6bf24e71-15db-413c-b650-8cd40f5944c2")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -7382,7 +7393,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d5383bfb-7fcd-4bb3-b7c0-679b6ce644e3")
+			(uuid "51924193-5d84-4de7-8170-125d0c129bca")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -7392,12 +7403,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "02d1380f-5220-4c2b-8652-a50ec7dc01c0")
+			(uuid "b1df076a-22b8-41c6-aff1-c8fe318e98e3")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "e123a6db-ff57-46f6-8969-a26e0184e81b")
+			(uuid "e694569e-2677-4970-b2a1-2518fe472a6f")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -7412,7 +7423,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "be03e006-a0de-4f8a-9ee2-3b19f541eaa5")
+			(uuid "75964866-6b6a-4428-8571-b09fd67c5350")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -7421,7 +7432,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "00167932-9ba7-490d-901f-f21af2a4ee88")
+			(uuid "de5b7174-95aa-4c4d-aa3b-476d8149233a")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -7444,7 +7455,7 @@
 		(property "Reference" "R6"
 			(at 2.2 0.1 0)
 			(layer "F.SilkS")
-			(uuid "6ccbfe8e-b701-4b8f-a0d8-294fb537c417")
+			(uuid "34c2a3ee-a825-4d20-b971-bf2242641bfc")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -7456,7 +7467,7 @@
 			(at 0 1.17 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "baf4375b-d6ae-4798-a9ac-786c6e4752c8")
+			(uuid "a27b23b4-b39b-4788-b566-d91218e6cd02")
 			(effects
 				(font
 					(size 1 1)
@@ -7469,7 +7480,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7d19d814-0415-45ea-80d9-66f0753febec")
+			(uuid "6ee76f69-8bd9-4999-952d-454c9135ead2")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7482,7 +7493,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5ed013e4-aefa-4717-a486-55dd0216b37a")
+			(uuid "ac71eaa4-0fce-488b-87d7-0a746c003239")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7495,7 +7506,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4da1e653-8a94-48a5-bf33-b481d9d12033")
+			(uuid "360ca221-d8b7-4b3a-affb-6fe6fe2c17b9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7528,7 +7539,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e3eddc8a-d6cb-48a9-9dd9-dbdaa23366a9")
+			(uuid "c4a0ed87-0916-415f-b0bc-972105d04ace")
 		)
 		(fp_line
 			(start -0.153641 0.38)
@@ -7538,7 +7549,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2a611e05-16bc-4920-9c41-ada4583c5970")
+			(uuid "19f095a4-8a19-43a2-bdc8-fff329194288")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -7548,7 +7559,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "42ac546a-a45c-4a9b-8cfb-18c77adefd4a")
+			(uuid "32a5d503-8877-4d0f-964f-7cf6a5654019")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -7558,7 +7569,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "60da3d93-ac87-4542-a01b-ba48683e0803")
+			(uuid "0a615299-34e8-47cc-98c7-ee2cf3b183e1")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -7568,7 +7579,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "97465a88-36cf-4c84-b46b-f7b89f03085d")
+			(uuid "8f1d15c7-20f4-4849-a7ca-d2a00eea7480")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -7578,7 +7589,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f7a96a56-8266-463f-bb9e-cfbf831cb2d3")
+			(uuid "8c6eba20-9dc0-4519-9a00-57c0d9de365d")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -7588,7 +7599,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e25ae248-2906-4b5e-ae87-721b76be9ba9")
+			(uuid "d3b7c730-94bd-48b3-bef0-08828cb3567a")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -7598,7 +7609,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "73b1f587-237d-4392-a86c-9fe683875c4a")
+			(uuid "a5c647f3-8475-4c9b-8fec-abbfe6576cd2")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -7608,7 +7619,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f14ea724-623f-4cc9-b95b-b3cd52e04d03")
+			(uuid "b3e73769-b6d7-4b70-be0d-4f9bc61759d9")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -7618,12 +7629,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f53bfaf9-3719-42d5-801a-86c0781ad299")
+			(uuid "eedd6147-650d-47b8-b8ab-dbd77b61e6b7")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "ddf69bb0-2356-4ec2-9d6e-097dd13c3473")
+			(uuid "2ef4cf91-081a-4568-bd77-a9d5a668f743")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -7638,7 +7649,7 @@
 			(roundrect_rratio 0.25)
 			(net 32 "Net-(U2-USB_DM)")
 			(pintype "passive")
-			(uuid "521b1dcb-0369-4b95-9d13-1ddc538722dd")
+			(uuid "e8dbf8cd-0703-4dcd-9fe7-b6210ce00e45")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0)
@@ -7647,7 +7658,7 @@
 			(roundrect_rratio 0.25)
 			(net 23 "/MCU/D_{-}")
 			(pintype "passive")
-			(uuid "f1847378-f30b-40cb-8d8c-65251c408a65")
+			(uuid "044e1b4a-5334-4b57-b1d5-9ee506959090")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -7670,7 +7681,7 @@
 		(property "Reference" "TP4"
 			(at 0.6 -2 0)
 			(layer "F.SilkS")
-			(uuid "cd54c2d1-4e4a-4e76-86d2-9d1f38117298")
+			(uuid "dff49985-14fa-4cf3-84be-10581e4ceb17")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -7682,7 +7693,7 @@
 			(at 0 2.05 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "32ccc2cf-07ce-48cc-bb9b-420f8fbda226")
+			(uuid "531b49a5-a27e-4b43-9cb7-3acad0d12ed3")
 			(effects
 				(font
 					(size 1 1)
@@ -7695,7 +7706,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "80b49579-4711-4bf1-8405-cf39e2a9b997")
+			(uuid "fcada275-02cb-464e-9ca3-247ebd97cd43")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7708,7 +7719,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a43dbda1-30d5-4cdb-85c0-fcca8e07f3c4")
+			(uuid "fccaec13-8a1a-44bf-86cf-df473431bfe0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7721,7 +7732,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e7aa7653-ae64-48ac-b24d-4765342512d1")
+			(uuid "45b149d3-525c-4e1b-a420-0b7742b7f105")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7743,7 +7754,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "82da8121-bc27-4f52-94a4-a46fb690c47f")
+			(uuid "eab22a1c-dbce-48cb-ba96-8bb21fa1359c")
 		)
 		(fp_circle
 			(center 0 0)
@@ -7754,7 +7765,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "69da9372-8330-441f-9570-0b45ef8ddc39")
+			(uuid "028a2472-0521-4860-a2c9-93c1794e00d5")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 0)
+			(layer "F.Fab")
+			(uuid "a0404c72-37ec-481e-8e21-a91e68630a41")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0)
@@ -7763,11 +7785,10 @@
 			(net 3 "+3.3V")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "de2c89ec-ee21-4ea4-8b4c-0c849d31c124")
+			(uuid "452cf113-cca7-4f37-ad43-1079b6933fe9")
 		)
 	)
 	(footprint "open-ephys:SUNLED_PLCC4-INV_3.2x2.8x1.9mm"
-		(locked yes)
 		(layer "F.Cu")
 		(uuid "66464bb4-15dc-4232-9ded-3d590b15cb52")
 		(at 123.5 61.25 180)
@@ -7775,7 +7796,7 @@
 			(at 0 2.4 0)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "c93b10a8-2c02-4fee-82e0-433100197a45")
+			(uuid "6d231b36-c88e-4642-ad1e-991b5e5dfa85")
 			(effects
 				(font
 					(size 1 1)
@@ -7788,7 +7809,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ec26f927-769c-4743-b7fe-9dda154d27e0")
+			(uuid "215d75da-e436-4cb8-9bad-fa81c5f5bb36")
 			(effects
 				(font
 					(size 1 1)
@@ -7800,7 +7821,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "eea14c42-1d59-4e0d-b83f-885205688143")
+			(uuid "3fa25943-83dc-4642-818b-83b6e0e4ba7e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7812,7 +7833,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2c97754d-a42c-4bc0-8aea-5a2657cc9a97")
+			(uuid "02142c98-490a-4a6a-b04d-35a7f4f2faa6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7824,7 +7845,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6cbe5b45-5dbc-403d-a2bc-e946f62d87e5")
+			(uuid "4616599b-c01b-4868-803c-340a6f17649a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7845,7 +7866,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "d28687ca-4d44-4e0d-b736-b9d858cbd2fe")
+			(uuid "7586d5ab-5a4b-4b8c-8293-c90c5b8c16db")
 		)
 		(fp_line
 			(start 1.9 -1.7)
@@ -7855,7 +7876,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "10cf7ce0-c213-4bd6-87b0-6f56f4e59571")
+			(uuid "c460cd40-29fc-4ef8-8953-b6c7f6a6814c")
 		)
 		(fp_line
 			(start 1.7 1.7)
@@ -7865,7 +7886,29 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "dcc10f00-2745-4d03-91cb-4b6390739286")
+			(uuid "61dc606c-24c8-4a91-9e2e-fd20e8b1d1e9")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 1.5 0)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill solid)
+			(layer "B.Mask")
+			(uuid "7e93c1f3-a97a-400d-b8ad-a5eba912b499")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 0 -1.5)
+			(stroke
+				(width 0.2)
+				(type solid)
+			)
+			(fill solid)
+			(layer "F.Mask")
+			(uuid "7ea2c522-1733-4df2-b082-74923a3ca3be")
 		)
 		(fp_rect
 			(start 3.5 -1.8)
@@ -7876,7 +7919,7 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "b44dcea3-8530-4d55-980f-4a3780f0be55")
+			(uuid "9d9574cc-6670-4e9c-b67a-e5c28197f735")
 		)
 		(fp_line
 			(start 1.6 -0.3)
@@ -7886,7 +7929,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "7b9110f2-f219-4d52-a280-f53f09b32925")
+			(uuid "c4d858f6-df13-43b4-aa12-a779afd0489d")
 		)
 		(fp_rect
 			(start 1.6 -1.4)
@@ -7897,24 +7940,13 @@
 			)
 			(fill none)
 			(layer "F.Fab")
-			(uuid "348c16ce-7d96-4232-aee7-4fd2829440ad")
-		)
-		(fp_circle
-			(center 0 0)
-			(end -1.6 0)
-			(stroke
-				(width 0.02)
-				(type solid)
-			)
-			(fill none)
-			(layer "F.Fab")
-			(uuid "d6ce3fa7-6a4b-4523-9051-51c7366a4f27")
+			(uuid "e9741f07-faba-4d73-a4b6-1c2e7b3ead93")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "2d9cd0da-46c2-45ce-8128-3ba5b0205a8c")
+			(uuid "618a8711-bde7-4536-b2af-8364fb886809")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -7931,7 +7963,7 @@
 			(pinfunction "RK")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "074e47c5-af82-4921-984a-7b53ba2b23d8")
+			(uuid "ea00c66c-4454-4a7a-b53e-ef73b7b6b167")
 		)
 		(pad "2" smd roundrect
 			(at -2.6 -0.725)
@@ -7942,7 +7974,7 @@
 			(pinfunction "A")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "e46f962a-9a86-4c60-bb68-8ced3ce2a388")
+			(uuid "ccb4c92e-8419-4fa8-9888-5766645bb703")
 		)
 		(pad "3" smd roundrect
 			(at -2.6 0.725)
@@ -7953,7 +7985,7 @@
 			(pinfunction "BK")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "9a17270e-651d-4a64-86ec-72db2ef36a26")
+			(uuid "fee88316-0119-4a47-a871-58bb01f48f5a")
 		)
 		(pad "4" smd roundrect
 			(at 2.6 0.725)
@@ -7964,7 +7996,44 @@
 			(pinfunction "GK")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "525e6c0f-a316-4d4b-9e7e-1eb5981e942a")
+			(uuid "1b469c72-a359-440e-b6ba-8d88c706a068")
+		)
+		(zone
+			(net 0)
+			(net_name "")
+			(layers "*.Cu" "*.Adhes" "*.Paste" "F.SilkS")
+			(uuid "d578f393-4710-4976-9f32-496f99f2c69e")
+			(name "led-window")
+			(hatch edge 0.5)
+			(connect_pads
+				(clearance 0)
+			)
+			(min_thickness 0.25)
+			(filled_areas_thickness no)
+			(keepout
+				(tracks not_allowed)
+				(vias not_allowed)
+				(pads not_allowed)
+				(copperpour not_allowed)
+				(footprints not_allowed)
+			)
+			(fill
+				(thermal_gap 0.5)
+				(thermal_bridge_width 0.5)
+			)
+			(polygon
+				(pts
+					(xy 121.9 61.25) (xy 121.919699 61.500295) (xy 121.97831 61.744427) (xy 122.07439 61.976385) (xy 122.205573 62.190456)
+					(xy 122.368629 62.381371) (xy 122.559544 62.544427) (xy 122.773615 62.67561) (xy 123.005573 62.77169)
+					(xy 123.249705 62.830301) (xy 123.5 62.85) (xy 123.750295 62.830301) (xy 123.994427 62.77169) (xy 124.226385 62.67561)
+					(xy 124.440456 62.544427) (xy 124.631371 62.381371) (xy 124.794427 62.190456) (xy 124.92561 61.976385)
+					(xy 125.02169 61.744427) (xy 125.080301 61.500295) (xy 125.1 61.25) (xy 125.080301 60.999705) (xy 125.02169 60.755573)
+					(xy 124.92561 60.523615) (xy 124.794427 60.309544) (xy 124.631371 60.118629) (xy 124.440456 59.955573)
+					(xy 124.226385 59.82439) (xy 123.994427 59.72831) (xy 123.750295 59.669699) (xy 123.5 59.65) (xy 123.249705 59.669699)
+					(xy 123.005573 59.72831) (xy 122.773615 59.82439) (xy 122.559544 59.955573) (xy 122.368629 60.118629)
+					(xy 122.205573 60.309544) (xy 122.07439 60.523615) (xy 121.97831 60.755573) (xy 121.919699 60.999705)
+				)
+			)
 		)
 		(model "${OE_3DMODEL_DIR}/SUNLED_PLCC4-INV_3.2x2.8x1.9mmd.STEP"
 			(offset
@@ -7987,7 +8056,7 @@
 		(property "Reference" "C29"
 			(at 3 0 90)
 			(layer "F.SilkS")
-			(uuid "5c26b2e6-48e9-4b47-b054-222b63792790")
+			(uuid "26d63cd2-efeb-4588-851c-86d9ba549367")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -7999,7 +8068,7 @@
 			(at 0 1.68 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a1a651b0-7f65-49b5-b7a7-e303a18dbeb6")
+			(uuid "5817ea4d-6dae-4af2-83dc-ed1e18051c32")
 			(effects
 				(font
 					(size 1 1)
@@ -8012,7 +8081,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "68f75ee6-1e65-42ba-94ac-29112bce427c")
+			(uuid "60074261-c8ad-4efe-aa24-03f95291512c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8025,7 +8094,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9435de9a-c0f7-4d7c-ac5f-2376cdd12df8")
+			(uuid "ff287578-733f-4966-89c8-e4045e56656d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8038,7 +8107,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f3aece15-a590-461c-a5e8-4b1bc41ae878")
+			(uuid "5856e0f4-a75b-4cc2-9e83-21d549568820")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8072,7 +8141,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2e9795c5-6140-42b0-acce-12efb4a92528")
+			(uuid "8e72e69b-5967-474b-8b93-b830569a6a76")
 		)
 		(fp_line
 			(start -0.261252 -0.735)
@@ -8082,7 +8151,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "85bfaced-7526-4892-a8a0-09408264892b")
+			(uuid "20a9dab6-390f-4f74-8277-3d3e8226816a")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -8092,7 +8161,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "bdd4c8d5-50b0-4c46-832c-22119b539296")
+			(uuid "4cdcd59c-8dcd-439b-bdb8-08329a6fc638")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -8102,7 +8171,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "164831cf-d408-4561-a106-a458a80820e4")
+			(uuid "9296376a-2852-4425-844b-9cfc8d390d82")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -8112,7 +8181,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "64722343-e863-4b8b-8bda-e1cbac83b63a")
+			(uuid "29aa3541-5c29-4046-8258-533180d416cf")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -8122,7 +8191,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0f2c0eac-fcbe-44e5-adde-06b98449ace2")
+			(uuid "114bea24-67b3-4b3b-841f-010d12eb0fc9")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -8132,7 +8201,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ce659592-4e9a-47c5-bc11-d9d94e5719fe")
+			(uuid "9bec6d9d-22e9-4f90-8a6c-7c6504ca9053")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -8142,7 +8211,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "56e6b83a-f089-46c4-ba5b-d326f76c6ba0")
+			(uuid "7ff0bfb1-2219-4d83-95e5-8a6be8e4355d")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -8152,7 +8221,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "85b730d1-8945-404a-803f-2ac521e3a634")
+			(uuid "3df193b4-8513-47c4-9315-c656043cf595")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -8162,12 +8231,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "fc872b7f-8ebf-4224-8294-b690f25d62c4")
+			(uuid "8b546889-1257-407a-8832-830c4328c20b")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "9a608d07-ae9d-4bc2-95f6-7f95e3e0de2b")
+			(uuid "54bc9714-55a5-4fb9-b928-58e80232a3f4")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -8182,7 +8251,7 @@
 			(roundrect_rratio 0.25)
 			(net 14 "Net-(U7-VCC)")
 			(pintype "passive")
-			(uuid "9892cf68-38af-46dc-8f1f-aa8f53bd9104")
+			(uuid "d2863d5d-8658-4254-a225-c8ab507a4e15")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 270)
@@ -8191,7 +8260,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "d21aa029-537e-4cf5-822b-e21376e24d20")
+			(uuid "0cd181e6-267a-4e6e-a62a-21d2cb90063a")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -8214,7 +8283,7 @@
 		(property "Reference" "R23"
 			(at -3 0 -90)
 			(layer "F.SilkS")
-			(uuid "4a02ec04-5786-4ed6-907a-7a286364cf5e")
+			(uuid "87f8e9f2-62a5-4349-8007-7fed508422b6")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -8226,7 +8295,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "20049465-b366-4ab3-8e75-0fe23543e3ea")
+			(uuid "8b3db00b-12c3-4867-a18b-7530fec236aa")
 			(effects
 				(font
 					(size 1 1)
@@ -8239,7 +8308,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f0d27304-acea-406f-9264-89a4aa20b7bf")
+			(uuid "d0c9475f-abcc-4e26-a8f6-1ae27c5a555a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8252,7 +8321,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "27476df6-e7dd-468e-b743-34e9adaaed1d")
+			(uuid "6476757c-8722-4326-8202-8a0f71138f74")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8265,7 +8334,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "852462e3-9e3a-4187-8023-60de8ad716c2")
+			(uuid "24cd106b-099a-42a4-b33a-3e309938d86f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8286,7 +8355,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0bacf6af-27b9-48cd-99d9-a65b1d89937f")
+			(uuid "aa917bef-1fd2-41c0-91d3-5dbc0c21366c")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -8296,7 +8365,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "304f1ae3-e4b9-4591-8356-9d016a17a77a")
+			(uuid "a72c1cf3-f031-4962-8523-28826450c790")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -8306,7 +8375,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f4bd315e-e9c5-4f5f-bd88-a3ffd23b4c9b")
+			(uuid "a52a4f80-0823-4325-9e71-3b7ca59a0aa5")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -8316,7 +8385,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6ef5ae80-f9b3-4212-8da0-b3a03dbf8678")
+			(uuid "4dbce653-343d-4455-aeef-95a81cb94f6c")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -8326,7 +8395,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "aeaa4297-d43a-4d15-be07-25877dbf90fe")
+			(uuid "a14a15d4-aa6d-4128-b6cc-f5b0ac22fac4")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -8336,7 +8405,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a8ce4d2c-8e5f-4140-b104-998ac6c7dacb")
+			(uuid "82d14152-86f4-402e-b541-51df59d8e699")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -8346,7 +8415,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b3e13a9e-55fc-4e00-aa3b-d04efd09328f")
+			(uuid "01ca2550-2c9b-45ae-9abd-1f09872b8fe9")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -8356,7 +8425,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4365d3b3-537e-493d-9ffb-2395ddfc9b5d")
+			(uuid "4e9a754c-6a44-473d-94ab-02dae557875f")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -8366,7 +8435,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "caa8a387-5e1e-49b5-80c8-cd335abd9b0a")
+			(uuid "b947c42d-e7a1-4b59-9fc4-8a6de216da4a")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -8376,12 +8445,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f433e58d-4d25-470a-8446-66e72eb09f3b")
+			(uuid "760c559d-4424-4b06-a665-260f5256f397")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "710dd76b-cd99-43d2-9a2c-b42092dd9ec7")
+			(uuid "2808c396-f6c4-49d7-a7f8-2cbb07f65281")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -8396,7 +8465,7 @@
 			(roundrect_rratio 0.25)
 			(net 45 "/MCU/IS31_{BM}")
 			(pintype "passive")
-			(uuid "9159ffae-2ffa-47e3-a9c6-2f901769aa89")
+			(uuid "f1e72ab8-abad-4cd7-a20c-b2d8ac4ce3b4")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -8405,7 +8474,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "cf3aab2d-682b-4c31-b89a-bd5b4e5a458c")
+			(uuid "b6ec2c47-5df6-4cff-99ba-a79e8a060b6e")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -8428,7 +8497,7 @@
 		(property "Reference" "R2"
 			(at -2 -0.1 0)
 			(layer "F.SilkS")
-			(uuid "bc99ed11-c12e-4462-9328-3b514c7630b7")
+			(uuid "63a651fc-c5a2-4f08-973a-b8c73da79e25")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -8440,7 +8509,7 @@
 			(at 0 1.43 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "10c6d905-2e6a-4963-9f1b-29988bc2c2b2")
+			(uuid "3ca42047-ccd7-4783-9bc0-e696537119c4")
 			(effects
 				(font
 					(size 1 1)
@@ -8453,7 +8522,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ae72780a-51dc-4d2d-8e3e-10f9d040fdd6")
+			(uuid "5dbab791-3b47-45e1-b3e3-397549da531f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8466,7 +8535,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2dd61318-7a1c-4cbd-88a2-09fb64db08a4")
+			(uuid "acf6d7ec-e774-4ed0-9d85-da0e9a1380d9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8479,7 +8548,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "09e1e9ef-cfa2-40f7-bd54-f65ca28d5857")
+			(uuid "498c1c29-f1ae-454d-a183-3cf26ba2f6c4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8500,7 +8569,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5fe1de2d-1a19-44f5-a7bb-f3b8f11dfa54")
+			(uuid "1fc3062c-61ab-41ad-a423-94962d2503bc")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -8510,7 +8579,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6a27114c-ae73-4a52-ae85-ccbde511b082")
+			(uuid "9ace4fc6-f5df-468d-a09f-2880a187b4f2")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -8520,7 +8589,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4e6c5578-b431-4722-a40f-920d8fa7da59")
+			(uuid "a9c6d611-7c87-4dd2-af65-01e73244bd19")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -8530,7 +8599,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "abf32a0c-f74d-492e-ab68-cbe181ad449b")
+			(uuid "d2370cc5-b09e-49c2-9cc8-6c6d9cb16764")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -8540,7 +8609,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1853d53e-6930-4ef0-a675-d1f89e56c6d7")
+			(uuid "1cd8d0e5-4ddc-4960-a9ef-8e8ccca2936c")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -8550,7 +8619,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3b4d3d38-d634-432f-8f75-070fc71cc1fc")
+			(uuid "542e5484-2f6c-4987-897e-620df737ea0e")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -8560,7 +8629,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "09e501e7-1969-4eba-a6b6-de174e4aeed0")
+			(uuid "0ed291dd-a856-4a0e-965b-e345a7555ffc")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -8570,7 +8639,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7e422158-5570-4a52-85fb-242c232a531b")
+			(uuid "b4997164-1152-44c5-9491-7f6a7d1ec228")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -8580,7 +8649,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5e5f3335-b329-4f48-9db8-a83b525db953")
+			(uuid "d311934b-1e32-4462-a416-f4ec98150c97")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -8590,12 +8659,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c138521b-cfb7-488f-8967-57da4407188d")
+			(uuid "8c53106a-aeb8-4373-b662-51de7d4094b3")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "f8d3eff6-ac10-49ff-ac94-f354284a9540")
+			(uuid "2a052cfa-e8b4-495f-96a5-59d53887684f")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -8610,7 +8679,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "57f49f52-b5f0-40a5-9b95-6da7bfff4498")
+			(uuid "179c4954-5346-4e47-8b00-857035d497ed")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -8619,7 +8688,7 @@
 			(roundrect_rratio 0.25)
 			(net 29 "/MCU/SDA")
 			(pintype "passive")
-			(uuid "f74722fb-df04-4f48-899a-8ea1ad3600f8")
+			(uuid "49f154db-7e1c-4742-aeae-4b90e15e0b6b")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -8642,7 +8711,7 @@
 		(property "Reference" "C21"
 			(at -5 2.7 0)
 			(layer "F.SilkS")
-			(uuid "573e0ea5-2ae2-424a-af0a-b638710cf2d2")
+			(uuid "c63d98f9-c30c-4b79-97f6-c7c37bf63d89")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -8654,7 +8723,7 @@
 			(at 0 5.2 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b99f3926-c840-4810-9cdf-d3e3d6bfeb88")
+			(uuid "f45d9f75-370d-4286-bdcd-091835e8f760")
 			(effects
 				(font
 					(size 1 1)
@@ -8667,7 +8736,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "934b4cd2-62ac-4854-836d-3dbe27c6fbee")
+			(uuid "341b4be8-51fb-4263-949b-e6df183dbc21")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8680,7 +8749,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "72bc917e-763b-40b7-b7ca-41b6eb003ee4")
+			(uuid "5e2df1ee-41ec-4792-a25a-9a4796451eff")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8693,7 +8762,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1d398472-a384-455c-8b61-4cf26663e8cc")
+			(uuid "b785abab-8394-48f6-b3ac-4206c81acf5e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -8714,7 +8783,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "de481e5c-45be-42df-8f9c-581129c9dd09")
+			(uuid "840ddb4b-5d24-428d-897b-57146926013a")
 		)
 		(fp_line
 			(start 4.26 4.26)
@@ -8724,7 +8793,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5861c449-4f57-4c4c-b651-18afb800f6bb")
+			(uuid "570629f3-2a02-42d8-a462-5699b754cab8")
 		)
 		(fp_line
 			(start -4.26 3.195563)
@@ -8734,7 +8803,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5e62372b-ad59-4e11-81bd-b71485fdb9e7")
+			(uuid "04791e42-9574-49c2-aad7-719aa8a16438")
 		)
 		(fp_line
 			(start -4.26 3.195563)
@@ -8744,7 +8813,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4f650e60-9e9a-4c92-8537-ea3b24b29294")
+			(uuid "a19a07ed-39cf-427c-a7af-6cb1e2e6dca7")
 		)
 		(fp_line
 			(start -4.26 -3.195563)
@@ -8754,7 +8823,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8c8e1663-417b-481c-957b-765a7d84b44a")
+			(uuid "f361aad6-3a8a-4dbd-97e0-ec979bc8dc74")
 		)
 		(fp_line
 			(start -4.26 -3.195563)
@@ -8764,7 +8833,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a3ac2590-d578-41d9-a5c3-27271dbcd7c8")
+			(uuid "9f5abf08-b132-4f1f-93a1-865fdca0d9e6")
 		)
 		(fp_line
 			(start -3.195563 -4.26)
@@ -8774,7 +8843,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "bf42b807-1587-40c8-8075-83c7edf13d7d")
+			(uuid "caf144ed-84f4-45ec-a6d2-620b9d79c92f")
 		)
 		(fp_line
 			(start 4.26 -4.26)
@@ -8784,7 +8853,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1573bfd5-33b9-49a1-9eee-8f7476394e49")
+			(uuid "eed20cb0-30f7-4275-ad7a-07fd42345e02")
 		)
 		(fp_line
 			(start -3.25 4.4)
@@ -8794,7 +8863,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f41b0f33-3eb0-48b4-b538-a0728bd0c096")
+			(uuid "8533bc44-5a0c-4d17-9e7b-8bf10f3281ed")
 		)
 		(fp_line
 			(start -4.4 3.25)
@@ -8804,7 +8873,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "23883c20-8116-45fd-b358-8e78c6e42a42")
+			(uuid "93dd9ca3-bf61-44fe-80b1-127394d49324")
 		)
 		(fp_line
 			(start -6.1 1.3)
@@ -8814,7 +8883,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3b0ea921-8e4c-41bb-9864-a8ffcc1788db")
+			(uuid "2c9dd800-8171-4761-84e6-f013c5515161")
 		)
 		(fp_line
 			(start -4.4 1.3)
@@ -8824,7 +8893,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3b5fc519-a2d8-47ea-a347-4d892080ad29")
+			(uuid "878a73af-60d9-44a6-9e2a-6ae945519e65")
 		)
 		(fp_line
 			(start 4.4 1.3)
@@ -8834,7 +8903,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "671c60e9-e37c-4a83-be86-0735b2b99147")
+			(uuid "da767c95-33eb-4334-9771-e9da7b267072")
 		)
 		(fp_line
 			(start 6.1 1.3)
@@ -8844,7 +8913,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3cd131a9-f6c2-440d-9e2b-50cc02430d47")
+			(uuid "e35a29b0-ea61-4264-b3d8-dd455fcf29f0")
 		)
 		(fp_line
 			(start -6.1 -1.3)
@@ -8854,7 +8923,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d98db980-a79f-4bd0-9ecf-f7dc762cfb41")
+			(uuid "5631c9d3-4088-452a-abc0-882c7bbaa4d3")
 		)
 		(fp_line
 			(start -4.4 -1.3)
@@ -8864,7 +8933,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "77d33f19-c31d-43a9-85fa-29be1bbc3fbb")
+			(uuid "510d38de-fb2c-4b34-b7a4-1c59c89fd13b")
 		)
 		(fp_line
 			(start 4.4 -1.3)
@@ -8874,7 +8943,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "71cabb41-57b0-4cec-ac27-7973a87bd078")
+			(uuid "40e17dcf-24e7-4ec2-b8bc-d91afd392d86")
 		)
 		(fp_line
 			(start 6.1 -1.3)
@@ -8884,7 +8953,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9b15abea-d63f-491f-9198-d2f99d7b69f1")
+			(uuid "9faee23c-851d-4fbf-9e47-e05eda7c83ec")
 		)
 		(fp_line
 			(start -4.4 -3.25)
@@ -8894,7 +8963,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3d35864a-5b3a-4b2c-9368-88e43879bd42")
+			(uuid "d55653e0-f5d2-4cd3-99a3-d4b33a4d00ac")
 		)
 		(fp_line
 			(start -4.4 -3.25)
@@ -8904,7 +8973,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ba8e9bff-5f1c-4c7c-8c52-ab02c44a242d")
+			(uuid "43e01660-9625-4905-a746-21e2e878c86c")
 		)
 		(fp_line
 			(start -3.25 -4.4)
@@ -8914,7 +8983,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "157eb02b-f5c8-4d02-aefe-77160963ca35")
+			(uuid "f20bcd05-c126-482e-8c0b-3a98e41dfd2e")
 		)
 		(fp_line
 			(start 4.4 -4.4)
@@ -8924,7 +8993,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d283a195-4e39-43cc-a163-fb99ddd9a8d2")
+			(uuid "692b7a39-88fd-4ad9-9360-62f71f88453b")
 		)
 		(fp_line
 			(start -3.15 4.15)
@@ -8934,7 +9003,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8b75d522-4aae-4cf0-8e99-7e4720e3fcff")
+			(uuid "a2fe0328-ec06-435c-a066-2465ec6f9403")
 		)
 		(fp_line
 			(start -4.15 3.15)
@@ -8944,7 +9013,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "46321c1a-e10d-4dd0-8b55-1f2904dff241")
+			(uuid "78e3c80b-56c1-42dc-8ff1-342e084a135a")
 		)
 		(fp_line
 			(start -4.15 -3.15)
@@ -8954,7 +9023,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "aa22188e-d458-47c8-9421-9e43aea044cb")
+			(uuid "07b6845b-33e8-44bb-827c-bfd9aab85851")
 		)
 		(fp_line
 			(start -4.15 -3.15)
@@ -8964,7 +9033,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4e26251a-634c-42b1-b9f7-6d69a767c237")
+			(uuid "793a1897-9149-41b3-878a-ab0c83437220")
 		)
 		(fp_line
 			(start -3.15 -4.15)
@@ -8974,7 +9043,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e9a766ae-effb-4f9a-ba31-aec57a89a4ae")
+			(uuid "3487402a-678e-4bc5-b6ac-1dd413e63d7d")
 		)
 		(fp_line
 			(start 4.15 -4.15)
@@ -8984,7 +9053,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "12074bc6-9748-4a1c-8dd3-9b638452a7a7")
+			(uuid "12bcbcf2-e73a-47ce-b16f-134861e29b07")
 		)
 		(fp_circle
 			(center 0 0)
@@ -8995,12 +9064,12 @@
 			)
 			(fill none)
 			(layer "F.Fab")
-			(uuid "dc49c4a5-da34-408d-9238-95dc5ebff900")
+			(uuid "ca4353b2-8632-4dc6-8d42-4afdacba3953")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "2bc378c0-7292-4e62-b33b-ecba5bcebc40")
+			(uuid "c35793fc-85fc-4586-8377-e03bbeeabc7e")
 			(effects
 				(font
 					(size 1 1)
@@ -9015,7 +9084,7 @@
 			(roundrect_rratio 0.119048)
 			(net 2 "+5V")
 			(pintype "passive")
-			(uuid "edf50c6b-f630-4ffb-ac7a-e519abd39e01")
+			(uuid "45bed2a4-d6e4-4681-833c-bf248f1a7491")
 		)
 		(pad "2" smd roundrect
 			(at 3.6 0 270)
@@ -9024,7 +9093,7 @@
 			(roundrect_rratio 0.119048)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "fa3f6e33-c2a1-4f27-a2de-58e32032e570")
+			(uuid "1856e1c2-5206-4a3c-a5d4-a4e23534daed")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_Elec_8x10.2.wrl"
 			(offset
@@ -9047,7 +9116,7 @@
 		(property "Reference" "C27"
 			(at 2.3 0 -90)
 			(layer "F.SilkS")
-			(uuid "343aba5b-eca4-4081-83ac-12638ce1f36a")
+			(uuid "2fef9fcf-6d9c-4995-88cb-7ff73118ee2c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -9059,7 +9128,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "40a9f053-4b5f-4b44-8cf4-f0dbec59d200")
+			(uuid "b996711d-ecbf-4cd9-b047-34c9ac6ce0ff")
 			(effects
 				(font
 					(size 1 1)
@@ -9072,7 +9141,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7815b8f9-2bea-4e4b-a308-876a5a8acfcc")
+			(uuid "947459ff-389f-44de-a7b1-0ecd89b52e89")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9085,7 +9154,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "29e6d734-f7f6-4936-bf84-17f10f74c83c")
+			(uuid "fb209971-9efc-4567-b541-e18f0e1b45ab")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9098,7 +9167,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "312c8ccf-efcb-4c87-a10f-80e184bf225a")
+			(uuid "b3230888-1446-46e4-9a7e-ba1748b53625")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9132,7 +9201,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "71e6b0f6-a7f6-439d-9831-aae008e16b0d")
+			(uuid "6da389cc-bc74-4ad5-b1c0-55d2e9417bff")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -9142,7 +9211,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e252f4c0-dad7-4455-bd27-d527e427a2a8")
+			(uuid "39533800-b2de-4b1d-8147-7359b2081c27")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -9152,7 +9221,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "83d3454e-b3a3-4d96-9616-2e052bedb719")
+			(uuid "55970b17-db72-45dc-bf30-4d36088c594a")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -9162,7 +9231,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "05f829ce-6bff-47d3-8349-11bc5b7f14f3")
+			(uuid "3381256f-db86-4bc9-9ff2-37c8a6216643")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -9172,7 +9241,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5023ee97-e38e-4c2a-8b04-12b34eb0bf9a")
+			(uuid "947c972f-2fd4-40fa-9a39-885daeff7666")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -9182,7 +9251,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4da0c438-e897-49a1-943d-f0460983ffc1")
+			(uuid "a0b21653-c475-4e0a-b62b-75424daabe6f")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -9192,7 +9261,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2f8e34d5-e10f-46e3-8dc6-ece925c0bf30")
+			(uuid "27dc56a6-832a-449d-9fa3-7417e285d96a")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -9202,7 +9271,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "41547dc8-58a8-4f05-acd0-52de3d5fad98")
+			(uuid "845252f3-e33c-4c5f-84de-55483765cab5")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -9212,7 +9281,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "abf6a90c-02e9-4624-954c-72a31994b571")
+			(uuid "2b7bd482-470a-47a6-9095-2fa391e97df0")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -9222,12 +9291,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d1c4e3e7-561c-4268-8ee2-943c5abe7728")
+			(uuid "9b5af78d-378d-42f8-ba77-fe296f1ab7ad")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "ae33c34a-9a13-4c71-847c-b9ce31049bb1")
+			(uuid "bb9d525a-bac3-4b1c-9ef0-dc123ebf9457")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -9242,7 +9311,7 @@
 			(roundrect_rratio 0.25)
 			(net 13 "Net-(U7-VCP)")
 			(pintype "passive")
-			(uuid "b8154bb3-05eb-477c-998a-9aed776279ca")
+			(uuid "2a13b1b9-ef06-4ada-a514-5afa68546334")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -9251,7 +9320,7 @@
 			(roundrect_rratio 0.25)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "d80ebaeb-a54e-4d33-a629-1fd9e2335ba1")
+			(uuid "deb03cda-5ae8-4f36-ab55-e543327ee458")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -9274,7 +9343,7 @@
 		(property "Reference" "U7"
 			(at 0 -4.33 -90)
 			(layer "F.SilkS")
-			(uuid "eec67261-6332-4f65-9f36-f23831a1d4d5")
+			(uuid "a02346ac-73e7-4efc-aaeb-3358d851920a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -9286,7 +9355,7 @@
 			(at 0 4.33 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7088d90a-b7b9-45d1-8dcc-bdfc6e43c813")
+			(uuid "802c4652-f97f-49e6-8019-434ea3cbc678")
 			(effects
 				(font
 					(size 1 1)
@@ -9299,7 +9368,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7120734a-cc86-4c32-b242-ba3162e12157")
+			(uuid "b07b434a-b8a6-4c48-8b47-0bbfdf40a8c3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9312,7 +9381,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b17dd606-738c-44d4-8472-1379a0fa820c")
+			(uuid "8aaa6b19-cabd-48ec-b8d8-bb82f615f0cf")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9325,7 +9394,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "45a03c71-7eee-4a02-826d-9a6cb534163a")
+			(uuid "0a30c839-9f89-4606-b847-3364877491c0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -9346,7 +9415,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "034c6409-c48b-433c-9474-14f9c45b8b0b")
+			(uuid "c9283764-4db7-4407-b6af-9ad80c339ec0")
 		)
 		(fp_line
 			(start -2.135 3.11)
@@ -9356,7 +9425,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a9ba9dd7-56ca-4237-b73d-b486e209d5f6")
+			(uuid "9931c0be-b587-41b5-8be2-57546c04da4b")
 		)
 		(fp_line
 			(start 2.135 3.11)
@@ -9366,7 +9435,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a9e8cd07-b4e4-46a9-a57d-ae8ac6703757")
+			(uuid "f0b81b30-ca52-4991-8b94-582f951baf71")
 		)
 		(fp_line
 			(start 2.61 3.11)
@@ -9376,7 +9445,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "db413d58-8fbb-44ed-9663-9b8860460a0b")
+			(uuid "4caa06e6-3c29-434b-8a03-b614b37751e5")
 		)
 		(fp_line
 			(start -2.61 -2.635)
@@ -9386,7 +9455,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "95673362-0d1d-45c2-a003-1ce5dd90d582")
+			(uuid "67703a59-f5ea-4599-95a9-9f8de1570796")
 		)
 		(fp_line
 			(start -2.135 -3.11)
@@ -9396,7 +9465,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5dccd6ba-d8e2-4b2d-b7fd-e8d1b61723dc")
+			(uuid "6f504a19-0201-4e86-953d-3bf8df397f41")
 		)
 		(fp_line
 			(start 2.135 -3.11)
@@ -9406,7 +9475,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8ae1071a-acc1-459d-8203-99c91917222c")
+			(uuid "020bc5ad-7b12-4cac-a0e7-e160f2a9c1ee")
 		)
 		(fp_line
 			(start 2.61 -3.11)
@@ -9416,7 +9485,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "3600f13f-95d8-49bd-8fc5-95c3b88d5360")
+			(uuid "2b889f6f-0d44-47a8-9c2d-e8b0e304dafa")
 		)
 		(fp_poly
 			(pts
@@ -9428,7 +9497,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "091bc152-47ad-4a8a-bc27-62b483444637")
+			(uuid "fadb486b-4cd3-4356-807c-bbd2f2a683f7")
 		)
 		(fp_line
 			(start -3.13 3.63)
@@ -9438,7 +9507,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "55adb3d0-9a5f-48c0-9b9b-4556b5845b6b")
+			(uuid "f825b01a-b596-49c6-a1f6-8fc24d7bea2b")
 		)
 		(fp_line
 			(start 3.13 3.63)
@@ -9448,7 +9517,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a3fc9d34-f0b9-4a89-ace0-ac439d6d6585")
+			(uuid "51805637-6ffc-4469-bc9a-a4420faa47a9")
 		)
 		(fp_line
 			(start -3.13 -3.63)
@@ -9458,7 +9527,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b18098c9-e405-48c3-b2b2-dc19fe5bbacc")
+			(uuid "0ac1e012-0a6f-4f96-912c-dee9ec6a6825")
 		)
 		(fp_line
 			(start 3.13 -3.63)
@@ -9468,7 +9537,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "64a88a56-ecfe-4da6-b509-7e80e708ead2")
+			(uuid "ed81cefc-5895-4ed5-a307-cd102b4e4ffb")
 		)
 		(fp_line
 			(start -2.5 3)
@@ -9478,7 +9547,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0a5a982b-98b0-4395-a636-75d9ff6fa5f9")
+			(uuid "5225447f-5561-4689-9280-52d010ce2087")
 		)
 		(fp_line
 			(start 2.5 3)
@@ -9488,7 +9557,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "57ac477c-59ae-497f-9215-4965797a2598")
+			(uuid "8c89ade9-732b-44c0-bc33-9ee25b239de2")
 		)
 		(fp_line
 			(start -2.5 -2)
@@ -9498,7 +9567,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ddf8859b-331a-4e6c-a9d8-b1310491145e")
+			(uuid "0c7f782e-82b2-42cb-a34f-82f0633b6374")
 		)
 		(fp_line
 			(start -1.5 -3)
@@ -9508,7 +9577,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e6cbb49d-b4ec-441b-ab24-d0292e58b396")
+			(uuid "d62e2468-2817-432c-807c-e1669ad0d5e2")
 		)
 		(fp_line
 			(start 2.5 -3)
@@ -9518,12 +9587,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9e44fc2a-625d-4e17-898c-7368a0a71c11")
+			(uuid "46395579-a66d-4e0a-aff9-7bb143dbec7e")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "461f8991-b4d6-4273-b915-aa763e3b290d")
+			(uuid "5e7994ff-3243-46a4-b331-6d2b57cf607c")
 			(effects
 				(font
 					(size 1 1)
@@ -9536,63 +9605,63 @@
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "5e460cd9-c65f-4d2a-a734-4a5a9bfaea6d")
+			(uuid "6c414106-b093-45d8-8708-525c9dac62eb")
 		)
 		(pad "" smd roundrect
 			(at -1.2 0 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "8148068a-c733-4ba9-a2b3-f7cdd70840ec")
+			(uuid "c41115e9-ba3a-4e46-b2e6-d28789b38d4d")
 		)
 		(pad "" smd roundrect
 			(at -1.2 1.37 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "6da1496d-ac3e-48db-8ce6-9bbd3a57c7d2")
+			(uuid "f1cb2715-b20e-445c-89bf-86eeb5e2d65a")
 		)
 		(pad "" smd roundrect
 			(at 0 -1.37 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a24a2854-fc98-4f02-b75c-bbd8921117ec")
+			(uuid "06c613ef-4355-43e5-8b36-ff9216396702")
 		)
 		(pad "" smd roundrect
 			(at 0 0 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "432a96b5-ab11-41fa-865d-2ac76ffd40f4")
+			(uuid "aa310884-67bf-4491-9b11-8ac56174d7e9")
 		)
 		(pad "" smd roundrect
 			(at 0 1.37 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "6f066eb9-3dc7-4da9-b3bd-5879cddc7a96")
+			(uuid "22521847-12b1-4a86-8b82-654c26ce1e36")
 		)
 		(pad "" smd roundrect
 			(at 1.2 -1.37 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "0eb9e311-5542-497c-af2b-7648aa92b60d")
+			(uuid "d2d331ea-8ce4-4596-aac3-690fa3d3bfe3")
 		)
 		(pad "" smd roundrect
 			(at 1.2 0 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "679a78a8-3378-478a-bbd1-29ceb0ba9746")
+			(uuid "b57d13e1-498d-4de7-8faa-af5bc11ab11d")
 		)
 		(pad "" smd roundrect
 			(at 1.2 1.37 270)
 			(size 0.97 1.1)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "bb572dd6-5555-40d6-be18-642b70cbb80d")
+			(uuid "b321232a-f421-4912-95a3-888ba57f0a09")
 		)
 		(pad "1" smd roundrect
 			(at -2.45 -2.25 270)
@@ -9602,7 +9671,7 @@
 			(net 1 "GND")
 			(pinfunction "CLK")
 			(pintype "input")
-			(uuid "96e1fc7e-608f-4187-9deb-2c7499fa49b3")
+			(uuid "8fad7fd3-65fd-4f0c-af2c-9c6009ea5ac5")
 		)
 		(pad "2" smd roundrect
 			(at -2.45 -1.75 270)
@@ -9612,7 +9681,7 @@
 			(net 55 "/MCU/TMC_{~{CS}}")
 			(pinfunction "~{CS}_CFG3")
 			(pintype "input")
-			(uuid "398b0762-483c-46dd-bc5a-7037fddbb635")
+			(uuid "ca7eeea6-d24c-41c9-ab03-3b3625484dc9")
 		)
 		(pad "3" smd roundrect
 			(at -2.45 -1.25 270)
@@ -9622,7 +9691,7 @@
 			(net 60 "/MCU/SCLK")
 			(pinfunction "SCK_CFG2")
 			(pintype "input")
-			(uuid "a4a42b88-4b00-423c-8599-e6b31ee1acc1")
+			(uuid "ff75f449-09d6-49eb-9917-80462fe14a49")
 		)
 		(pad "4" smd roundrect
 			(at -2.45 -0.75 270)
@@ -9632,7 +9701,7 @@
 			(net 57 "/MCU/MOSI")
 			(pinfunction "SDI_CFG1")
 			(pintype "input")
-			(uuid "60729a90-736a-4be6-857b-0929163dc5be")
+			(uuid "b5865724-2b6c-49ab-ba6b-82a62d436c77")
 		)
 		(pad "5" smd roundrect
 			(at -2.45 -0.25 270)
@@ -9642,7 +9711,7 @@
 			(net 70 "/MCU/MISO")
 			(pinfunction "SDO_CFG0")
 			(pintype "bidirectional")
-			(uuid "12adc4b1-277c-4b29-8a1d-3766e2e60be0")
+			(uuid "70a58c80-507a-4853-9ca4-b7a69b493708")
 		)
 		(pad "6" smd roundrect
 			(at -2.45 0.25 270)
@@ -9652,7 +9721,7 @@
 			(net 56 "/MCU/TMC_{STEP}")
 			(pinfunction "STEP")
 			(pintype "input")
-			(uuid "2f5d3846-1285-4614-85b6-5ca9364232d6")
+			(uuid "608506c2-2f81-4161-bb07-714fd42cf214")
 		)
 		(pad "7" smd roundrect
 			(at -2.45 0.75 270)
@@ -9662,7 +9731,7 @@
 			(net 66 "/MCU/TMC_{DIR}")
 			(pinfunction "DIR")
 			(pintype "input")
-			(uuid "2610c800-3a15-4e91-b439-2e550c8bcf3a")
+			(uuid "f6f14e57-133a-4cfd-ae03-4c603d66725f")
 		)
 		(pad "8" smd roundrect
 			(at -2.45 1.25 270)
@@ -9672,7 +9741,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VCC_IO")
 			(pintype "power_in")
-			(uuid "7ac27a5a-6614-4d3a-94f5-1d9b1cb2c054")
+			(uuid "8c1599d9-c634-4642-ab93-fd4cbb08328b")
 		)
 		(pad "9" smd roundrect
 			(at -2.45 1.75 270)
@@ -9682,7 +9751,7 @@
 			(net 77 "unconnected-(U7-DNC-Pad9)")
 			(pinfunction "DNC")
 			(pintype "no_connect")
-			(uuid "20a55f41-362b-4bb7-966c-57bcb7cfe0e9")
+			(uuid "c33f3c0c-ecf4-4b51-b043-513deb23f497")
 		)
 		(pad "10" smd roundrect
 			(at -2.45 2.25 270)
@@ -9692,7 +9761,7 @@
 			(net 76 "unconnected-(U7-SPI_MODE-Pad10)")
 			(pinfunction "SPI_MODE")
 			(pintype "input+no_connect")
-			(uuid "e0b0b151-471e-45d0-851f-c100051c95c7")
+			(uuid "0fc02803-79e2-4406-b33a-c9b013e78e54")
 		)
 		(pad "11" smd roundrect
 			(at -1.75 2.95 270)
@@ -9702,7 +9771,7 @@
 			(net 1 "GND")
 			(pinfunction "NC")
 			(pintype "passive")
-			(uuid "e22bc5ce-536e-4f04-a972-b5d02b9aaf09")
+			(uuid "0b0e79cc-35ee-4351-81c4-a4f98cc96fde")
 		)
 		(pad "12" smd roundrect
 			(at -1.25 2.95 270)
@@ -9712,7 +9781,7 @@
 			(net 1 "GND")
 			(pinfunction "GNDP")
 			(pintype "power_in")
-			(uuid "f2ed997f-a4dd-4da0-821c-cf7dcdf199c4")
+			(uuid "93e6dd77-a41c-4a0a-a62b-e2ca4c21b6f6")
 		)
 		(pad "13" smd roundrect
 			(at -0.75 2.95 270)
@@ -9722,7 +9791,7 @@
 			(net 78 "/Motor Driver/OB1")
 			(pinfunction "OB1")
 			(pintype "output")
-			(uuid "a13463ef-af0e-48d2-b6b0-66ede915da24")
+			(uuid "2ab96b27-2297-4e3e-a85d-afd45fd9e977")
 		)
 		(pad "14" smd roundrect
 			(at -0.25 2.95 270)
@@ -9732,7 +9801,7 @@
 			(net 42 "Net-(U7-BRB)")
 			(pinfunction "BRB")
 			(pintype "passive")
-			(uuid "ad307a4b-8d55-47b8-a845-8a8868a517e6")
+			(uuid "fc57d483-4968-4255-9034-d0f377782c8e")
 		)
 		(pad "15" smd roundrect
 			(at 0.25 2.95 270)
@@ -9742,7 +9811,7 @@
 			(net 80 "/Motor Driver/OB2")
 			(pinfunction "OB2")
 			(pintype "output")
-			(uuid "669f5fc3-7d78-4423-af66-2e72c6d28e54")
+			(uuid "aeea5501-3396-4197-8fba-0b39fd2bac14")
 		)
 		(pad "16" smd roundrect
 			(at 0.75 2.95 270)
@@ -9752,7 +9821,7 @@
 			(net 82 "+12V")
 			(pinfunction "VS")
 			(pintype "power_in")
-			(uuid "4e688c89-e697-44a0-b2ba-6e4a780e2843")
+			(uuid "a4057f1e-424e-4077-a80d-cbc743d0cd2d")
 		)
 		(pad "17" smd roundrect
 			(at 1.25 2.95 270)
@@ -9762,7 +9831,7 @@
 			(net 74 "unconnected-(U7-DCO-Pad17)")
 			(pinfunction "DCO")
 			(pintype "output+no_connect")
-			(uuid "1ebb36b0-2f67-49ed-97c0-90f1f0321d68")
+			(uuid "4b7f600e-b545-4e09-a0b8-e3e25f343703")
 		)
 		(pad "18" smd roundrect
 			(at 1.75 2.95 270)
@@ -9772,7 +9841,7 @@
 			(net 1 "GND")
 			(pinfunction "DCEN_CFG4")
 			(pintype "input")
-			(uuid "7f2fa1e5-dc65-4196-a71e-0b67971d16c2")
+			(uuid "d3ca3d86-8aad-44e4-8c5b-8cd135919496")
 		)
 		(pad "19" smd roundrect
 			(at 2.45 2.25 270)
@@ -9782,7 +9851,7 @@
 			(net 1 "GND")
 			(pinfunction "DCIN_CFG5")
 			(pintype "input")
-			(uuid "95784ac8-a1b5-49b9-b63e-02d0230ce0f0")
+			(uuid "e28a5792-dc37-4edd-9b46-ee5da7d4e8d5")
 		)
 		(pad "20" smd roundrect
 			(at 2.45 1.75 270)
@@ -9792,7 +9861,7 @@
 			(net 81 "unconnected-(U7-DIAG0-Pad20)")
 			(pinfunction "DIAG0")
 			(pintype "output+no_connect")
-			(uuid "2b45b7a0-cbee-4ea1-9815-c7fd8178c775")
+			(uuid "0dcabe21-4a3c-43c0-ad29-f05aca06a444")
 		)
 		(pad "21" smd roundrect
 			(at 2.45 1.25 270)
@@ -9802,7 +9871,7 @@
 			(net 75 "unconnected-(U7-DIAG1-Pad21)")
 			(pinfunction "DIAG1")
 			(pintype "output+no_connect")
-			(uuid "d3e8b10a-b3e2-427a-878a-41f952aaad0e")
+			(uuid "f7e609ab-08b7-4e50-8a59-e6dc661a0d0d")
 		)
 		(pad "22" smd roundrect
 			(at 2.45 0.75 270)
@@ -9812,7 +9881,7 @@
 			(net 68 "/MCU/TMC_{~{EN}}")
 			(pinfunction "~{DRV_EN}_CFG6")
 			(pintype "input")
-			(uuid "49da5c3b-63d2-4d73-aaf9-9317bc04e146")
+			(uuid "ebe4058b-34e1-4c3a-a8c7-45cc7ae9c4c4")
 		)
 		(pad "23" smd roundrect
 			(at 2.45 0.25 270)
@@ -9822,7 +9891,7 @@
 			(net 44 "Net-(U7-AIN_IREF)")
 			(pinfunction "AIN_IREF")
 			(pintype "input")
-			(uuid "40ea5d70-82aa-4e52-99a0-2b41d8e78496")
+			(uuid "cf303b8d-a167-4d40-b9fd-37c7d62fe91a")
 		)
 		(pad "24" smd roundrect
 			(at 2.45 -0.25 270)
@@ -9832,7 +9901,7 @@
 			(net 1 "GND")
 			(pinfunction "GNDA")
 			(pintype "power_in")
-			(uuid "b8cf93a0-4eb3-4d10-8d1e-6e2bd3c21d69")
+			(uuid "bff97471-9934-4679-9b1c-4ae8ed3979f7")
 		)
 		(pad "25" smd roundrect
 			(at 2.45 -0.75 270)
@@ -9842,7 +9911,7 @@
 			(net 15 "/Motor Driver/TMC_{5V}")
 			(pinfunction "5VOUT")
 			(pintype "power_out")
-			(uuid "d78d2f38-e07e-4275-b5c6-527d67786d81")
+			(uuid "bebad13f-50a4-4ba0-b3d7-65117499a69a")
 		)
 		(pad "26" smd roundrect
 			(at 2.45 -1.25 270)
@@ -9852,7 +9921,7 @@
 			(net 14 "Net-(U7-VCC)")
 			(pinfunction "VCC")
 			(pintype "power_in")
-			(uuid "1a6a9239-42b6-4a25-a1c9-429fda6a561e")
+			(uuid "43bd40f5-f923-4272-be03-dd6aa8029d62")
 		)
 		(pad "27" smd roundrect
 			(at 2.45 -1.75 270)
@@ -9862,7 +9931,7 @@
 			(net 16 "Net-(U7-CPO)")
 			(pinfunction "CPO")
 			(pintype "passive")
-			(uuid "22fe64f2-4358-48da-a9f1-aa1e50944859")
+			(uuid "daf65f63-8466-418d-ae2b-44c508cf952f")
 		)
 		(pad "28" smd roundrect
 			(at 2.45 -2.25 270)
@@ -9872,7 +9941,7 @@
 			(net 17 "Net-(U7-CPI)")
 			(pinfunction "CPI")
 			(pintype "passive")
-			(uuid "2bdbdffa-ecc7-4e71-8011-9dd3b0b14a6f")
+			(uuid "98e68432-10c4-44bb-8f9d-5b785e37abf3")
 		)
 		(pad "29" smd roundrect
 			(at 1.75 -2.95 270)
@@ -9882,7 +9951,7 @@
 			(net 13 "Net-(U7-VCP)")
 			(pinfunction "VCP")
 			(pintype "passive")
-			(uuid "a9cabb55-9d4d-4b77-8412-76a38a1952bd")
+			(uuid "a1e18f2e-b796-4a58-8ff0-2ee4252559b9")
 		)
 		(pad "30" smd roundrect
 			(at 1.25 -2.95 270)
@@ -9892,7 +9961,7 @@
 			(net 82 "+12V")
 			(pinfunction "VSA")
 			(pintype "power_in")
-			(uuid "86b57f35-372d-4678-bab2-566e5fe8c6b6")
+			(uuid "a65a84c9-8c8f-487d-bf57-c2548b257a68")
 		)
 		(pad "31" smd roundrect
 			(at 0.75 -2.95 270)
@@ -9902,7 +9971,7 @@
 			(net 82 "+12V")
 			(pinfunction "VS")
 			(pintype "power_in")
-			(uuid "701c70e1-5f45-44bc-ad70-6a50fc0c5d08")
+			(uuid "506e8149-44a8-4970-880c-e76130bc221e")
 		)
 		(pad "32" smd roundrect
 			(at 0.25 -2.95 270)
@@ -9912,7 +9981,7 @@
 			(net 79 "/Motor Driver/OA2")
 			(pinfunction "OA2")
 			(pintype "output")
-			(uuid "48ec1179-2b50-4f2b-ad57-b32c3aa9fd7e")
+			(uuid "dcf0a052-8251-4e77-8ea6-7ccf69ee3c2a")
 		)
 		(pad "33" smd roundrect
 			(at -0.25 -2.95 270)
@@ -9922,7 +9991,7 @@
 			(net 43 "Net-(U7-BRA)")
 			(pinfunction "BRA")
 			(pintype "passive")
-			(uuid "64c8a333-c53b-4ad9-a04d-7ec816ecab07")
+			(uuid "e84d5085-56a4-4ad0-b3b7-fbea056d8f65")
 		)
 		(pad "34" smd roundrect
 			(at -0.75 -2.95 270)
@@ -9932,7 +10001,7 @@
 			(net 73 "/Motor Driver/OA1")
 			(pinfunction "OA1")
 			(pintype "output")
-			(uuid "aa4d0cfa-eccc-41e4-98cd-7780be809274")
+			(uuid "95e92aa5-f50a-43f9-8184-754390acf25b")
 		)
 		(pad "35" smd roundrect
 			(at -1.25 -2.95 270)
@@ -9942,7 +10011,7 @@
 			(net 1 "GND")
 			(pinfunction "GNDP")
 			(pintype "passive")
-			(uuid "c8395bdf-4fee-4227-beef-b52681487412")
+			(uuid "2a4f6d84-e2cf-43f4-a6be-c60c683f60cc")
 		)
 		(pad "36" smd roundrect
 			(at -1.75 -2.95 270)
@@ -9952,7 +10021,7 @@
 			(net 1 "GND")
 			(pinfunction "TST_MODE")
 			(pintype "input")
-			(uuid "c6351790-db81-4618-868c-b6c99c059a78")
+			(uuid "410d01f2-147d-4b37-96a0-2b185f49637c")
 		)
 		(pad "37" smd rect
 			(at 0 0 270)
@@ -9963,7 +10032,7 @@
 			(pinfunction "EP")
 			(pintype "power_in")
 			(zone_connect 2)
-			(uuid "7e5f8a3d-09ca-4b7e-a7f9-b4ae0eb9c31a")
+			(uuid "f8defdcf-aa06-4773-bd8f-98148017c66c")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-36-1EP_5x6mm_P0.5mm_EP3.6x4.1mm.wrl"
 			(offset
@@ -9986,7 +10055,7 @@
 		(property "Reference" "C32"
 			(at -2.4125 0.05 0)
 			(layer "F.SilkS")
-			(uuid "8e78a68e-993e-4ed4-91a7-e467b11265ab")
+			(uuid "85b1c535-3c5d-4ed6-9eed-11a96c5cb9ad")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -9998,7 +10067,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "75334ec5-ca22-426e-9593-6c32695492ed")
+			(uuid "669cbe35-427f-4ba4-aa68-3bac1952c4d1")
 			(effects
 				(font
 					(size 1 1)
@@ -10011,7 +10080,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "41f24a93-8189-4e67-aa18-b895d202130f")
+			(uuid "1e29bf47-35a3-4825-9ac5-819f50fc8143")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10024,7 +10093,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4c8e10e9-7ed7-4390-a4ec-627b1194537e")
+			(uuid "14baae38-19da-4fcc-9989-fb0d91bb5720")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10037,7 +10106,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ade23466-1758-46ab-a0f1-26254896923a")
+			(uuid "6bc88d91-905c-43f2-ba02-3294f87bad1c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10071,7 +10140,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5871e409-7da3-42d1-b140-31b6a812827c")
+			(uuid "506feb41-43ed-4a02-8fce-21a0548d1699")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -10081,7 +10150,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fa1c6b6b-10aa-4674-ad09-816f0a0c0d3e")
+			(uuid "208b817b-c9ef-44e9-bed0-283b11b2e5b4")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -10091,7 +10160,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0940e259-9804-42cd-b70a-77e7a476687a")
+			(uuid "65bc471e-d767-40bc-b298-3fc4a0a7a066")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -10101,7 +10170,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "63f0fd9f-2929-45bf-9cd8-355b31e363fc")
+			(uuid "1c31deec-37b6-4fce-b3be-bfadf94b295c")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -10111,7 +10180,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9c108bfd-b213-43c7-b3b0-a03b0f8b6149")
+			(uuid "d938d1af-30e8-49fb-a5b2-bd2331934432")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -10121,7 +10190,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fe6c2ec6-feb2-4a67-a3de-62b98a6b9290")
+			(uuid "59b7283d-0e72-4144-a1d8-09bbee552807")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -10131,7 +10200,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "bc7d4dc1-8f11-424f-95d4-1057bb886c81")
+			(uuid "3509d6dd-e2ab-431e-a36a-76c2323026eb")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -10141,7 +10210,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "580da1fe-843e-4cdf-9c47-40c86e505334")
+			(uuid "866f689e-cfee-4400-bbef-d29cbad8f1d7")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -10151,7 +10220,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "667fe891-166f-4266-ae50-0b57e89db24c")
+			(uuid "46f39948-507b-4a8b-93e6-f97edac046a9")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -10161,12 +10230,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6eadc216-8308-41b1-a334-fa9a7b8c3caf")
+			(uuid "387748a9-a456-498c-bcfa-38d362825832")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "fd33e3e6-88b5-4795-9f1a-887381e88490")
+			(uuid "71821080-cf0a-446e-a843-c0cf4f24e822")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -10181,7 +10250,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "339c1cd3-a5d3-4e4e-a150-191c96c1e854")
+			(uuid "5479c817-f027-4e9d-8413-5be2f16ed95f")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0)
@@ -10190,7 +10259,7 @@
 			(roundrect_rratio 0.25)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "fbfde4a3-995c-4324-ac20-b27fb4a83648")
+			(uuid "1d7a04bf-4a5f-478e-b07f-7230491805b9")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -10213,7 +10282,7 @@
 		(property "Reference" "R20"
 			(at 0 1.75 180)
 			(layer "F.SilkS")
-			(uuid "c31a55f1-e0bd-4117-af21-845dd091dfb3")
+			(uuid "fad60f41-5dcb-470b-85de-c643dfec0860")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -10225,7 +10294,7 @@
 			(at 0 1.82 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "aa7b67d5-dfec-4171-834e-6f67f630ac66")
+			(uuid "7281ffdf-5f74-4543-a310-b0fdf1e45de5")
 			(effects
 				(font
 					(size 1 1)
@@ -10238,7 +10307,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "436c5ee2-0ba7-4f24-a7d1-55112343ee9f")
+			(uuid "ec1adff5-781e-45ff-8af4-67d172ce6162")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10251,7 +10320,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "09395878-31ab-4a06-a737-3abe2313fd92")
+			(uuid "517a3555-7adc-42f1-8f20-3eddab463f3e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10264,7 +10333,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "28261678-9979-4312-80b2-b4c8be939fa8")
+			(uuid "2c8ea68c-6f88-45fd-9aa0-97ff558f3018")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10298,7 +10367,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8aa5f3cd-e4eb-4135-9542-0e48d3c27011")
+			(uuid "9313313d-5150-4c2d-bd3a-a94ddc386fd1")
 		)
 		(fp_line
 			(start -0.727064 -0.91)
@@ -10308,7 +10377,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "eb6e406f-e275-41f3-bfe8-9df1dd6a3e39")
+			(uuid "fd7938da-c537-4263-9dae-1bbbc4f3ec70")
 		)
 		(fp_line
 			(start 2.28 1.12)
@@ -10318,7 +10387,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0261cdb8-0004-42ca-8b82-c32e7e2b8ec3")
+			(uuid "05806b69-5c2e-42a6-9fd4-422e2cf3460a")
 		)
 		(fp_line
 			(start 2.28 -1.12)
@@ -10328,7 +10397,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "287a5b03-c1ed-46ee-84dc-fa6614796492")
+			(uuid "de2c25c3-283f-42e2-b7f0-e139c6e19e73")
 		)
 		(fp_line
 			(start -2.28 1.12)
@@ -10338,7 +10407,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0246c5e1-f65e-4089-b80a-e2b5bbfaa295")
+			(uuid "e88a2512-7352-4edd-b758-5dedf7a3f7fc")
 		)
 		(fp_line
 			(start -2.28 -1.12)
@@ -10348,7 +10417,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6f22f5e4-4f8c-41da-a69d-950ee245e8e6")
+			(uuid "d2c7caa8-4e74-414a-801b-29ceeee0f3cd")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -10358,7 +10427,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b1f770ba-31da-4bed-ab02-b06ddb78a05a")
+			(uuid "55f403ae-7ecb-4e92-830f-1157b3f528c3")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -10368,7 +10437,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2c24d3f6-377c-4241-9cc9-36efe2e5f6bb")
+			(uuid "c105c5e8-d393-4840-8fd9-96142fd4e415")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -10378,7 +10447,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1bff482c-f43f-4820-a3be-938ed4177a39")
+			(uuid "1082e711-ffe9-480d-878d-69b0068f2df0")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -10388,12 +10457,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ec32b403-2755-4ed1-b7ae-563c2574ee4c")
+			(uuid "ff22945f-7f16-48e0-b0ae-32cf4daf1c8b")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "6c22d76a-ee7a-43d5-a306-3644ca990c0f")
+			(uuid "85d6ecdc-c63e-4370-9408-687b71d7b5dd")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -10408,7 +10477,7 @@
 			(roundrect_rratio 0.222222)
 			(net 42 "Net-(U7-BRB)")
 			(pintype "passive")
-			(uuid "1f13e00e-3de9-4a3e-a41b-14e6c299dd2a")
+			(uuid "3109fd6c-131a-4fbb-8ed7-8cf26c9fbdea")
 		)
 		(pad "2" smd roundrect
 			(at 1.4625 0 180)
@@ -10417,7 +10486,7 @@
 			(roundrect_rratio 0.222222)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "f2d6724e-6fde-4153-b6e0-42cc2a3ff792")
+			(uuid "c3ea1f83-a5b9-43bc-a026-618126497c40")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_1206_3216Metric.wrl"
 			(offset
@@ -10439,7 +10508,7 @@
 			(at 5.5 -12.1 0)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "280e1fbd-0962-473d-959d-069c5ddba123")
+			(uuid "b9db68c8-8838-4951-814c-abd1e4353259")
 			(effects
 				(font
 					(size 1 1)
@@ -10452,7 +10521,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "355a714c-bf6f-4d55-ae86-57cdc7f1dcd2")
+			(uuid "e1f5a701-325b-47ca-8000-1ff547adfafb")
 			(effects
 				(font
 					(size 1 1)
@@ -10464,7 +10533,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9e95025c-5bf1-490b-a533-862d85662370")
+			(uuid "7984ddfd-4ba3-4688-bf3e-98a5ade2c350")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10476,7 +10545,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bd6aaa85-b78a-4a65-923a-707d5e217612")
+			(uuid "2994eb46-e76f-411c-84bb-1d9bfe8ff468")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10488,7 +10557,7 @@
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "37dbcccf-5b6c-4de3-bfcc-57e6c986b27c")
+			(uuid "e077296d-d1ef-4a8c-a9aa-eb9bb6809ce1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10508,7 +10577,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "f6192d01-1599-4a98-92ac-dfc78bbd9951")
+			(uuid "74ad0715-0c04-420d-9e99-b2094808744e")
 		)
 		(fp_line
 			(start -6.4 -11.2)
@@ -10518,7 +10587,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "ac13da8f-504a-41d4-8844-1898c9145e7f")
+			(uuid "5985a1e6-2888-4709-b6fe-2db2098d486a")
 		)
 		(fp_line
 			(start -6.4 11.1)
@@ -10528,7 +10597,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "32f35d0d-b8a5-4aaf-9d38-3e899c3772d9")
+			(uuid "dc9e1fef-2744-47b1-8b29-38c2688dce05")
 		)
 		(fp_line
 			(start -6.4 11.1)
@@ -10538,7 +10607,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "7f75e3de-e13e-4c81-91cb-9bfa6fcfcfdb")
+			(uuid "5b9375e4-dc9d-49bf-938e-35c5864d1c56")
 		)
 		(fp_line
 			(start 6.4 -11.2)
@@ -10548,7 +10617,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "5075c8eb-12cf-4b4c-ad65-d763ca885be2")
+			(uuid "67f1b392-714d-4904-80e6-5a63e10146ea")
 		)
 		(fp_line
 			(start 6.4 -11.2)
@@ -10558,7 +10627,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "ad2bf4f6-b68e-41b7-9a12-622470899e20")
+			(uuid "d2f431f8-127f-4e8f-a5d8-53feddf49c17")
 		)
 		(fp_line
 			(start 6.4 11.1)
@@ -10568,7 +10637,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "2f550094-f288-4f9c-9924-5bde80750448")
+			(uuid "a86e8d26-0367-461b-879e-cdd9c53959ff")
 		)
 		(fp_line
 			(start 6.4 11.1)
@@ -10578,7 +10647,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "daa11d17-25b1-48a1-b79d-5a7e2e272a23")
+			(uuid "2866eade-dbc0-4be1-9581-d9a24783b110")
 		)
 		(fp_rect
 			(start -6.8 11.55)
@@ -10589,7 +10658,7 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "2a2515aa-eb9e-4c0d-9803-71f59c3dcf9a")
+			(uuid "16630188-7d20-4945-9298-10b4c9d2dcc2")
 		)
 		(fp_line
 			(start -6.3 -11.15)
@@ -10599,7 +10668,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "e976f269-f4c6-410f-815f-71af1396882a")
+			(uuid "4d8d68e8-6f25-43c3-869b-d5abd44b124f")
 		)
 		(fp_line
 			(start -6.3 11.05)
@@ -10609,7 +10678,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "8401f54f-aa3b-49bd-8118-d0fd9a22c24a")
+			(uuid "33f3816d-2a3e-4489-acf7-595c864e1699")
 		)
 		(fp_line
 			(start 5.1 -11.15)
@@ -10619,7 +10688,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "fbfc3948-3ebd-4086-80dd-4d132d27f730")
+			(uuid "82e85a19-ddbb-4282-a636-dd6ce1bc805e")
 		)
 		(fp_line
 			(start 6.3 -9.95)
@@ -10629,7 +10698,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "8f659bfe-fd7c-4871-a94e-6e7748754f91")
+			(uuid "d6b64908-0049-4fab-9b73-2368ee0b8ac2")
 		)
 		(fp_line
 			(start 6.3 11.05)
@@ -10639,13 +10708,13 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "341e8707-7e37-472b-bef3-8e4326ba6399")
+			(uuid "6cbcf392-ff0c-405e-8207-d54c45a614b8")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "883a6601-30bf-43ac-81ec-9cb25c0f2a1f")
+			(uuid "32cac479-b5ee-4cdc-921b-ad7c52d85901")
 			(effects
 				(font
 					(size 1 1)
@@ -10660,7 +10729,7 @@
 			(net 1 "GND")
 			(pinfunction "GND")
 			(pintype "power_in")
-			(uuid "f760d44d-1b78-4529-a0a4-dcd030b79438")
+			(uuid "2e1e4a32-622d-4209-bb49-09c65830480e")
 		)
 		(pad "2" smd circle
 			(at -1.58 -9.53)
@@ -10669,7 +10738,7 @@
 			(net 2 "+5V")
 			(pinfunction "VI")
 			(pintype "power_in")
-			(uuid "36282fbd-1d42-4cb0-9e23-c8d0546c55f4")
+			(uuid "64424986-41da-4c2d-97f2-7b2c644cab11")
 		)
 		(pad "3" smd circle
 			(at -4.76 9.53)
@@ -10678,7 +10747,7 @@
 			(net 36 "Net-(U5-ADJ)")
 			(pinfunction "ADJ")
 			(pintype "passive")
-			(uuid "39c030ae-e73e-44b1-970c-18ac2c4d4e80")
+			(uuid "2ecfe3c6-bf31-46be-ae74-dc5a029f38e7")
 		)
 		(pad "4" smd circle
 			(at 4.76 9.53)
@@ -10687,7 +10756,7 @@
 			(net 82 "+12V")
 			(pinfunction "VO")
 			(pintype "power_out")
-			(uuid "a51d8de1-eddc-4027-8997-dc9c67d2099d")
+			(uuid "982e7aaf-610b-4ac0-9eee-3f836b464848")
 		)
 		(model "${OE_3DMODEL_DIR}/TI_R-PDSS_B4_SMD.STEP"
 			(offset
@@ -10710,7 +10779,7 @@
 		(property "Reference" "R5"
 			(at 0 -1.13 0)
 			(layer "F.SilkS")
-			(uuid "8b00d95e-54b2-4a5f-864c-0a25b4f4f38e")
+			(uuid "ba6980aa-9a15-4247-93e8-45df23d0bc89")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -10722,7 +10791,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "56b5f511-59b1-441e-ab1d-4a1e40929d75")
+			(uuid "097113c7-d693-43ce-9528-b5ca4b65e1f8")
 			(effects
 				(font
 					(size 1 1)
@@ -10735,7 +10804,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1c2e36a2-b130-4bdf-acd8-4331f9d407b0")
+			(uuid "5ae2617a-4a4d-44bc-81f7-86cb79c33183")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10748,7 +10817,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "52d9f5b0-7957-4db2-b72d-2a8bd91f0b03")
+			(uuid "64425a55-d931-41ee-b5f6-8eec6e63afe0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10761,7 +10830,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a1d1b729-d319-4c66-8d8c-5dc62e5a662b")
+			(uuid "40060f39-b212-439f-8ca4-37372fe68ba3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10782,7 +10851,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6b8f7eb7-4232-4abb-b09c-0bb96c10c681")
+			(uuid "3cb7450a-5274-47a2-b7e9-4884eff3d2f9")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -10792,7 +10861,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "82e05244-097c-455e-8591-083ce62492ba")
+			(uuid "5b7ec7b8-a81e-4188-88df-fd84b02715fb")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -10802,7 +10871,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "102dafc1-e272-493b-903c-7b824533079f")
+			(uuid "f0f86e05-1d24-4d75-9c70-64345296c650")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -10812,7 +10881,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "267a947a-1e10-43d1-acd3-54e95e7e94c9")
+			(uuid "c1b499c4-17a8-4866-be63-8ad93578b048")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -10822,7 +10891,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4771a2fd-6dd5-46dd-865d-23177bf70519")
+			(uuid "192533d6-f7cf-464d-b1eb-8d8f772df939")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -10832,7 +10901,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ec1b4eb1-513b-460b-86f2-7abbc36a3b72")
+			(uuid "afa52250-0727-4638-b8ab-4e61b938c577")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -10842,7 +10911,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "fd238f0d-78d7-4ad3-aa2d-acaa158c5ed9")
+			(uuid "ab5f55c8-45ec-433d-95e3-b4863aa484bb")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -10852,7 +10921,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "53c04359-fb57-41b8-b197-5fac0cf75b77")
+			(uuid "c89f1a4c-4ef5-4772-bd20-44c2e46639d0")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -10862,7 +10931,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1677f1db-0129-47af-8d08-5f0912b96fcd")
+			(uuid "5e1ed242-d0e2-40f2-8643-c0d90bb16a96")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -10872,12 +10941,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6b3f2850-22fa-4d69-8b03-2c2e59a00e4a")
+			(uuid "56f9ef4b-c45c-4c81-ab22-fdbda1f22807")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "2e97018f-5c7f-47f2-979e-037d4b4670d3")
+			(uuid "ba0fe642-a4eb-4203-9ccd-d648744fe7e8")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -10892,7 +10961,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "ac3025a3-a93e-41bd-89f7-3bddb0d4dd02")
+			(uuid "054e8439-a2e8-4039-adfc-0e8d6268d82c")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -10901,7 +10970,7 @@
 			(roundrect_rratio 0.25)
 			(net 31 "/MCU/QSPI_{~{CS}}")
 			(pintype "passive")
-			(uuid "10c26e71-c14a-4245-bf0d-43b4e763074d")
+			(uuid "07463493-c13b-4722-b0ac-9cb366a03db3")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -10924,7 +10993,7 @@
 		(property "Reference" "C1"
 			(at 2.5 0 0)
 			(layer "F.SilkS")
-			(uuid "627042fe-cdd4-4488-94ed-0377a556ff00")
+			(uuid "0909703b-de19-432f-b09c-9cbd21d247e6")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -10936,7 +11005,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6006d895-414b-40c1-9181-bad5deca48d4")
+			(uuid "e82e2a2e-66fc-4739-b57d-24b8e1cd70c6")
 			(effects
 				(font
 					(size 1 1)
@@ -10949,7 +11018,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "aa740a03-fcaa-4dbe-a9be-792fc083104b")
+			(uuid "4d7b6d70-9326-4670-969b-ec9525a9e43b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10962,7 +11031,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f2693a35-2cd1-4b55-8a96-19a19738e82d")
+			(uuid "ec720672-7502-46fa-a256-82a37664f08b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -10975,7 +11044,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a0b5925b-f10b-49f0-abf6-6d445323a0e3")
+			(uuid "cd103113-7591-44c8-ac00-647bc1b48838")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11008,7 +11077,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0c7a25e3-f540-4dfe-8074-c51965a1eb35")
+			(uuid "415c6671-8a1d-4b8f-b6d0-57bfd05ab279")
 		)
 		(fp_line
 			(start -0.14058 0.51)
@@ -11018,7 +11087,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cb41a290-0e6a-46ef-a614-9e73bdcd3bf9")
+			(uuid "5b8ce544-7576-4d2d-9475-e42f3c656045")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -11028,7 +11097,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c63c75f4-838e-47d0-903d-62a366a81978")
+			(uuid "a488aba1-9daf-42f4-a588-625c5d0f73ee")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -11038,7 +11107,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a58d33c7-89f5-4b8b-b2eb-b75b334e54c4")
+			(uuid "36e4f649-1786-4c32-afde-2607cc8025d6")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -11048,7 +11117,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "03c34916-6d96-4598-8c9c-84f8cfe586da")
+			(uuid "1a9659e6-4b18-42ee-8f33-28041c292329")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -11058,7 +11127,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "eddb50d1-dbbc-45e2-ad50-3da8c056421b")
+			(uuid "5cd4820f-ea5e-428e-9e24-30099272f319")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -11068,7 +11137,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3a5a6050-b6af-4e5b-af84-67154ddb883a")
+			(uuid "a7e5c070-5db5-4183-ba05-91c01c58b052")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -11078,7 +11147,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f7ee2f86-67fa-420e-8621-6b12281e5866")
+			(uuid "847805df-78f3-4996-b0b5-a337b0250a2e")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -11088,7 +11157,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7e6d5f77-402b-457c-948c-d64c6efb6992")
+			(uuid "d2ef0d7c-49ae-458f-bab3-621c9b5490aa")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -11098,12 +11167,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "776e713b-c052-4365-bfc4-3eaa4f098dbf")
+			(uuid "a367f494-fc6e-43cc-9b9e-07ec7f1066c0")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "5bb3a80f-0519-44fe-8b75-a1939ab4e254")
+			(uuid "309a24fa-876b-4cfe-9d3a-cecb95e8851c")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -11118,7 +11187,7 @@
 			(roundrect_rratio 0.25)
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pintype "passive")
-			(uuid "bfc4afcd-aa51-44a9-a1a5-67d39dc1615d")
+			(uuid "c73100d0-262b-42df-9a29-ba5375d936f1")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0)
@@ -11127,7 +11196,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "77a47d5e-7530-4dde-abe4-b506abcce8ca")
+			(uuid "04183c01-bb30-4cee-83f2-8f1d8c5945cf")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -11150,7 +11219,7 @@
 		(property "Reference" "R22"
 			(at 0 -1.4 90)
 			(layer "F.SilkS")
-			(uuid "d2dd2a5e-c8d4-4b64-9edd-04aff1ecde41")
+			(uuid "55cc46f7-bba7-4ee7-9312-7bbf91c3fa3d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -11162,7 +11231,7 @@
 			(at 0 1.43 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b50e286a-b025-4dae-9b67-3da819e25813")
+			(uuid "2145413e-311f-4e1f-a63f-fa046028df26")
 			(effects
 				(font
 					(size 1 1)
@@ -11175,7 +11244,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7ec3994f-2cbf-4a8a-851e-bee739e38b3d")
+			(uuid "c3408a75-2fa8-44ac-a7a0-003b9e44cf4a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11188,7 +11257,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "496bfef1-1ff3-4a80-84fa-ea410b2d0513")
+			(uuid "a21892e6-e0c4-42c5-95b7-f1989cbdd1b4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11201,7 +11270,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3b81f532-c7ea-4a29-b369-4a9cd9336e66")
+			(uuid "84f90b3e-492d-4cfb-ab3b-5b4fffd14b6b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11222,7 +11291,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d9d7ac04-fa7e-4772-85f6-b9bf272a6773")
+			(uuid "a68ed291-6155-40c4-a203-68dc25b7db6e")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -11232,7 +11301,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "9315b3c5-96ce-428c-a80b-29d6c086e6c5")
+			(uuid "40e9eb60-d129-46f5-a4c0-ae7abfaea355")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -11242,7 +11311,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "7ed9a65e-31c2-464d-a39e-d95c18957f7e")
+			(uuid "96e591f1-284b-45aa-898a-14c3fd897a8c")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -11252,7 +11321,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "7673c077-f25c-42da-b379-e978d0ccdab2")
+			(uuid "bd3ef37f-dcbe-48fa-a97b-428cd6b3ca0c")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -11262,7 +11331,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "eb7ea40a-a8a3-43ac-94a4-4622e7a07bd7")
+			(uuid "6b3e5e88-7b1f-4793-b167-a25805873aa6")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -11272,7 +11341,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ceea1b20-8ad7-4292-97d2-1ee97984a721")
+			(uuid "35edc205-1061-4e70-a2cd-03249adb1244")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -11282,7 +11351,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3502ede6-5d06-4745-9dd2-2e9430e042c0")
+			(uuid "cbc4eaf5-33c3-4e7d-8cab-7e5bd9e027d6")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -11292,7 +11361,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4552c77c-c608-4a93-a594-cdfb33b60e7e")
+			(uuid "cf655d5e-2c0e-4a8d-bd74-89df0b3b0e98")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -11302,7 +11371,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "dfe468be-8577-42dd-b606-9f636e8a45a0")
+			(uuid "4f6e08aa-3a6c-49d8-8b4f-ac9e1f38a0b7")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -11312,12 +11381,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b922b31a-f8bf-4ffe-b2fb-e3e0de9a6f4b")
+			(uuid "5e454108-fb74-4e24-8130-33f018d9fde5")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "8c7624d5-a9b5-44c9-809a-aac80924314c")
+			(uuid "030b6a17-a513-4a07-9879-22a4a071a32d")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -11332,7 +11401,7 @@
 			(roundrect_rratio 0.25)
 			(net 15 "/Motor Driver/TMC_{5V}")
 			(pintype "passive")
-			(uuid "d53cf676-5985-4af4-aace-4e383d9eb8d5")
+			(uuid "d89c936a-e918-4497-b160-894cf84eb3e1")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 90)
@@ -11341,7 +11410,7 @@
 			(roundrect_rratio 0.25)
 			(net 44 "Net-(U7-AIN_IREF)")
 			(pintype "passive")
-			(uuid "af627179-31b9-468e-9181-8040b9f9e44c")
+			(uuid "39dd1e52-3084-420d-b7d4-691026c0b4c4")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -11364,7 +11433,7 @@
 		(property "Reference" "C24"
 			(at -5.8 -2.05 180)
 			(layer "F.SilkS")
-			(uuid "58074acb-7ef6-4ab6-a2a8-cdae9a7c69ab")
+			(uuid "3d2a165d-a4b1-44be-9694-7c1673e9264c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -11376,7 +11445,7 @@
 			(at 0 5.2 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2dc851b4-a6f3-46e4-8e07-ce3e23274b03")
+			(uuid "a3d3539a-8b9e-4a7a-89fc-357deec9d697")
 			(effects
 				(font
 					(size 1 1)
@@ -11389,7 +11458,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b802ebc8-9d5d-4fff-bc8e-9b2fb2473fb6")
+			(uuid "e900ebf9-7d56-4961-bfc1-89268efc9288")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11402,7 +11471,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "31dc9825-e8f1-4e27-98f8-dd96eabec4c3")
+			(uuid "83ebe13b-ba76-4796-b96e-424b260ba0e5")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11415,7 +11484,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0bfc36f9-725b-49f0-acd2-0f95f047781a")
+			(uuid "f290fca3-1d1c-47e4-bbb8-d6173eaae2f8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11436,7 +11505,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "766f150b-5a4c-4c16-ba07-a77a96fdcba3")
+			(uuid "8412f7e9-df96-4058-8ce1-35db2aead6a1")
 		)
 		(fp_line
 			(start 4.26 -4.26)
@@ -11446,7 +11515,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5bbeffe7-30bd-4b2e-9054-a95348ce361f")
+			(uuid "3087dff6-e66b-43b8-b8e6-0c8657df924a")
 		)
 		(fp_line
 			(start -3.195563 4.26)
@@ -11456,7 +11525,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a6524e6c-c8dd-4eca-a2c1-c152b609056b")
+			(uuid "1b346781-9934-4620-a1aa-278566b99143")
 		)
 		(fp_line
 			(start -3.195563 -4.26)
@@ -11466,7 +11535,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ec5a857f-d965-4522-b86d-d3a6e25ea2b6")
+			(uuid "43339dcc-38ce-4a64-aaba-23a720b97072")
 		)
 		(fp_line
 			(start -4.26 3.195563)
@@ -11476,7 +11545,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1b567e61-4f48-4ae1-8d18-d3dbc5859826")
+			(uuid "01ee2444-a32e-4a14-af1d-2c784efbb8c7")
 		)
 		(fp_line
 			(start -4.26 3.195563)
@@ -11486,7 +11555,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "20f10e71-f04e-4b93-a811-b6f22e6e1769")
+			(uuid "46959ec0-4514-47a6-a180-2a7a6d67918e")
 		)
 		(fp_line
 			(start -4.26 -3.195563)
@@ -11496,7 +11565,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1ef97d73-87a4-4500-8376-ac6855ed4334")
+			(uuid "8d3ce4f1-d88a-4130-8b36-011dff13ce4f")
 		)
 		(fp_line
 			(start -4.26 -3.195563)
@@ -11506,7 +11575,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "43e306e8-0678-468e-a0d3-001a6ec42798")
+			(uuid "843217d8-4f4b-4d23-aa76-732c0c784ecb")
 		)
 		(fp_line
 			(start 6.1 1.3)
@@ -11516,7 +11585,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "34e6711c-cba0-4665-8304-514fe5045b60")
+			(uuid "021445e5-0901-49bd-b0b3-5de2c42e3be1")
 		)
 		(fp_line
 			(start 6.1 -1.3)
@@ -11526,7 +11595,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "26a518b7-af15-4a98-8b07-1d525d1c8f0b")
+			(uuid "9146eb72-275f-4a33-99c2-5b321877946e")
 		)
 		(fp_line
 			(start 4.4 1.3)
@@ -11536,7 +11605,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d0e54461-f92d-4720-9cce-72daf5342a83")
+			(uuid "33cfcfab-74e4-4980-81f5-233d09d27361")
 		)
 		(fp_line
 			(start 4.4 -1.3)
@@ -11546,7 +11615,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fc385c86-b776-4283-9d6b-954ccf6c0c99")
+			(uuid "7d5984ae-703f-4f3e-a2aa-3fe66b591d0a")
 		)
 		(fp_line
 			(start 4.4 -4.4)
@@ -11556,7 +11625,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b8f0b18b-ee47-42f1-8d0b-248bfecaf143")
+			(uuid "4aa24742-b98e-48aa-b334-ae8b1003cb46")
 		)
 		(fp_line
 			(start -3.25 4.4)
@@ -11566,7 +11635,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "87d4dd9f-b5b0-4440-83d0-d4f3f1f4b021")
+			(uuid "a3b655bc-c581-478d-86f4-806d07e0b187")
 		)
 		(fp_line
 			(start -3.25 -4.4)
@@ -11576,7 +11645,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "63c4c2c2-6c48-4134-b51b-74524a68bc7f")
+			(uuid "9065ba45-07fa-48dd-b59e-01ad446a603c")
 		)
 		(fp_line
 			(start -4.4 3.25)
@@ -11586,7 +11655,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1cbc0954-a0cb-4346-9199-a0aa35562fa5")
+			(uuid "f49ed7af-9133-46a4-9bfb-c1c904c7bc47")
 		)
 		(fp_line
 			(start -4.4 1.3)
@@ -11596,7 +11665,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "059faa31-10d3-40d5-ac5b-9cfe267122c7")
+			(uuid "e56e79e0-93fb-465f-87d4-d351b4fcadb2")
 		)
 		(fp_line
 			(start -4.4 -1.3)
@@ -11606,7 +11675,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b2328af9-122e-4a7e-a5ce-47bda5020b1e")
+			(uuid "572b6735-ee44-4b82-9066-07ac34d1a4b1")
 		)
 		(fp_line
 			(start -4.4 -3.25)
@@ -11616,7 +11685,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "72be111a-96b8-433f-a08b-3b30046dc7aa")
+			(uuid "21a4a6c1-740e-444e-9286-df506aecb3be")
 		)
 		(fp_line
 			(start -4.4 -3.25)
@@ -11626,7 +11695,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a28cd0b5-7e33-4824-8088-e8fce3cd61d5")
+			(uuid "9003ca60-9404-43df-b001-afb909a32d70")
 		)
 		(fp_line
 			(start -6.1 1.3)
@@ -11636,7 +11705,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "12ac1c05-1838-42f2-a61b-9f48b97f9b46")
+			(uuid "9983f941-5a3a-455b-908a-845c013938be")
 		)
 		(fp_line
 			(start -6.1 -1.3)
@@ -11646,7 +11715,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a77ed851-e113-40f7-9a05-2ed7bb5ffe82")
+			(uuid "699ca1ad-2db6-4c64-9dc9-e6e3242d30b7")
 		)
 		(fp_line
 			(start 4.15 -4.15)
@@ -11656,7 +11725,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6040ea6f-7b6d-4e95-a42b-cc8c2e66d11e")
+			(uuid "1948c7e9-4354-4d9c-99dc-30a251c55ed7")
 		)
 		(fp_line
 			(start -3.15 4.15)
@@ -11666,7 +11735,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2464703c-4726-4f02-aed4-7144697653df")
+			(uuid "c2abc071-e47e-4289-a8fe-821fcabaca56")
 		)
 		(fp_line
 			(start -3.15 -4.15)
@@ -11676,7 +11745,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0b000495-c304-4d64-966b-727265680ab9")
+			(uuid "517e77f5-9327-43b0-b5b3-57ad1b467910")
 		)
 		(fp_line
 			(start -4.15 3.15)
@@ -11686,7 +11755,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "09519ba8-259c-4b87-96f1-18780e0bd042")
+			(uuid "8fb909d7-d923-4154-a25a-1cf2fedbae78")
 		)
 		(fp_line
 			(start -4.15 -3.15)
@@ -11696,7 +11765,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "10c42f7d-a2aa-4b7c-8f75-5bd56ebe3868")
+			(uuid "5af9a03a-31bd-49f0-b005-a8d7f929fc2d")
 		)
 		(fp_line
 			(start -4.15 -3.15)
@@ -11706,7 +11775,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4fabbd0f-eb6f-4054-95f7-eff1d27cc356")
+			(uuid "8a28d90b-54f3-484e-84cf-3a59fb4d4480")
 		)
 		(fp_circle
 			(center 0 0)
@@ -11717,12 +11786,12 @@
 			)
 			(fill none)
 			(layer "F.Fab")
-			(uuid "289a747d-8181-413d-8128-b3d465d8543b")
+			(uuid "7c849564-ec9e-47da-a36a-97b6ec7de68c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "b4e96a80-5750-43dd-8b2e-3efedd5dc089")
+			(uuid "57fe9241-dcba-4340-bffe-8ef1aca5c2e3")
 			(effects
 				(font
 					(size 1 1)
@@ -11737,7 +11806,7 @@
 			(roundrect_rratio 0.119048)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "e95801b0-2edf-4793-bba4-29ec11c41aec")
+			(uuid "6e92b288-373c-478f-bf5e-cd8c8fe79d12")
 		)
 		(pad "2" smd roundrect
 			(at 3.6 0 180)
@@ -11746,7 +11815,7 @@
 			(roundrect_rratio 0.119048)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "8ee69606-c0bc-43b9-aaea-4a8c6add5333")
+			(uuid "4f93c7c5-0da7-4fa5-929f-95e04158f4dd")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_Elec_8x10.2.wrl"
 			(offset
@@ -11770,7 +11839,7 @@
 		(property "Reference" "C18"
 			(at 0 -1.16 180)
 			(layer "F.SilkS")
-			(uuid "285e8e41-2038-4814-901a-a54e523b9321")
+			(uuid "99066fe8-7f27-4a7a-8e4e-ea465339e6ec")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -11782,7 +11851,7 @@
 			(at 0 1.16 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bd99b47f-020b-4d0a-9de8-854d469d6f71")
+			(uuid "e638ab75-2fe2-45fc-9c09-72fc00266df9")
 			(effects
 				(font
 					(size 1 1)
@@ -11795,7 +11864,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0e670a08-11f0-4bbb-b9b9-9ee008e9c87c")
+			(uuid "8f5c22fa-d3c4-4717-8ec8-0342b2b21d21")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11808,7 +11877,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7f776db6-7fd9-4ea3-a1a1-bd867ba733f4")
+			(uuid "73d9bd9a-1255-4820-bca8-e1d31ea47365")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11821,7 +11890,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "720419da-f846-4583-838e-40705b17e037")
+			(uuid "52c387e1-c669-4381-9f0f-eaef004b515e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -11842,7 +11911,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ef8ec3f1-37ca-4e53-a51a-7dd5caf2c313")
+			(uuid "ca4ec94f-0022-4833-b4fb-8b59c21c0eca")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -11852,7 +11921,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b6c61b5f-7ebc-4c6a-8670-f8693eef205d")
+			(uuid "75703ae3-0ee4-4d45-9dc5-314e77504285")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -11862,7 +11931,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "137d2c41-71b0-41af-a12a-70f708123f98")
+			(uuid "528c62b4-1dd0-4a11-be21-46ca3c8657c3")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -11872,7 +11941,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "462e37a8-49bb-41ba-a697-bca2d21e90ae")
+			(uuid "c456c903-1c32-42ed-8026-ce0bc9b7c07e")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -11882,7 +11951,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b009fbb9-b13a-48fb-9d08-f26c3b8e7e1e")
+			(uuid "14b2c82a-29b3-40e3-bee1-42b1c5b77f46")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -11892,7 +11961,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c731dc54-e980-4fd4-9a18-4ba82731e4e1")
+			(uuid "6333a94f-69e6-4d74-950b-a4e62de6a3f7")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -11902,7 +11971,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f5e43e58-7f15-47d5-9976-ce14afdb48eb")
+			(uuid "0e617541-78cd-427a-9172-5922b5424b70")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -11912,7 +11981,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5a010bec-a6b7-4ffd-874a-d878dbfe11f7")
+			(uuid "240b9f3c-7ee2-499f-9269-6ba0884d117f")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -11922,7 +11991,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d660f73a-7e1f-4f06-bff9-be02bfc6d65a")
+			(uuid "5814b806-2cfe-4a22-a2ea-4c7d37903d2f")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -11932,12 +12001,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5ca352fc-d128-4128-8425-b1132dd196f8")
+			(uuid "e76ec70d-e94f-4baf-82ad-fb7a9fbef96a")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "b6b9f85c-58d1-4270-92a8-c651bfe21663")
+			(uuid "53da283b-f493-498c-bc84-b4598e4d945b")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -11952,7 +12021,7 @@
 			(roundrect_rratio 0.25)
 			(net 9 "VBUS")
 			(pintype "passive")
-			(uuid "4d0145f1-409e-407b-87a6-0a7f67708ab2")
+			(uuid "21cd3a75-d5e8-49b3-a415-c083d488e14f")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -11961,7 +12030,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "c203a788-13e3-4a4d-9656-fc42c4f6988a")
+			(uuid "457ce43e-71bf-454c-9e16-2dcd699d79cb")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -11986,7 +12055,7 @@
 			(at 0 -3.25 0)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "1794c98f-2254-4557-aec3-6c7a447f8c41")
+			(uuid "16425f9a-64bb-43af-bb60-250fdbfc4ce0")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -11998,7 +12067,7 @@
 			(at 0 3.25 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "40eab20a-51b1-43d9-99ee-a56bfe5f12ce")
+			(uuid "8e44437e-3d5a-4b2e-8d32-7fd4c2ef99c5")
 			(effects
 				(font
 					(size 1 1)
@@ -12011,7 +12080,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0826e649-2b1c-41ef-99d6-0295e471f90d")
+			(uuid "f931bed8-e66e-4d7f-b33f-8912cfb2f902")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12024,7 +12093,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b2c45de0-37c9-4d82-8c7b-912b2043662f")
+			(uuid "8270ed92-1b58-4c85-bfd1-fa8310fb22da")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12037,7 +12106,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "276847fa-7bab-4414-a5ba-fec69a8f24c7")
+			(uuid "38ad3f8d-8a80-4dc8-9dd4-e7850cb9740a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12059,7 +12128,7 @@
 			)
 			(fill none)
 			(layer "Cmts.User")
-			(uuid "4ce5a131-92a0-4eeb-9373-87d3c529912e")
+			(uuid "f9a4b6d5-45c3-4143-ab78-2d70697e8010")
 		)
 		(fp_circle
 			(center 0 0)
@@ -12070,13 +12139,13 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "5d800a96-fb26-45bb-8a90-e3d5310f7631")
+			(uuid "7493f462-3d81-4ddb-8030-6bf4e74a584f")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f29f4a3e-fcfe-43e4-9662-9e64d83e9632")
+			(uuid "27a9d3c1-2131-4add-b957-ce7f4a834241")
 			(effects
 				(font
 					(size 1 1)
@@ -12089,7 +12158,7 @@
 			(size 2.7 2.7)
 			(drill 2.7)
 			(layers "*.Cu" "*.Mask")
-			(uuid "67fd337b-c8d1-4804-97df-be9a207840e1")
+			(uuid "5333a148-b7af-4caf-baf1-0fb173481d00")
 		)
 	)
 	(footprint "Capacitor_SMD:C_1206_3216Metric"
@@ -12101,7 +12170,7 @@
 		(property "Reference" "C22"
 			(at -1.2 -1.75 180)
 			(layer "F.SilkS")
-			(uuid "b43403c8-636e-47cd-a65b-e0229b50d8d3")
+			(uuid "5ad65b89-ae50-4157-9c0d-64d8e3d08ddb")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -12113,7 +12182,7 @@
 			(at 0 1.850001 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "189b6f7a-ee4a-4069-be58-92ea3494b5f9")
+			(uuid "6b923ecd-2f9e-4ff8-92d2-7b602e3190a5")
 			(effects
 				(font
 					(size 1 1)
@@ -12126,7 +12195,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c355726f-7047-4e9a-9107-dd26b4c0e6fe")
+			(uuid "00fe8669-8bc3-485e-b011-ad313100f5d9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12139,7 +12208,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4a818280-545d-41ae-9ca8-ebc93d9baa1a")
+			(uuid "1d3641f7-78a7-4cc6-9d37-db5c70202b6d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12152,7 +12221,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "93a6fba3-6ae8-4c16-8ec3-fff22f89945c")
+			(uuid "c7fa07a2-6bf7-49cd-b5b9-b75c9d986644")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12173,7 +12242,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b535ead1-9e26-4bdd-9373-9b9621d5d583")
+			(uuid "20da3846-deb9-4c43-a76c-977b78334d8f")
 		)
 		(fp_line
 			(start -0.711252 0.91)
@@ -12183,7 +12252,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0b74a826-e93a-4659-9ab5-290442dbda97")
+			(uuid "39ee1dbd-d3b3-4527-a294-d3498162dad7")
 		)
 		(fp_line
 			(start -2.3 -1.15)
@@ -12193,7 +12262,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c7d37c2f-cd77-4c2d-b7d3-f4536edd5ec2")
+			(uuid "a12dbcb6-0b47-4dcd-9641-4c82eb68def6")
 		)
 		(fp_line
 			(start -2.3 1.15)
@@ -12203,7 +12272,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "276dc861-03ed-4507-8317-86f0cba37fb0")
+			(uuid "18a7e4aa-43c9-45c6-93fb-337f0dd5319d")
 		)
 		(fp_line
 			(start 2.3 -1.15)
@@ -12213,7 +12282,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5a1f7e55-e84c-4092-9378-e17dcc07b97a")
+			(uuid "0eed9c1b-08e8-4532-a952-a05a01041265")
 		)
 		(fp_line
 			(start 2.3 1.15)
@@ -12223,7 +12292,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "01950590-0f5a-4e6c-a649-477fbc0bf401")
+			(uuid "1db57547-b2e9-43d1-a2c9-6e299a83499c")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -12233,7 +12302,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "de0f7803-f29d-4977-b546-2ebbb5b85d02")
+			(uuid "a2fe4416-83e3-496b-910e-a44958d6bd24")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -12243,7 +12312,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8793ab04-a809-4c6d-a8ef-4976d14cdffc")
+			(uuid "3921d7a0-cfc8-409a-8d42-7a1c9cca0301")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -12253,7 +12322,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e64cff2f-a8a6-453f-89fe-3ed51efd5b4a")
+			(uuid "ae6254e1-89d1-49d1-898e-28b6d414b7b9")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -12263,12 +12332,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2ecdd6c5-fc4e-41b8-90f8-2eced4c0cfaf")
+			(uuid "c364cd72-9f1b-4064-a83a-1b6ba93302d3")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "6d424f88-cfa5-4126-a6cc-771c7e372fb2")
+			(uuid "9946f329-5bb9-4865-a2e1-acd88068a07a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -12283,7 +12352,7 @@
 			(roundrect_rratio 0.217391)
 			(net 2 "+5V")
 			(pintype "passive")
-			(uuid "1f911ecb-6d32-451d-87d2-35beed786c16")
+			(uuid "588c86ae-5506-4db9-8fe9-0adfecfa595b")
 		)
 		(pad "2" smd roundrect
 			(at 1.475 0)
@@ -12292,7 +12361,7 @@
 			(roundrect_rratio 0.217391)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "6f26c179-7e30-4f1a-9aa2-9c451631f4de")
+			(uuid "e08185c9-bac8-4c88-99e7-061c9947f922")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_1206_3216Metric.wrl"
 			(offset
@@ -12315,7 +12384,7 @@
 		(property "Reference" "C31"
 			(at -2.2875 -0.05 180)
 			(layer "F.SilkS")
-			(uuid "2a924a13-b663-4b58-89ce-eb9a21a950ea")
+			(uuid "62cbe2b0-13e6-4384-baf0-d9cb7954a231")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -12327,7 +12396,7 @@
 			(at 0 1.16 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e4f75fdc-c764-4b2f-a391-f21e6518a1c4")
+			(uuid "d5b1b1c9-39b4-40e1-9641-af88fd5632c9")
 			(effects
 				(font
 					(size 1 1)
@@ -12340,7 +12409,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "87e93028-2ab6-43d9-8db6-7b71ecd21ee6")
+			(uuid "a2378d0b-a699-4f89-b277-610c1091b532")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12353,7 +12422,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7a188f7a-de9c-43d4-b4c3-b7eee8b83adb")
+			(uuid "ec6e37da-1d5c-4c2f-9c21-44bd02b6976d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12366,7 +12435,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d5a082f2-a9ca-4536-981b-51991b4210eb")
+			(uuid "63114156-92af-46fa-9fd7-c21ef0a205cf")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12400,7 +12469,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "51193abb-1d15-4fd7-8b02-d0a973578fdd")
+			(uuid "b2427c4b-6c71-4a2a-8a18-2d30f144f167")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -12410,7 +12479,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8e247a51-b42b-4281-91c3-3a435f49f906")
+			(uuid "5cea4d36-9dca-461d-82bb-f8c0381c4fa6")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -12420,7 +12489,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "558e74a4-6fb5-46ec-9fbf-934fc0d05b25")
+			(uuid "bcfaf1f7-1761-4ed4-be17-bb67b10587f2")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -12430,7 +12499,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "929cf149-34cd-476e-ad34-019eb303b241")
+			(uuid "18220801-32d7-4dc9-bb9c-86f19c9e7d8e")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -12440,7 +12509,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9be7b024-e15e-4d88-849d-31f271e55eca")
+			(uuid "0642a646-0c6d-41fb-8657-ecf3d495657f")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -12450,7 +12519,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b4502c6b-fb59-42fc-b84e-1b302b6c65c3")
+			(uuid "ba8745a3-873e-4ca0-9d4b-7c0532c0a027")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -12460,7 +12529,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a63c3ae1-7cbb-46cc-8345-399cedeaf567")
+			(uuid "55993d28-c4db-481f-a1fc-7fea82988ea8")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -12470,7 +12539,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a6ef1a29-efab-4d02-8ddf-b740bb380430")
+			(uuid "05ba4ad3-706e-4a93-95be-3f4d145c71e8")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -12480,7 +12549,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "afcfd398-753e-4a1b-8ed8-5401d645a523")
+			(uuid "229fea96-02b5-4bc9-88ac-c7da56379241")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -12490,12 +12559,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "182c6fa1-1a52-46da-9b4e-befb4ea5f237")
+			(uuid "ca179dc3-42c4-4075-9c91-f928334af413")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "c3277e9b-4ac8-460d-aa24-9dbaedf01deb")
+			(uuid "760d89bd-b60d-4590-96aa-d875a8227b10")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -12510,7 +12579,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "d1e34043-d69c-4d08-8387-e074f9653ba3")
+			(uuid "e58ff69d-5ab9-4e7c-8018-b32d678b8a4f")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -12519,7 +12588,7 @@
 			(roundrect_rratio 0.25)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "cf12c140-5650-4fd6-9a90-d55006fe402c")
+			(uuid "89000e07-c20b-4131-9730-1be9b03e1ce5")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -12542,7 +12611,7 @@
 		(property "Reference" "C33"
 			(at -3.125 -0.0125 90)
 			(layer "F.SilkS")
-			(uuid "95a145de-f521-4484-a474-ecf854c45aa4")
+			(uuid "de2c4325-26b9-4903-b7c3-94ff1a3c952d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -12554,7 +12623,7 @@
 			(at 0 1.68 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f7846a23-da2d-4fdf-b6a9-c7586c47c8f8")
+			(uuid "2472d4ba-325b-4d58-93df-b4c680104e91")
 			(effects
 				(font
 					(size 1 1)
@@ -12567,7 +12636,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "52af2e74-ec71-4a8f-9251-221354479f73")
+			(uuid "81a17bc1-b48e-46cf-8d94-66692244cdde")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12580,7 +12649,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bfa5e64c-d43b-49b2-8348-30c14ba1d302")
+			(uuid "72c38b83-7108-416a-92f6-53a34fedf099")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12593,7 +12662,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b7f6b6b0-809e-4a42-8de4-8f8191b1fd26")
+			(uuid "e4d9da93-5322-4aba-ae7b-835eb0df9957")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12627,7 +12696,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fc5ffd5f-60eb-42cd-a733-8ef67dc5ce60")
+			(uuid "fe4a2bd8-18ba-4729-a7e3-dd403c077d99")
 		)
 		(fp_line
 			(start -0.261252 0.735)
@@ -12637,7 +12706,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "db43fd91-4b51-40aa-931d-964ffb1ae499")
+			(uuid "5a3f556a-3652-4c98-8230-8bc8c04290f6")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -12647,7 +12716,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "aaa7d3b0-dcda-4c3d-869d-b82fcf3639e6")
+			(uuid "9079a326-611b-485f-b566-e31464eee8f6")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -12657,7 +12726,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1b68d14d-affe-4fa5-bd9d-490d3246a65d")
+			(uuid "18f64759-cfb9-4249-b4e3-c2afef0d2a24")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -12667,7 +12736,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "93c56092-a8da-4ecc-9e22-878e03ce8bb6")
+			(uuid "2baa5774-d3b1-40df-9452-5c6b3e06b45c")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -12677,7 +12746,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "405334f1-ab63-4b6c-ac53-48e0c18a86ef")
+			(uuid "e89bb0ad-f940-48ff-9eb9-cbb15d367e9e")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -12687,7 +12756,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ae98e55f-716a-43c6-afd4-94c757df4eaf")
+			(uuid "82e00811-3b7c-43e7-8ebc-c700df76c5ec")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -12697,7 +12766,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d3d7805c-288d-4c88-a3e1-06eff8dd8c6a")
+			(uuid "29baef83-6e8a-489b-99c0-ed78b4c7f5db")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -12707,7 +12776,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0c153284-258d-439b-a91f-7041bad02e48")
+			(uuid "9bc54e29-a128-4c42-9bba-abf369b66605")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -12717,12 +12786,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2d2ac0ca-6d8d-4ea7-a3d6-8ff483185259")
+			(uuid "f1aa3983-0213-4a83-b855-bcb1a20cbce6")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "edb49d3d-689c-45ac-b88a-bfb099f3f915")
+			(uuid "d25b1cfe-7001-4b09-9e44-9c39006a429b")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -12737,7 +12806,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "214c449d-3fcf-447f-9710-80370e1086f0")
+			(uuid "4a7e9ffa-e9b0-485e-8ee8-30609b788faa")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 90)
@@ -12746,7 +12815,7 @@
 			(roundrect_rratio 0.25)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "2a986d91-8abe-436f-aed3-b0c0414ae180")
+			(uuid "852ae192-e685-47cb-8a59-0e5060204a1e")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -12769,7 +12838,7 @@
 		(property "Reference" "C28"
 			(at -2.3 0 180)
 			(layer "F.SilkS")
-			(uuid "fc12a7f4-6d9d-4724-9e4a-7e3c4437a28e")
+			(uuid "09bd3b06-cca8-4da8-ba53-d581f73b10fa")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -12781,7 +12850,7 @@
 			(at 0 1.16 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8203336f-52c2-4da8-9245-b06146fc35cd")
+			(uuid "585a7edd-8d35-4886-bba1-714abe679719")
 			(effects
 				(font
 					(size 1 1)
@@ -12794,7 +12863,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "efec91ad-4b2c-48bd-ab34-3514249f01e2")
+			(uuid "4ef682b8-f38c-4def-80b2-5e802924402d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12807,7 +12876,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c66bcb80-f38d-4281-9df9-52fc6c7a08f3")
+			(uuid "c3302117-3075-4cda-85cf-2970be3c99b8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12820,7 +12889,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c180956b-b65c-4e6c-bef2-99d1789641df")
+			(uuid "2a029964-1cbe-43c7-8785-9c20f266a087")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -12854,7 +12923,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1f47fb4e-ae52-4954-9779-d0ae39bd75af")
+			(uuid "574dd337-f03c-41fd-9973-6cdb9950322e")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -12864,7 +12933,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8e0a8f43-54b8-4bf0-bd70-32fe37d28551")
+			(uuid "626ab2a5-cf5c-4aca-99e3-117f57d58707")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -12874,7 +12943,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6fa03fd1-34fd-4313-8008-c4dd661571f9")
+			(uuid "0e16d3b5-1386-4419-aad7-57613034c22d")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -12884,7 +12953,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d7cacf8a-80ed-448e-a008-11ad14edf863")
+			(uuid "9103e460-0def-4064-ade2-42a1c0d569b2")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -12894,7 +12963,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e89de903-c30a-44d7-ba0e-1b20b34d4e0e")
+			(uuid "b457150c-0bac-4da4-8f48-bc9eda1ba654")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -12904,7 +12973,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c52af4c5-70dc-41b4-ac2a-afe76b79ba56")
+			(uuid "68c47eaf-e987-49e9-8dff-d75dc3936440")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -12914,7 +12983,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "57896e02-7ea7-4129-ab3b-0a481f6835fc")
+			(uuid "1f3b85f4-7d25-46b7-af09-a7e38b2663a7")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -12924,7 +12993,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c0b709c3-14f6-4232-a2e6-b164151870a2")
+			(uuid "fe1286fc-3a30-4838-af69-4d148418f061")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -12934,7 +13003,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "18e06a27-9a28-4af2-b049-b81802f57310")
+			(uuid "d3472e44-5277-4873-84fd-81e00b9dac9f")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -12944,12 +13013,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "206cd733-16be-4673-8ff0-955c62237c93")
+			(uuid "4b7fc90b-05e2-45b0-ab88-23df7c4e4317")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "2524882b-ca29-43e7-b360-054222d8c09e")
+			(uuid "6998061e-8ddc-4765-b55a-fd1fc62829b8")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -12964,7 +13033,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "f6da6644-f495-4391-9b31-9e0954138c8d")
+			(uuid "e7212613-a740-4e60-a2c0-eb76efa5ab00")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -12973,7 +13042,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "ee3ec9ac-8292-4482-84ff-8059c84f6dad")
+			(uuid "20c67efb-9e91-4aa8-b30f-71a46fee793d")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -12996,7 +13065,7 @@
 		(property "Reference" "C12"
 			(at 3 0 0)
 			(layer "F.SilkS")
-			(uuid "6d3e3d7a-16c2-4891-bb4d-a868467d09ec")
+			(uuid "8f1608e2-9aee-4ec9-a276-d1d2ef525a60")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -13008,7 +13077,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b9553337-6015-4d3c-82c4-b5fa8e33af1d")
+			(uuid "73770018-f018-4e8a-8c10-341b1d097d85")
 			(effects
 				(font
 					(size 1 1)
@@ -13021,7 +13090,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b9a80e6d-d9bc-484b-8750-51f6b69dec5b")
+			(uuid "92a9365a-a128-429c-acb9-efd0fd507eda")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13034,7 +13103,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "590afa1f-de5a-4400-9e4d-617e4ce98624")
+			(uuid "5b6323b2-375b-4e85-8966-f1451213df5b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13047,7 +13116,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "12e2c91e-e492-4b09-b585-624623403da1")
+			(uuid "df4ad814-584f-4e06-8752-56953a6042f0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13068,7 +13137,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e835587a-d89f-40a4-94de-f849d02c94a5")
+			(uuid "c141f7ef-ed76-451f-99a9-7d2ea51ac09e")
 		)
 		(fp_line
 			(start -0.14058 0.51)
@@ -13078,7 +13147,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a236943b-ca20-4257-a8a5-2a9798025c59")
+			(uuid "2785e616-c9f0-42a6-b9d1-81794a650e0b")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -13088,7 +13157,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fe38dd1e-f0f6-4118-acff-ea4b1f06de80")
+			(uuid "8a6b3043-10ec-4c0f-9343-1b442a05f71e")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -13098,7 +13167,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9ddc3c10-f662-4ca8-b270-81763acee742")
+			(uuid "e4e5cfaf-2777-4123-8025-9e2214cc4213")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -13108,7 +13177,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "410810ac-2480-41f7-9b08-7893f3142490")
+			(uuid "417bc33d-122f-4fae-b8db-8eabe309ebba")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -13118,7 +13187,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ca933f7e-64bc-4c1e-b2cb-d16724b70439")
+			(uuid "b71d043c-9956-4133-a572-f7eabc530c3a")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -13128,7 +13197,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6c984bc0-ab15-48d8-b74c-712e1ae22d72")
+			(uuid "f9c0c892-a6ff-4754-bb22-783dc074e49e")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -13138,7 +13207,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7a73ab5b-1284-4b95-94e2-fbcd6cf59243")
+			(uuid "26c0fda0-e5bb-4529-9847-ff1bcc34a4da")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -13148,7 +13217,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5eabbb55-dbf0-4b8d-afb7-863e15e99d81")
+			(uuid "2ba929b0-f2c7-467b-bffb-07c64ebd184f")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -13158,12 +13227,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e044e53b-f3e5-4046-a89d-3dfada651936")
+			(uuid "35f897a6-0d15-4c47-8871-d69d4f949f34")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "2f3450c1-cbc4-422e-8159-088b9091ab65")
+			(uuid "fa3aaa86-1def-4915-8478-66b8f6fe7467")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -13178,7 +13247,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "1a03eeef-d725-413b-a2f0-1b9c62f9d345")
+			(uuid "896ef0a3-0145-423a-92a2-63d29358f96a")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0)
@@ -13187,7 +13256,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "7eae0094-ea4f-4c83-8283-acb4b19d9e31")
+			(uuid "65b14ffe-c023-49b9-b0fe-77bbbb83ffc1")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -13210,7 +13279,7 @@
 		(property "Reference" "C3"
 			(at 0 -1 0)
 			(layer "F.SilkS")
-			(uuid "21d035a4-b5c5-41c1-8f75-065a4f328dd7")
+			(uuid "ca45e702-a537-4113-ae81-1bb149016fe7")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -13222,7 +13291,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "11147d25-e08d-4ba6-bb85-b60c841a0b86")
+			(uuid "7be6aed6-f3d9-4fc2-9bf4-2e4602df8f13")
 			(effects
 				(font
 					(size 1 1)
@@ -13235,7 +13304,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d98e9bd6-4273-4052-8dcc-a90adba1d0f5")
+			(uuid "2c8313f5-c457-41eb-96fb-c196b9e24ed9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13248,7 +13317,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5cb54af4-5ec0-4fa3-b771-acbd5ef6cc04")
+			(uuid "f616aa56-dd63-4d5d-887a-9de7b45bd966")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13261,7 +13330,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "97987cd9-e6d1-40d6-b7e8-e76ebb2f0a30")
+			(uuid "22b2803c-8dcd-4720-98ac-a212bb2d643d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13294,7 +13363,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b89f6b23-345b-4366-a9a8-9a2de37d0c9a")
+			(uuid "98f73d03-43b7-4a24-a70a-639f6f2cbb83")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -13304,7 +13373,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1bbc6542-471b-4b1b-8695-7079eb738a33")
+			(uuid "a8f3a306-2baf-4484-915e-f7c76108493b")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -13314,7 +13383,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1bb2cc83-12c2-4e8f-9720-9f49d7aadd1e")
+			(uuid "d70669d5-b739-480c-b55a-0c942f2ec4df")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -13324,7 +13393,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b9a5a439-0844-4771-8e51-f1bf7feed2b3")
+			(uuid "71363a6e-fec3-4dee-9697-28f05d3e21fa")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -13334,7 +13403,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "280fd7ef-a769-4eaf-92d2-7535256e3511")
+			(uuid "eac116c7-8ce6-4259-9137-cb28baa08cf9")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -13344,7 +13413,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "afb843a2-3b21-4bd2-9f43-fb0afb45558d")
+			(uuid "3b240905-a2be-4588-8f9d-8b67c7a04d38")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -13354,7 +13423,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "1e0caf80-f712-422d-9824-cca227c5ffa5")
+			(uuid "dfa688be-0aa4-4c9f-b9a3-c23dd995664d")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -13364,7 +13433,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2e63e582-a529-4cac-abb1-2661f36c102d")
+			(uuid "3f90bcee-35e5-47f7-a92d-6a8415a0d5ed")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -13374,7 +13443,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e62b5ec8-632e-4b59-9c47-a5a67063597d")
+			(uuid "1ba6a338-f7c5-4a50-bf1d-88c41f08ff8a")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -13384,12 +13453,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f922bae3-349f-450f-9e2c-bf0ba787098e")
+			(uuid "190fe7e3-f0c0-4ef1-b6f7-71cbaff24e22")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "81da6d9f-e845-42ee-9e2c-f39310af44a7")
+			(uuid "6bdad98d-994c-4575-8892-1ff00b1aa586")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -13404,7 +13473,7 @@
 			(roundrect_rratio 0.25)
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pintype "passive")
-			(uuid "686e9469-1c6e-4437-bcc4-3996f67dc51b")
+			(uuid "4fba072d-b87d-417f-8b15-1b7240ba7240")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0)
@@ -13413,7 +13482,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "f61e76c1-037f-4f11-83db-472c413b09c4")
+			(uuid "b84f2fdb-bea9-4e00-81b1-091ad3b051da")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -13436,7 +13505,7 @@
 		(property "Reference" "R29"
 			(at -2.14 -0.29 -90)
 			(layer "F.SilkS")
-			(uuid "48b0d913-c5d7-4668-8c40-9db45c6dfa64")
+			(uuid "f1e67c89-7959-4a8b-a7c0-2263cf51097b")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -13448,7 +13517,7 @@
 			(at 0 1.17 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5ad6873b-c83d-42e5-ad9a-33039da85f0a")
+			(uuid "ab131a0a-75ab-4975-bf75-5ff8a9fe7279")
 			(effects
 				(font
 					(size 1 1)
@@ -13461,7 +13530,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5da2d537-ad32-4b09-a4e3-d6692cd9818f")
+			(uuid "1923952e-892b-436d-a6f6-3d6c3510a383")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13474,7 +13543,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bf5493f3-2705-4899-9928-624f9139f5cc")
+			(uuid "48fbf1c3-433b-45c2-a4a0-cf991f90190c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13487,7 +13556,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3e5bb9df-becf-4264-8b9a-bdf485dfb862")
+			(uuid "4d914ca0-9761-42aa-bda8-7c2112ebf258")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13508,7 +13577,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "aa00bcfb-fef5-4bdf-83dc-810f22e52bb1")
+			(uuid "3fe82209-91e6-4fb9-802b-bbfff3c006d6")
 		)
 		(fp_line
 			(start -0.153641 -0.38)
@@ -13518,7 +13587,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5de5cf3d-5753-448d-b213-357e8fcc71e8")
+			(uuid "8a9b2e9f-7526-4f20-ae37-198d926744c9")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -13528,7 +13597,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c0ec223b-3d78-47a7-b44f-5884b0238372")
+			(uuid "e1aaf737-a756-4c62-a085-858a9b807d08")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -13538,7 +13607,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "bce27330-a261-4215-80ae-dc0a0b7e3a93")
+			(uuid "3d0ebccc-0498-4022-89ee-b7e9d185eb6b")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -13548,7 +13617,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d1baf2fa-202e-4389-8f84-2c4b292d77d7")
+			(uuid "0adb3cf3-d91a-4030-935e-33360d8c28eb")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -13558,7 +13627,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3b4293a7-733f-413c-a0c1-6f25d3238e58")
+			(uuid "b033a6ad-0b26-48b7-916e-d7fd9f6a8c68")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -13568,7 +13637,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "94537b6f-5505-4187-a374-ff98da1f1c1b")
+			(uuid "5dbde531-0068-4cc7-98af-7ae091b14d24")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -13578,7 +13647,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9349daf7-65c7-4a28-b2fd-f4a11202d8f3")
+			(uuid "f950f8a2-0bad-439e-83a7-9683dae3340c")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -13588,7 +13657,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "745af3b2-9ece-4449-940b-9ed8fc729678")
+			(uuid "ad01c330-d8fa-424d-9ca7-eb1bf9e07ba0")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -13598,12 +13667,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5b3caef4-a402-48e4-b061-f4c3d806a836")
+			(uuid "195bfb1e-9bfc-4b04-a790-8da312f3d531")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "6d7a06cf-b1db-486b-bc58-4de9c3c9720d")
+			(uuid "8126f9fa-312f-4e2a-8c72-ff2372a25bc9")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -13618,7 +13687,7 @@
 			(roundrect_rratio 0.25)
 			(net 85 "/MCU/UART0_RX")
 			(pintype "passive")
-			(uuid "a5be1a6f-e426-42b7-a635-dd40d6aaebc2")
+			(uuid "dd2753d1-6cc4-4f81-8788-0e231f843faa")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0 270)
@@ -13627,7 +13696,7 @@
 			(roundrect_rratio 0.25)
 			(net 92 "Net-(U2-GPIO1)")
 			(pintype "passive")
-			(uuid "5a118794-2d67-40d3-b22a-dc23ac9963a6")
+			(uuid "2ec1b83a-7bdd-4829-83e5-a546a158276f")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -13650,7 +13719,7 @@
 		(property "Reference" "R19"
 			(at 0 -1.25 180)
 			(layer "F.SilkS")
-			(uuid "58926dc5-8b6c-4c0c-8324-9eaf1c0c6c7d")
+			(uuid "20bfb018-2363-46b7-b30b-0b5afb8d6d1c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -13662,7 +13731,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5e72ff5f-6501-4f1d-8a6c-52388db0eb67")
+			(uuid "f54cd686-fb85-49f3-aed6-4b3552f4c709")
 			(effects
 				(font
 					(size 1 1)
@@ -13675,7 +13744,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c7eb0658-a248-4dbc-a44c-0f631d4c7dac")
+			(uuid "f13dc44b-babd-4502-8a2f-8e6d33361f14")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13688,7 +13757,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ae9d0980-39c3-4083-b34e-8335ef37ea18")
+			(uuid "441d694c-89bf-4c75-b8e1-ea2a8e9bcd2f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13701,7 +13770,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ee079f05-3c0f-4ca3-bc4d-f9ff5ab4b5d9")
+			(uuid "5b7a3e7d-6c8d-47b8-abfb-ac1370000308")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13735,7 +13804,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ba41934c-552f-46c7-9d3a-476de84ea076")
+			(uuid "cce06fa8-50cc-4a1c-b9fd-954ebf7f387c")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -13745,7 +13814,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a55b5023-dc69-456a-b0ba-510862db57b1")
+			(uuid "be408c2e-1ae4-4972-b261-f4eabe011458")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -13755,7 +13824,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "57adb478-f578-4f79-bd62-e094c60e1153")
+			(uuid "455cf7cb-7f08-4bf5-9cf6-1e06f83317ad")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -13765,7 +13834,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c7d1d427-2794-4924-abbd-ada62259ee7d")
+			(uuid "711671b3-5f7b-4359-8aca-9eb5367f7105")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -13775,7 +13844,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "75854710-a555-45e6-b862-4ad7d33cb0c7")
+			(uuid "93d19e20-a2d9-4aff-b2d6-e28bb828318d")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -13785,7 +13854,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "514534f6-1f95-4db7-bdbe-53678e257cc2")
+			(uuid "9d7cda67-862c-4a1d-be2a-00459120d68f")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -13795,7 +13864,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "139f8fee-e9b4-4bf4-ae6d-84bae352b519")
+			(uuid "90412165-59ba-491f-bde2-b23ac8a6d2ce")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -13805,7 +13874,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "49ee8493-d18f-4126-ac59-afdaa0ac29fa")
+			(uuid "37950fb8-022e-4107-b71d-5a37761978ae")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -13815,7 +13884,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f1512d3a-b5b7-4054-b622-90721a6ce563")
+			(uuid "b1d03d49-6a6c-439c-96c1-4566b9866875")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -13825,12 +13894,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4c5d30cc-6cee-4d3c-8839-2319fd907ed3")
+			(uuid "463be20f-7761-4ac5-a300-3618dc6d04a9")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "b417503a-e69d-4ed2-a758-e06aa87f8453")
+			(uuid "0382e5bd-9679-4530-bea3-dfff7481606c")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -13845,7 +13914,7 @@
 			(roundrect_rratio 0.25)
 			(net 14 "Net-(U7-VCC)")
 			(pintype "passive")
-			(uuid "64f8f6ca-2fb1-43cb-8947-f064ffbd1919")
+			(uuid "5bfa0b8c-e95f-4fb7-97ee-29d85022cce7")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 180)
@@ -13854,7 +13923,7 @@
 			(roundrect_rratio 0.25)
 			(net 15 "/Motor Driver/TMC_{5V}")
 			(pintype "passive")
-			(uuid "84d5b540-baa9-4c15-869f-b0f68be9d9df")
+			(uuid "1af76f73-85b2-43e1-abe0-ed7e5ccf4bad")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -13877,7 +13946,7 @@
 		(property "Reference" "R12"
 			(at -3 0 180)
 			(layer "F.SilkS")
-			(uuid "4722ba1e-50c8-4b39-a11b-98fe588f5d07")
+			(uuid "af54aeb6-e6f3-455f-bfe1-b4801fdd05af")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -13889,7 +13958,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d8da6c02-4bd9-42fc-835f-da340dd6208c")
+			(uuid "4c4eaa30-6169-453d-8f05-85f20621e6f9")
 			(effects
 				(font
 					(size 1 1)
@@ -13902,7 +13971,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a3616f72-38c6-4dce-9ad7-98f4fe5ba534")
+			(uuid "e29105ff-3e81-441e-8730-b96a7b6ce4d3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13915,7 +13984,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "368e2c17-b872-4882-bdf4-d5ba258ac755")
+			(uuid "13eb4df9-68a6-43d1-98d0-4c0160d95988")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13928,7 +13997,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "554bc691-785e-4763-a0fd-ed1f815c8657")
+			(uuid "321ea977-55b6-4133-8b2d-cbe5c1f016d4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -13962,7 +14031,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4687e957-7875-4659-8b76-a2d22a59673e")
+			(uuid "bb6f042f-59e4-4357-a73a-43aafdda1241")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -13972,7 +14041,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2caa6c69-e85b-4a71-8c52-df7117aabeb5")
+			(uuid "68fa3825-bb54-4ab9-ae5c-0c083db3543c")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -13982,7 +14051,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "43605f52-8637-48fc-b316-d1b1955238e9")
+			(uuid "9fbb1332-9690-415b-ad0e-90a1284f7394")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -13992,7 +14061,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e9d0f0c8-a5a4-4f28-9d47-67b8a2cfa31a")
+			(uuid "2a6dad0a-ab59-49ef-b5bf-d748048caba0")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -14002,7 +14071,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d0732e69-6df2-444f-8447-92899859281d")
+			(uuid "1f1fa2d4-7e3c-4380-a777-9c9a736fbb5d")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -14012,7 +14081,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1bbd4bd4-baaa-4915-9318-16d05b42364a")
+			(uuid "bdc55cb5-519c-4216-97e4-2024f7000bb7")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -14022,7 +14091,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e9b9a9ec-851e-4d03-96f8-f3c83a0691b7")
+			(uuid "800adfa5-7b4b-49cc-b900-559daa1bdcca")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -14032,7 +14101,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f52f2063-ecb1-4e28-9e7b-fa1c599443b2")
+			(uuid "4d5f7f5e-95b1-4c54-94b7-de6d12d0b6b2")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -14042,7 +14111,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "cafed2fb-e3c8-42c2-98d0-23e3f35b8682")
+			(uuid "f228bded-594f-4bfa-96ad-c0adad43dcc3")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -14052,12 +14121,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "955d8a56-a0e2-4ba3-a887-7fa883010df3")
+			(uuid "528d041e-e67c-4f83-bf05-1aab284ab141")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "8368fd6f-06a3-44e2-b377-c1e67301cd6d")
+			(uuid "c250be0e-0d50-4fd6-8500-96eae213cd8e")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -14072,7 +14141,7 @@
 			(roundrect_rratio 0.25)
 			(net 36 "Net-(U5-ADJ)")
 			(pintype "passive")
-			(uuid "c174275e-ddfe-4c9a-8048-4c3a80c6aa23")
+			(uuid "c1afc0ea-a60f-457d-839f-4ae320fb7083")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -14081,7 +14150,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "9477e366-d040-454a-ad8d-d23852c95153")
+			(uuid "291252be-62d8-4e3f-a5f1-2872247596d2")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -14099,12 +14168,12 @@
 		(layer "F.Cu")
 		(uuid "a1ec657f-3f45-49f9-bb99-743778cf6b27")
 		(at 137.3 67.7 90)
-		(descr "SOT, 5 Pin (https://www.jedec.org/sites/default/files/docs/Mo-178c.PDF variant AA), generated with kicad-footprint-generator ipc_gullwing_generator.py")
+		(descr "SOT, 5 Pin (JEDEC MO-178 Var AA https://www.jedec.org/document_search?search_api_views_fulltext=MO-178), generated with kicad-footprint-generator ipc_gullwing_generator.py")
 		(tags "SOT TO_SOT_SMD")
 		(property "Reference" "U9"
 			(at 0 2.7 90)
 			(layer "F.SilkS")
-			(uuid "6099c30a-720e-4fb9-b19a-5407540e95f6")
+			(uuid "f40f6baf-4395-4129-9585-3f0ad13d4be4")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -14116,7 +14185,7 @@
 			(at 0 2.4 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3590440b-4f00-496f-9c99-4f9b5770f509")
+			(uuid "ba122ef0-1d2b-4c41-9366-04d11f7425dc")
 			(effects
 				(font
 					(size 1 1)
@@ -14129,7 +14198,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b0234e49-9a7c-4138-935d-66ca333a1230")
+			(uuid "e2b9290c-eb4d-4e35-9430-efd65c235252")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14142,7 +14211,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e33d46fe-a131-4d7a-a873-5f9ce9abab16")
+			(uuid "0820048f-07eb-4b52-b60c-42bcdfe0df1e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14155,7 +14224,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bfe60097-bac5-4150-8049-3a01d6dd87fe")
+			(uuid "dcea1dc5-9ee0-47cc-a5f4-8cd984c32c21")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14176,7 +14245,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d953ce2e-8ec3-4b2a-a320-d7ec805c5f21")
+			(uuid "303dad0f-8c1f-4ef5-8eb6-a5b8566559df")
 		)
 		(fp_line
 			(start 0 -1.56)
@@ -14186,7 +14255,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ab740534-14bb-4c41-900f-9b373d77fba0")
+			(uuid "a940cca7-bbc5-4d52-b345-f6ec4af0597d")
 		)
 		(fp_line
 			(start 0 1.56)
@@ -14196,7 +14265,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5994be02-0e78-4015-b083-ca646ac17aa9")
+			(uuid "3a12def9-4da3-4786-a197-be1d80e59e3c")
 		)
 		(fp_line
 			(start 0 1.56)
@@ -14206,7 +14275,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4d10c57f-9d75-4b7b-ac69-29a9ac85d837")
+			(uuid "dfae7327-4774-4dbe-999a-6734d281a874")
 		)
 		(fp_poly
 			(pts
@@ -14218,7 +14287,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "f40cdd94-2412-4fdd-bb70-2cebb58f64fc")
+			(uuid "425371e8-5242-418b-9742-36c4cca828b1")
 		)
 		(fp_line
 			(start 2.05 -1.7)
@@ -14228,7 +14297,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1f9f3008-0989-4be4-b794-4e814baf4e57")
+			(uuid "669ac204-c0d6-4e7c-be31-e02671d5eed1")
 		)
 		(fp_line
 			(start -2.05 -1.7)
@@ -14238,7 +14307,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f95e929b-62f3-4256-a173-be6d0dc7a370")
+			(uuid "8985c822-fc45-407f-aa57-b06f4f170fda")
 		)
 		(fp_line
 			(start 2.05 1.7)
@@ -14248,7 +14317,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c35c531c-5afe-4cd8-bfab-591cb5e27722")
+			(uuid "fa631c8a-5419-47ab-9335-ae05930498f7")
 		)
 		(fp_line
 			(start -2.05 1.7)
@@ -14258,7 +14327,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "52d5e83d-a0ac-4c26-ae85-22e5d7a5785d")
+			(uuid "c4f24e3f-d55e-480d-9b39-234d370f4a67")
 		)
 		(fp_line
 			(start 0.8 -1.45)
@@ -14268,7 +14337,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4d9731d9-b1ef-4b3c-97a5-cf91b3a22090")
+			(uuid "a8e7c2c4-2e11-4bce-a96e-95c43195c951")
 		)
 		(fp_line
 			(start -0.4 -1.45)
@@ -14278,7 +14347,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "80055388-7ccd-443f-9fc2-74d2eee17890")
+			(uuid "b653ac2b-6106-4eab-bc09-f7573cab8f51")
 		)
 		(fp_line
 			(start -0.8 -1.05)
@@ -14288,7 +14357,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4197bbdf-b91f-4e46-93af-9a5a5ccce27d")
+			(uuid "84eebaa5-1e71-45a5-a72e-1b9a11273cea")
 		)
 		(fp_line
 			(start 0.8 1.45)
@@ -14298,7 +14367,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b71c1be7-2117-48ff-a5c2-77e18f8557e4")
+			(uuid "40c654ec-177c-4413-be98-c3e5bea35948")
 		)
 		(fp_line
 			(start -0.8 1.45)
@@ -14308,12 +14377,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7b11deca-66ad-415c-9df4-1e8e74427679")
+			(uuid "f4d16500-2e64-4f0b-b00c-c4c702d0485d")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "36e77bda-e63d-4179-8416-ac46e9042571")
+			(uuid "ca679dee-cded-4641-bb6a-fdd8d3597290")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -14329,7 +14398,7 @@
 			(net 9 "VBUS")
 			(pinfunction "VIN")
 			(pintype "power_in")
-			(uuid "17c64377-03f6-467f-a57b-7d2e53c41c64")
+			(uuid "60106a85-d0de-4ca1-ac45-5f1a6f802233")
 		)
 		(pad "2" smd roundrect
 			(at -1.1375 0 90)
@@ -14339,7 +14408,7 @@
 			(net 1 "GND")
 			(pinfunction "GND")
 			(pintype "power_in")
-			(uuid "4a188142-c82b-4819-8c6e-f8b3a369afee")
+			(uuid "96b9e4ed-d6b4-44a3-a6d3-785be8269d2a")
 		)
 		(pad "3" smd roundrect
 			(at -1.1375 0.95 90)
@@ -14349,7 +14418,7 @@
 			(net 9 "VBUS")
 			(pinfunction "EN")
 			(pintype "input")
-			(uuid "ddc3c514-3afe-4f93-9fae-2eabe2d3e286")
+			(uuid "cc86a179-402b-4a6c-8ea3-57651a766d81")
 		)
 		(pad "4" smd roundrect
 			(at 1.1375 0.95 90)
@@ -14359,7 +14428,7 @@
 			(net 7 "unconnected-(U9-NC-Pad4)")
 			(pinfunction "NC")
 			(pintype "no_connect")
-			(uuid "3fb8da05-ab98-4f8d-9a17-ee18caf03213")
+			(uuid "252d52a8-9abd-496d-92b4-a282f9ab185f")
 		)
 		(pad "5" smd roundrect
 			(at 1.1375 -0.95 90)
@@ -14369,7 +14438,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VOUT")
 			(pintype "power_out")
-			(uuid "437745ac-e1c0-458a-a3c9-cd3695757234")
+			(uuid "45815975-18d8-4ae6-b5ea-fcf4b9a7c6d9")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_TO_SOT_SMD.3dshapes/SOT-23-5.wrl"
 			(offset
@@ -14392,7 +14461,7 @@
 		(property "Reference" "R25"
 			(at 0 1.2 90)
 			(layer "F.SilkS")
-			(uuid "5f63ee40-6166-449a-afba-b2ff0e859677")
+			(uuid "8d66dab3-8948-463c-86aa-fe51ce3ad1d7")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -14404,7 +14473,7 @@
 			(at 0 1.43 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ed2b3493-24ca-435e-bd8b-0bf5a5baddb0")
+			(uuid "7efc4619-7215-4bd5-b878-cdc7a33845d1")
 			(effects
 				(font
 					(size 1 1)
@@ -14417,7 +14486,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "73d621de-ab25-4628-b843-dfe9570d8ba1")
+			(uuid "12684793-30bd-4746-9dfe-51cca575bc96")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14430,7 +14499,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9928f8bb-e77b-43f1-b3e6-fd56f48ae433")
+			(uuid "61629c70-2681-45d8-8db0-686bb2865d7e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14443,7 +14512,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2e3c6192-473f-4ca1-9348-c6db0d1f8232")
+			(uuid "d89dcff9-fcb6-4b6a-89ab-5bdcd79132a3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14464,7 +14533,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2b84194b-e69e-4c18-b861-545745a838e2")
+			(uuid "7418363f-64b4-4406-96ab-d544c9e9d3a1")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -14474,7 +14543,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5c0d5390-6b91-41dc-bf2e-9affee3522df")
+			(uuid "de5f4a1b-cf2f-4136-98ef-459b576bd120")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -14484,7 +14553,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9ed547e2-5491-42d1-a768-b69105b1ff90")
+			(uuid "e6b17f6a-988e-4aa7-a288-55d30075c175")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -14494,7 +14563,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4fa80fd1-5976-4989-afa6-e0ec1f47422d")
+			(uuid "4f149fb2-1ced-46bc-b0b4-7fed21e3f0da")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -14504,7 +14573,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3e8267c8-7b1a-494f-8a2e-b7b86eef82fe")
+			(uuid "cbdb098e-329b-45a4-81fd-84bbdb0f1941")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -14514,7 +14583,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0cabb983-bed6-43a1-b52d-9756ce467ace")
+			(uuid "422b486c-e3cc-42af-aa73-5a869043b578")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -14524,7 +14593,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a312972e-eb64-49be-8585-b5007e1b1d81")
+			(uuid "f06b33b6-aeff-41c7-909f-feebbdc282fb")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -14534,7 +14603,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c3dc94c0-b186-46fb-97da-2c6697c83b85")
+			(uuid "7afd06b5-652e-4253-baf0-f407b3f392f0")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -14544,7 +14613,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9d3a483f-af80-48e6-a3b0-fff2fa58df4b")
+			(uuid "93f92947-8e38-4f22-8818-3963f1cd28dc")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -14554,12 +14623,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e3472b84-ff33-4871-94f9-7d5f84b08629")
+			(uuid "8b06debe-e474-4680-82a2-9c0e4702eb58")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "1b499596-236d-485c-be8b-6cef9d689f04")
+			(uuid "8dd65841-3332-4a47-b151-eb2fbc3f68ed")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -14574,7 +14643,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "aa9aa0d9-e8f8-4db0-8f06-292af9779e65")
+			(uuid "bf04056b-0998-45f1-a0db-e32251e1ac3a")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -14583,7 +14652,7 @@
 			(roundrect_rratio 0.25)
 			(net 69 "/MCU/ALERT#")
 			(pintype "passive")
-			(uuid "85666596-af47-41ab-9f08-db2c2d179e81")
+			(uuid "4b75024b-94c2-4cb7-8ce1-52add1fe0890")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -14606,7 +14675,7 @@
 		(property "Reference" "C20"
 			(at 0 -1.85 90)
 			(layer "F.SilkS")
-			(uuid "4e65fb02-1717-4d88-91e9-68168c3e671f")
+			(uuid "6a0bd68d-a8f2-44ff-983f-bf8aa839565a")
 			(effects
 				(font
 					(size 1 1)
@@ -14618,7 +14687,7 @@
 			(at 0 1.85 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dd4eb1d1-2d2e-4980-8c9b-81d051e1a43f")
+			(uuid "859d116e-2a9e-42b7-bd42-feb7374524b9")
 			(effects
 				(font
 					(size 1 1)
@@ -14631,7 +14700,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b1bb1171-d1e7-4725-863d-fac65a1eb0e2")
+			(uuid "a258133a-f62d-4862-be47-02be48f8953b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14644,7 +14713,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9fd2785d-dd1e-4183-9918-50bdcbf8d092")
+			(uuid "57a4e002-d817-4c79-8bff-fdb64fe49321")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14657,7 +14726,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "321ddf6c-7f60-4519-96a7-be909e8fb5fc")
+			(uuid "9435d70c-d73e-4c68-b46c-ba65556ebdab")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14678,7 +14747,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e741afd6-e558-4cf1-81dc-4becda4df5c3")
+			(uuid "d6e1b9bb-634d-4724-83b6-e32048e12102")
 		)
 		(fp_line
 			(start -0.711252 0.91)
@@ -14688,7 +14757,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "19ada329-c73d-4cb0-b066-62658e06b533")
+			(uuid "5606dbfe-59dd-40e1-8e95-55345e96c5e3")
 		)
 		(fp_line
 			(start 2.3 -1.15)
@@ -14698,7 +14767,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "dfe448af-c48e-480b-8110-320027e1b668")
+			(uuid "e402f2e9-ed62-427d-9052-6bfb4aa23485")
 		)
 		(fp_line
 			(start -2.3 -1.15)
@@ -14708,7 +14777,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "743017ec-2d6e-42bf-8bb9-1cfd13d4ed9c")
+			(uuid "9c059fe8-f009-452c-869d-b3d9e01239fc")
 		)
 		(fp_line
 			(start 2.3 1.15)
@@ -14718,7 +14787,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3fe80bc2-832d-4c72-84c0-34b995266370")
+			(uuid "ddc76569-5817-42b6-b85d-2eb765a816aa")
 		)
 		(fp_line
 			(start -2.3 1.15)
@@ -14728,7 +14797,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4eb76f09-9d2c-4398-800e-fb922b33c347")
+			(uuid "498c8dd1-b337-4e5d-9021-636e343e7955")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -14738,7 +14807,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "36a52bd6-c7f0-403a-99b8-5da054a1b9b0")
+			(uuid "8bcae264-5e31-48cf-8c0a-648e73b15b82")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -14748,7 +14817,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "48eaf801-250d-40bf-9a63-72a5160338b0")
+			(uuid "a5849aaa-2a5f-4b7f-85ee-659898a7b03e")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -14758,7 +14827,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "60176fd5-9480-4de3-81d7-338bd1677a1d")
+			(uuid "b5754cd7-3ad7-41de-a05b-4542d6f6bd98")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -14768,12 +14837,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ec6a2de5-bb50-43b4-a858-8050a0bb3c1b")
+			(uuid "eeec39ab-4604-4e93-b7f7-ef088e3fe766")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "e587b69e-88a0-4c72-bbe8-969783475d03")
+			(uuid "8cf6108a-1aaf-4ad4-947d-410130bb7e21")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -14788,7 +14857,7 @@
 			(roundrect_rratio 0.217391)
 			(net 2 "+5V")
 			(pintype "passive")
-			(uuid "8ca85a83-0d7e-4f6d-b36b-0109b6b5903b")
+			(uuid "736c3600-0842-4542-864e-0bb49d99744e")
 		)
 		(pad "2" smd roundrect
 			(at 1.475 0 90)
@@ -14797,7 +14866,7 @@
 			(roundrect_rratio 0.217391)
 			(net 12 "Net-(U6-VMID)")
 			(pintype "passive")
-			(uuid "c9f5fdbc-c146-440d-a86e-26ab8b55738c")
+			(uuid "6e59f9b0-a25a-41fc-b9a1-e486f06d3b0b")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_1206_3216Metric.wrl"
 			(offset
@@ -14822,7 +14891,7 @@
 			(at 0 -3.25 0)
 			(layer "F.SilkS")
 			(hide yes)
-			(uuid "cc4e8ddd-fddb-4fd1-bb9f-0ec1513c6843")
+			(uuid "a6b0d87d-410d-4306-8877-62b61d265a2e")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -14834,7 +14903,7 @@
 			(at 0 3.25 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e12353d0-a8e1-4c44-81c3-4e2fbf006031")
+			(uuid "00cb3a30-452d-43ae-8f44-db1130dd2eec")
 			(effects
 				(font
 					(size 1 1)
@@ -14847,7 +14916,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b8f0db3b-fe57-41a4-9fc9-1b869a03cb87")
+			(uuid "8ab781c2-2163-400d-a513-285ff3da81b1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14860,7 +14929,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4c83a19b-dba4-4f16-98cb-08e2cf8e9442")
+			(uuid "239bb6ee-3856-47df-9b73-f0437d1e057c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14873,7 +14942,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4f326e65-cd54-43c8-9d98-baa3a7f8323f")
+			(uuid "d4f7b932-2490-4c82-80a5-5acb46707965")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14895,7 +14964,7 @@
 			)
 			(fill none)
 			(layer "Cmts.User")
-			(uuid "4284d6b5-5c6f-4467-8b81-5e9959cf3d94")
+			(uuid "1556bba3-9cfd-41e9-90fa-77e43296eff4")
 		)
 		(fp_circle
 			(center 0 0)
@@ -14906,13 +14975,13 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "62b92c20-5a62-4fbe-95b9-f73fadd6d953")
+			(uuid "31aaf9a2-012e-49e6-bbf5-d206d49a101c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "85026a89-ae0f-457a-8e63-829a73eb521f")
+			(uuid "50aa297c-8688-436b-8cc2-5578d9c82bd4")
 			(effects
 				(font
 					(size 1 1)
@@ -14925,7 +14994,7 @@
 			(size 2.7 2.7)
 			(drill 2.7)
 			(layers "*.Cu" "*.Mask")
-			(uuid "050d9838-02d5-46ca-8f82-df67d5380348")
+			(uuid "64ee1a45-335d-4417-b227-044cad256fea")
 		)
 	)
 	(footprint "Resistor_SMD:R_0402_1005Metric"
@@ -14937,7 +15006,7 @@
 		(property "Reference" "R26"
 			(at -1.5 -1.1 -90)
 			(layer "F.SilkS")
-			(uuid "89beaadf-16b0-4034-abce-9d3a8c756f27")
+			(uuid "76215fd9-e82f-403b-8555-348b36c08a12")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -14949,7 +15018,7 @@
 			(at 0 1.17 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5d116130-aa57-48ee-86d3-b0db006cf1bf")
+			(uuid "7d25388a-aeac-4dfc-a83f-be40ec6ba9d2")
 			(effects
 				(font
 					(size 1 1)
@@ -14962,7 +15031,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a1e2ae05-5486-4a1a-b8e0-08bb260f0456")
+			(uuid "12a4453f-7720-4157-a87c-e2eb748b0b7c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14975,7 +15044,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c902caf0-c4fa-4db9-9528-a269c4420ca3")
+			(uuid "792433e6-0035-4e9e-87a3-41d73b9824cd")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -14988,7 +15057,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1484ba00-c722-4a11-b182-10c76249828e")
+			(uuid "67c53a6c-5da6-49bb-967e-e3ede9d23b70")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15009,7 +15078,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "76d28006-9b1b-44a3-a018-dd7e9e89d887")
+			(uuid "ee12ff2f-7a0e-4905-959c-c3e6d9602db7")
 		)
 		(fp_line
 			(start -0.153641 0.38)
@@ -15019,7 +15088,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1c52bdb0-6be6-4f58-9cb3-f6ca963561e2")
+			(uuid "fdcf2720-25c5-44bb-ab58-278f43c55f43")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -15029,7 +15098,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "cf8024b1-90db-4635-a95f-13b28a596b26")
+			(uuid "08852e60-e04d-4f02-bedf-c8f67ba229a3")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -15039,7 +15108,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8aea3235-be28-4ad8-b289-ec5ddbcc6b2d")
+			(uuid "31ec0386-fe49-4506-8d9a-67a23ef2330d")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -15049,7 +15118,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "51364963-7ad8-4c0a-b71d-926d668f19a4")
+			(uuid "790822b4-3361-4c93-a449-b0cc5a010987")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -15059,7 +15128,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "45a0c883-43ae-474f-b0df-37957fd0a9a3")
+			(uuid "99ed1503-b620-4c73-a6e1-7c5102344eac")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -15069,7 +15138,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6bdc2747-68e2-43d7-b171-56123fed843d")
+			(uuid "f18b2ef5-915a-4d81-ba40-103e5d24be62")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -15079,7 +15148,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e38fc748-c411-4658-943a-16c9a68c8117")
+			(uuid "3828023b-4d7f-4d62-8402-7e870220c4ce")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -15089,7 +15158,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8ec07082-2667-4202-9d24-d8622c111fe3")
+			(uuid "cf248f56-2b66-4022-a22d-fd51a437dbf6")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -15099,12 +15168,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e650b366-9f88-48f4-937b-fe6c1922ff3d")
+			(uuid "3a8039e1-3f8c-44f7-bf56-4aa8bebb4031")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "99b3eab1-d02c-4bf6-86be-2a7c546887f0")
+			(uuid "78548fc2-3d4e-47c5-b224-9bdde3ea544f")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -15119,7 +15188,7 @@
 			(roundrect_rratio 0.25)
 			(net 19 "Net-(J1-Pin_4)")
 			(pintype "passive")
-			(uuid "e61e1bed-085d-4076-815a-66f97ee14d6b")
+			(uuid "f6cc3ddc-c147-4a71-9a52-85bc07ffe373")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0 90)
@@ -15128,7 +15197,7 @@
 			(roundrect_rratio 0.25)
 			(net 89 "Net-(U2-SWCLK)")
 			(pintype "passive")
-			(uuid "d31c1c60-f7b0-470c-ab11-2ad84b6ace27")
+			(uuid "23254525-b40a-4805-9ffc-147ad205dab6")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -15151,7 +15220,7 @@
 		(property "Reference" "U2"
 			(at -3.6 -5 0)
 			(layer "F.SilkS")
-			(uuid "37fbd78a-5329-4df3-9791-6692f8a466f5")
+			(uuid "33eb4213-38b0-42bf-9a50-7accae6f7004")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -15163,7 +15232,7 @@
 			(at 0 4.83 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "da9030f7-b6e8-4dac-b43e-6df215746ec6")
+			(uuid "151f1ebe-9a10-4572-9957-67640cc9afc0")
 			(effects
 				(font
 					(size 1 1)
@@ -15176,7 +15245,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4f02870f-7912-42fd-81aa-8beacae01dea")
+			(uuid "5b5d73f0-7058-4c15-871c-4eb7b79b66a0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15189,7 +15258,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "085cdf6e-2e7d-4f9e-a240-6376bb821358")
+			(uuid "b5468c5c-f4fd-488a-ab2c-31815b2d9c6d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15202,7 +15271,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f8d74fdf-b1bc-4669-b581-1329f74b35c2")
+			(uuid "c70c2112-1789-4f00-8559-90e66a96053e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -15223,7 +15292,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e4382ee8-05b5-42b6-8cf1-6b08a608a7eb")
+			(uuid "681e07d2-0f06-48a6-b7cb-a13129761a1a")
 		)
 		(fp_line
 			(start -2.96 3.61)
@@ -15233,7 +15302,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "819d52bf-b441-4522-92fa-245aa7551cf4")
+			(uuid "dab38872-1973-4df2-8b6a-85ad587ef42a")
 		)
 		(fp_line
 			(start 2.96 3.61)
@@ -15243,7 +15312,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c2971cec-ad2f-4acd-9950-4b493530eef1")
+			(uuid "6538cb56-b817-4f21-997a-125b3530ca2b")
 		)
 		(fp_line
 			(start 3.61 3.61)
@@ -15253,7 +15322,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8230039a-0e18-4ab8-9ea1-7695d2b0248d")
+			(uuid "7bce715e-177b-49fa-be58-b22bc89e642c")
 		)
 		(fp_line
 			(start -3.61 -2.96)
@@ -15263,7 +15332,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "682e2533-62e5-40df-805a-72a530ba3dd6")
+			(uuid "e862e14c-6376-45fe-8f42-e9a314b80881")
 		)
 		(fp_line
 			(start -2.96 -3.61)
@@ -15273,7 +15342,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "7d3c5d2a-6657-45e9-a962-c0aaba42032c")
+			(uuid "c4969e74-8d9b-465b-b717-11d5df8c9e86")
 		)
 		(fp_line
 			(start 2.96 -3.61)
@@ -15283,7 +15352,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "962a02e0-c0de-43e8-a10c-2360ae8b70c4")
+			(uuid "9cb25a80-082a-4e75-8e08-f05237f3ddd2")
 		)
 		(fp_line
 			(start 3.61 -3.61)
@@ -15293,7 +15362,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "fc0db893-d6a3-4118-9a49-3f8f211619dc")
+			(uuid "cbfe399b-4c3e-4556-b1a7-5b4bfbf32841")
 		)
 		(fp_poly
 			(pts
@@ -15305,7 +15374,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "3908aed2-cea2-436b-805d-e103ed29aa2b")
+			(uuid "9e335e30-266d-4265-937f-581c289221c4")
 		)
 		(fp_line
 			(start -4.13 4.13)
@@ -15315,7 +15384,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "52720f08-e78f-4137-b239-bfad69d0d77b")
+			(uuid "9fdef42c-51e7-4180-8da7-df3caa15ae19")
 		)
 		(fp_line
 			(start 4.13 4.13)
@@ -15325,7 +15394,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "024e1d70-0022-4b94-8961-cda7b423e753")
+			(uuid "a7bff3d3-660f-4be0-8132-7d7ce581e848")
 		)
 		(fp_line
 			(start -4.13 -4.13)
@@ -15335,7 +15404,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f3925aa8-b62e-4330-a69c-c33eb631717c")
+			(uuid "8e38d0c1-3a6b-4ec7-b5a8-cee6d0d478c9")
 		)
 		(fp_line
 			(start 4.13 -4.13)
@@ -15345,7 +15414,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c5977c34-6671-46e8-ad53-11207e24dcc3")
+			(uuid "cd803f4a-7157-4f8d-96de-c346142109e1")
 		)
 		(fp_line
 			(start -3.5 3.5)
@@ -15355,7 +15424,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4d9b918e-551a-4bb5-b844-0d04421810f8")
+			(uuid "29d269b6-4f54-4151-a194-bf4799ac64f3")
 		)
 		(fp_line
 			(start 3.5 3.5)
@@ -15365,7 +15434,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e555f167-47ff-421a-84fd-5a93ff3bf6c5")
+			(uuid "65b9a082-7044-41ee-a974-0bf9320035b0")
 		)
 		(fp_line
 			(start -3.5 -2.5)
@@ -15375,7 +15444,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0074ef1d-bc65-4a14-97bb-645c4027de4a")
+			(uuid "9aadaf44-63dd-4692-9524-5117706c4e3b")
 		)
 		(fp_line
 			(start -2.5 -3.5)
@@ -15385,7 +15454,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "55ee4cdf-b93b-4a44-a757-f8dde6f927c2")
+			(uuid "e02f2d57-d64f-42d1-a338-3d0151112049")
 		)
 		(fp_line
 			(start 3.5 -3.5)
@@ -15395,12 +15464,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d8a05c51-17f1-4383-84f6-b513f5af8853")
+			(uuid "ac1ca0ed-ba57-4d61-8ded-c39ac0d806ea")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "10463b47-1782-4744-96fe-0e5437d0b43c")
+			(uuid "f6385170-6f52-41f5-a30c-26b7abda989e")
 			(effects
 				(font
 					(size 1 1)
@@ -15413,28 +15482,28 @@
 			(size 1.29 1.29)
 			(layers "F.Paste")
 			(roundrect_rratio 0.193798)
-			(uuid "dc97c8fa-4c02-4f0e-b580-1e0403ff540d")
+			(uuid "faf3eab7-21c1-47e9-ae6f-5fa92540a3b0")
 		)
 		(pad "" smd roundrect
 			(at -0.8 0.8 270)
 			(size 1.29 1.29)
 			(layers "F.Paste")
 			(roundrect_rratio 0.193798)
-			(uuid "ec2652ed-a439-46a0-850c-47dd66e3b8ea")
+			(uuid "142fbf40-d746-4c93-881f-15c52a768976")
 		)
 		(pad "" smd roundrect
 			(at 0.8 -0.8 270)
 			(size 1.29 1.29)
 			(layers "F.Paste")
 			(roundrect_rratio 0.193798)
-			(uuid "1646cc05-7763-4a3d-a3e4-cfe2fe4c1e6b")
+			(uuid "4292fe96-6f3b-459b-b054-fbe322ed3418")
 		)
 		(pad "" smd roundrect
 			(at 0.8 0.8 270)
 			(size 1.29 1.29)
 			(layers "F.Paste")
 			(roundrect_rratio 0.193798)
-			(uuid "98331fe6-bf23-408d-94ea-5bf501814b61")
+			(uuid "cce6e283-f6a5-46a4-b806-62d64f3ea0e0")
 		)
 		(pad "1" smd roundrect
 			(at -3.4375 -2.6 270)
@@ -15444,7 +15513,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "power_in")
-			(uuid "dbde5377-29dc-4294-b9c4-11e91d2bfbbe")
+			(uuid "354e361a-7f5f-42fc-8e12-8e8228c07135")
 		)
 		(pad "2" smd roundrect
 			(at -3.4375 -2.2 270)
@@ -15454,7 +15523,7 @@
 			(net 91 "Net-(U2-GPIO0)")
 			(pinfunction "GPIO0")
 			(pintype "bidirectional")
-			(uuid "fc2d39bd-a40e-4460-84ab-22513471d43e")
+			(uuid "3cd82621-4797-4e71-890d-27ad064dcbd4")
 		)
 		(pad "3" smd roundrect
 			(at -3.4375 -1.8 270)
@@ -15464,7 +15533,7 @@
 			(net 92 "Net-(U2-GPIO1)")
 			(pinfunction "GPIO1")
 			(pintype "bidirectional")
-			(uuid "3ca0a296-6cba-4ca9-acc8-2e2a4a4e5fa6")
+			(uuid "d4074e81-ea47-4e07-ae76-0ba93c20d84f")
 		)
 		(pad "4" smd roundrect
 			(at -3.4375 -1.4 270)
@@ -15474,7 +15543,7 @@
 			(net 29 "/MCU/SDA")
 			(pinfunction "GPIO2")
 			(pintype "bidirectional")
-			(uuid "da7b4f0e-39ff-4e49-8bc8-98a0e0aefbf4")
+			(uuid "453d9b81-baf6-42a0-a751-027422d02e5f")
 		)
 		(pad "5" smd roundrect
 			(at -3.4375 -1 270)
@@ -15484,7 +15553,7 @@
 			(net 28 "/MCU/SCL")
 			(pinfunction "GPIO3")
 			(pintype "bidirectional")
-			(uuid "cf5134a7-6486-4a17-811d-2ef289503246")
+			(uuid "8a912d13-76dd-45c3-a2cf-2754f036059b")
 		)
 		(pad "6" smd roundrect
 			(at -3.4375 -0.6 270)
@@ -15494,7 +15563,7 @@
 			(net 46 "/MCU/IS31_{EN}")
 			(pinfunction "GPIO4")
 			(pintype "bidirectional")
-			(uuid "32575a25-90d9-4d6a-92b5-44041cee2df5")
+			(uuid "587a4135-a258-427c-876e-f0c427f6ebe3")
 		)
 		(pad "7" smd roundrect
 			(at -3.4375 -0.2 270)
@@ -15504,7 +15573,7 @@
 			(net 45 "/MCU/IS31_{BM}")
 			(pinfunction "GPIO5")
 			(pintype "bidirectional")
-			(uuid "fe7e4c18-325d-4e18-9242-c4992596c22d")
+			(uuid "54d93a93-2e58-43f7-873b-23602afe9323")
 		)
 		(pad "8" smd roundrect
 			(at -3.4375 0.2 270)
@@ -15514,7 +15583,7 @@
 			(net 63 "unconnected-(U2-GPIO6-Pad8)")
 			(pinfunction "GPIO6")
 			(pintype "bidirectional+no_connect")
-			(uuid "c44c7aa5-6427-4440-b4fd-9660be2f2a51")
+			(uuid "c46a8da6-ab20-44b3-bb3f-708b011e2d20")
 		)
 		(pad "9" smd roundrect
 			(at -3.4375 0.6 270)
@@ -15524,7 +15593,7 @@
 			(net 58 "unconnected-(U2-GPIO7-Pad9)")
 			(pinfunction "GPIO7")
 			(pintype "bidirectional+no_connect")
-			(uuid "7a4524d0-0c11-4611-a147-1f1583c239fd")
+			(uuid "1bbc11a4-ddba-496f-afd8-256e9a20998f")
 		)
 		(pad "10" smd roundrect
 			(at -3.4375 1 270)
@@ -15534,7 +15603,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "passive")
-			(uuid "dff4e4c0-c6d5-401f-b81a-8ca03782d049")
+			(uuid "44187a7c-cd96-4075-b9db-7595b408cd65")
 		)
 		(pad "11" smd roundrect
 			(at -3.4375 1.4 270)
@@ -15544,7 +15613,7 @@
 			(net 65 "unconnected-(U2-GPIO8-Pad11)")
 			(pinfunction "GPIO8")
 			(pintype "bidirectional+no_connect")
-			(uuid "bcbd2ec7-4b5a-40f1-93c4-eecb144b098e")
+			(uuid "7fd951f0-623d-4b14-9f27-fae888209372")
 		)
 		(pad "12" smd roundrect
 			(at -3.4375 1.8 270)
@@ -15554,7 +15623,7 @@
 			(net 61 "unconnected-(U2-GPIO9-Pad12)")
 			(pinfunction "GPIO9")
 			(pintype "bidirectional+no_connect")
-			(uuid "deb839b0-d80e-4e66-804e-0995f13465a1")
+			(uuid "eca6d58a-2f9d-494d-b75e-87015be531ab")
 		)
 		(pad "13" smd roundrect
 			(at -3.4375 2.2 270)
@@ -15564,7 +15633,7 @@
 			(net 67 "unconnected-(U2-GPIO10-Pad13)")
 			(pinfunction "GPIO10")
 			(pintype "bidirectional+no_connect")
-			(uuid "0eee978d-81ed-428d-b2de-d070f281d1a5")
+			(uuid "de612163-4156-4441-8bdb-eddfaabb51c6")
 		)
 		(pad "14" smd roundrect
 			(at -3.4375 2.6 270)
@@ -15574,7 +15643,7 @@
 			(net 69 "/MCU/ALERT#")
 			(pinfunction "GPIO11")
 			(pintype "bidirectional")
-			(uuid "c82db834-cf30-42a7-be59-c3247b90a594")
+			(uuid "e59be642-0fce-4fbe-8cb6-bf9a20bbf498")
 		)
 		(pad "15" smd roundrect
 			(at -2.6 3.4375 270)
@@ -15584,7 +15653,7 @@
 			(net 87 "unconnected-(U2-GPIO12-Pad15)")
 			(pinfunction "GPIO12")
 			(pintype "bidirectional+no_connect")
-			(uuid "2f6c8a0d-dbff-41d2-9c9d-e324d96bec07")
+			(uuid "f3d60643-4f48-46d3-a290-9bd8f73efbce")
 		)
 		(pad "16" smd roundrect
 			(at -2.2 3.4375 270)
@@ -15594,7 +15663,7 @@
 			(net 88 "unconnected-(U2-GPIO13-Pad16)")
 			(pinfunction "GPIO13")
 			(pintype "bidirectional+no_connect")
-			(uuid "a151de9a-1e97-4bda-9bce-0529f1e3975e")
+			(uuid "33618d53-6315-4f7d-9289-0cc1593bc4d1")
 		)
 		(pad "17" smd roundrect
 			(at -1.8 3.4375 270)
@@ -15604,7 +15673,7 @@
 			(net 83 "unconnected-(U2-GPIO14-Pad17)")
 			(pinfunction "GPIO14")
 			(pintype "bidirectional+no_connect")
-			(uuid "a5ec01b5-0d9f-4f93-8618-f270e10d5ba5")
+			(uuid "3462db77-8ceb-403c-95cf-8b853f9a85cc")
 		)
 		(pad "18" smd roundrect
 			(at -1.4 3.4375 270)
@@ -15614,7 +15683,7 @@
 			(net 84 "unconnected-(U2-GPIO15-Pad18)")
 			(pinfunction "GPIO15")
 			(pintype "bidirectional+no_connect")
-			(uuid "a8551bd5-581e-458c-9796-745dd0e18b8d")
+			(uuid "ab09832c-4681-4750-aae9-edcc44869e62")
 		)
 		(pad "19" smd roundrect
 			(at -1 3.4375 270)
@@ -15624,7 +15693,7 @@
 			(net 1 "GND")
 			(pinfunction "TESTEN")
 			(pintype "input")
-			(uuid "3ae7a751-ba61-412b-ba5f-c5407e8f411e")
+			(uuid "eed86ee6-1d13-46ef-be31-2996642fe95c")
 		)
 		(pad "20" smd roundrect
 			(at -0.6 3.4375 270)
@@ -15634,7 +15703,7 @@
 			(net 10 "Net-(U2-XIN)")
 			(pinfunction "XIN")
 			(pintype "input")
-			(uuid "3a6980ee-091a-4ec0-b350-c8f4c95a82f1")
+			(uuid "7e79d426-7567-4032-b2ce-722013ae6fb0")
 		)
 		(pad "21" smd roundrect
 			(at -0.2 3.4375 270)
@@ -15644,7 +15713,7 @@
 			(net 33 "Net-(U2-XOUT)")
 			(pinfunction "XOUT")
 			(pintype "passive")
-			(uuid "623c4be2-48e5-4119-a5ad-7c0c23ea1273")
+			(uuid "3acc7725-963c-4fcb-94bf-0428506321f0")
 		)
 		(pad "22" smd roundrect
 			(at 0.2 3.4375 270)
@@ -15654,7 +15723,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "passive")
-			(uuid "375d205e-3ed6-41b5-bad4-c778845537c5")
+			(uuid "d8ce6feb-003c-48cf-bfec-b40e8e134553")
 		)
 		(pad "23" smd roundrect
 			(at 0.6 3.4375 270)
@@ -15664,7 +15733,7 @@
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pinfunction "DVDD")
 			(pintype "power_in")
-			(uuid "acce9a59-482a-41e7-be4b-28d588917aac")
+			(uuid "5dcbac84-fdaf-4ac0-b14f-634fcca73a2e")
 		)
 		(pad "24" smd roundrect
 			(at 1 3.4375 270)
@@ -15674,7 +15743,7 @@
 			(net 89 "Net-(U2-SWCLK)")
 			(pinfunction "SWCLK")
 			(pintype "input")
-			(uuid "91ac19b9-f8b3-4fe9-9a4d-84b8b3276030")
+			(uuid "a96a0deb-3169-4eac-8747-cb5e98a916aa")
 		)
 		(pad "25" smd roundrect
 			(at 1.4 3.4375 270)
@@ -15684,7 +15753,7 @@
 			(net 90 "Net-(U2-SWD)")
 			(pinfunction "SWD")
 			(pintype "bidirectional")
-			(uuid "89852207-ae86-456a-95b3-94270fe59f31")
+			(uuid "680b0297-56bb-4a34-b4c1-7675ce2449f1")
 		)
 		(pad "26" smd roundrect
 			(at 1.8 3.4375 270)
@@ -15694,7 +15763,7 @@
 			(net 20 "/MCU/~{RESET}")
 			(pinfunction "RUN")
 			(pintype "input")
-			(uuid "9b655bb0-fa33-40fa-966d-cc30f300d1c5")
+			(uuid "44cde2d6-edd9-4ba4-a858-2e30db11b489")
 		)
 		(pad "27" smd roundrect
 			(at 2.2 3.4375 270)
@@ -15704,7 +15773,7 @@
 			(net 59 "unconnected-(U2-GPIO16-Pad27)")
 			(pinfunction "GPIO16")
 			(pintype "bidirectional+no_connect")
-			(uuid "2b24049e-a63b-46ca-99d6-799840d45154")
+			(uuid "b8d5363b-b849-4878-8c6b-0256130c1118")
 		)
 		(pad "28" smd roundrect
 			(at 2.6 3.4375 270)
@@ -15714,7 +15783,7 @@
 			(net 68 "/MCU/TMC_{~{EN}}")
 			(pinfunction "GPIO17")
 			(pintype "bidirectional")
-			(uuid "5a3f6375-e51b-499a-8c83-45fbddcb447b")
+			(uuid "78e515b5-7d4d-4e9c-a774-76760818f95f")
 		)
 		(pad "29" smd roundrect
 			(at 3.4375 2.6 270)
@@ -15724,7 +15793,7 @@
 			(net 66 "/MCU/TMC_{DIR}")
 			(pinfunction "GPIO18")
 			(pintype "bidirectional")
-			(uuid "b2987cbf-b9b5-4494-82eb-5e1f93bda226")
+			(uuid "fffb99b3-4475-4a92-9ab9-566884bf928a")
 		)
 		(pad "30" smd roundrect
 			(at 3.4375 2.2 270)
@@ -15734,7 +15803,7 @@
 			(net 56 "/MCU/TMC_{STEP}")
 			(pinfunction "GPIO19")
 			(pintype "bidirectional")
-			(uuid "b8ec5e29-16cc-455a-a430-56bf1879a200")
+			(uuid "910355da-3610-41e9-98ca-b19c2b734a42")
 		)
 		(pad "31" smd roundrect
 			(at 3.4375 1.8 270)
@@ -15744,7 +15813,7 @@
 			(net 70 "/MCU/MISO")
 			(pinfunction "GPIO20")
 			(pintype "bidirectional")
-			(uuid "78966d10-18eb-4971-a5ce-2864f67874f3")
+			(uuid "463043a2-ce26-43b5-be9f-8b93e1c99c40")
 		)
 		(pad "32" smd roundrect
 			(at 3.4375 1.4 270)
@@ -15754,7 +15823,7 @@
 			(net 55 "/MCU/TMC_{~{CS}}")
 			(pinfunction "GPIO21")
 			(pintype "bidirectional")
-			(uuid "89249b7f-4874-4f06-af50-6c13e6ab89bd")
+			(uuid "e55cee24-b358-4a5e-940a-078efc0d6554")
 		)
 		(pad "33" smd roundrect
 			(at 3.4375 1 270)
@@ -15764,7 +15833,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "passive")
-			(uuid "f6967116-0b7d-4210-9862-6dbcff7ae629")
+			(uuid "2b78c7fd-527a-4973-a2ff-6aaf7cfef6cc")
 		)
 		(pad "34" smd roundrect
 			(at 3.4375 0.6 270)
@@ -15774,7 +15843,7 @@
 			(net 60 "/MCU/SCLK")
 			(pinfunction "GPIO22")
 			(pintype "bidirectional")
-			(uuid "e433da27-2b20-4d6c-81fe-c33cc35b5160")
+			(uuid "9d8e9f64-3f05-451e-a4b3-c3092aa15def")
 		)
 		(pad "35" smd roundrect
 			(at 3.4375 0.2 270)
@@ -15784,7 +15853,7 @@
 			(net 57 "/MCU/MOSI")
 			(pinfunction "GPIO23")
 			(pintype "bidirectional")
-			(uuid "034aeb93-2f42-4e1a-9c9e-b0c567b468e8")
+			(uuid "61c8b81f-6c19-4c71-adc2-f2acd7ae2910")
 		)
 		(pad "36" smd roundrect
 			(at 3.4375 -0.2 270)
@@ -15794,7 +15863,7 @@
 			(net 62 "unconnected-(U2-GPIO24-Pad36)")
 			(pinfunction "GPIO24")
 			(pintype "bidirectional+no_connect")
-			(uuid "c136d246-de47-4a05-a657-2fb0392603e8")
+			(uuid "c4a416d0-bd65-4c92-8a9b-7c48b1a7616b")
 		)
 		(pad "37" smd roundrect
 			(at 3.4375 -0.6 270)
@@ -15804,7 +15873,7 @@
 			(net 64 "unconnected-(U2-GPIO25-Pad37)")
 			(pinfunction "GPIO25")
 			(pintype "bidirectional+no_connect")
-			(uuid "adc62a0c-4f7a-4588-8677-b25175fd3a90")
+			(uuid "1e2913ba-417c-4964-9e26-0ca5d1c56807")
 		)
 		(pad "38" smd roundrect
 			(at 3.4375 -1 270)
@@ -15814,7 +15883,7 @@
 			(net 40 "/MCU/LTC44_{SEL}")
 			(pinfunction "GPIO26_ADC0")
 			(pintype "bidirectional")
-			(uuid "43a8702f-a91b-45f4-af9e-0bdac4059bfa")
+			(uuid "4dac2443-0d75-4ee6-a702-dcd4227a0fb4")
 		)
 		(pad "39" smd roundrect
 			(at 3.4375 -1.4 270)
@@ -15824,7 +15893,7 @@
 			(net 39 "/MCU/LTC44_{CURR}")
 			(pinfunction "GPIO27_ADC1")
 			(pintype "bidirectional")
-			(uuid "3a1e8e52-304e-4892-98fb-40cc44f4b96b")
+			(uuid "e47f1031-5c4a-4cff-9f4a-7385be30e7f7")
 		)
 		(pad "40" smd roundrect
 			(at 3.4375 -1.8 270)
@@ -15834,7 +15903,7 @@
 			(net 41 "/MCU/LTC44_{EN}")
 			(pinfunction "GPIO28_ADC2")
 			(pintype "bidirectional")
-			(uuid "0838a582-8c29-4a6d-9967-4773cedb969e")
+			(uuid "334e3eb7-637b-460b-9f56-a2105bf63f6b")
 		)
 		(pad "41" smd roundrect
 			(at 3.4375 -2.2 270)
@@ -15844,7 +15913,7 @@
 			(net 38 "/MCU/LTC44_{~{PFO}}")
 			(pinfunction "GPIO29_ADC3")
 			(pintype "bidirectional")
-			(uuid "db6e53ba-7316-4c10-95a1-ee1d1aa1b159")
+			(uuid "703910b9-d2bb-4921-959b-b5716784d8bc")
 		)
 		(pad "42" smd roundrect
 			(at 3.4375 -2.6 270)
@@ -15854,7 +15923,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "passive")
-			(uuid "1ea1daae-f14a-4c86-920f-4fe968114639")
+			(uuid "d1dde02f-8f5f-4414-844e-da20b0f340b0")
 		)
 		(pad "43" smd roundrect
 			(at 2.6 -3.4375 270)
@@ -15864,7 +15933,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "ADC_AVDD")
 			(pintype "power_in")
-			(uuid "44b165c1-4829-4ead-8029-d6e34823cb74")
+			(uuid "552c4982-0ca2-4691-a1ea-5f06d568018c")
 		)
 		(pad "44" smd roundrect
 			(at 2.2 -3.4375 270)
@@ -15874,7 +15943,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VREG_IN")
 			(pintype "power_in")
-			(uuid "8d194a50-ce55-4357-8b2b-3ef49774f1b7")
+			(uuid "4bc61a82-6a9a-4f4c-b89b-5dc8f2cdfd88")
 		)
 		(pad "45" smd roundrect
 			(at 1.8 -3.4375 270)
@@ -15884,7 +15953,7 @@
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pinfunction "VREG_VOUT")
 			(pintype "power_out")
-			(uuid "3c9b9928-e033-4b90-a676-084e81175069")
+			(uuid "49d5deee-9c07-479a-8987-b090a1ffba0b")
 		)
 		(pad "46" smd roundrect
 			(at 1.4 -3.4375 270)
@@ -15894,7 +15963,7 @@
 			(net 32 "Net-(U2-USB_DM)")
 			(pinfunction "USB_DM")
 			(pintype "bidirectional")
-			(uuid "3646bc86-1ce3-4adb-80fc-74fd474b34d7")
+			(uuid "94e5446c-b7b0-4164-909f-cd09a65c1f4a")
 		)
 		(pad "47" smd roundrect
 			(at 1 -3.4375 270)
@@ -15904,7 +15973,7 @@
 			(net 30 "Net-(U2-USB_DP)")
 			(pinfunction "USB_DP")
 			(pintype "bidirectional")
-			(uuid "155e092c-fe45-4e79-8cae-160d94e27a0d")
+			(uuid "55ee732d-b79d-4a0c-bb1a-aa6ea3476e85")
 		)
 		(pad "48" smd roundrect
 			(at 0.6 -3.4375 270)
@@ -15914,7 +15983,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "USB_VDD")
 			(pintype "power_in")
-			(uuid "5c215dc5-034a-4ee8-8dac-42f4311cb3b3")
+			(uuid "33ee3602-fde0-466d-881b-0f99d3c75f8d")
 		)
 		(pad "49" smd roundrect
 			(at 0.2 -3.4375 270)
@@ -15924,7 +15993,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "IOVDD")
 			(pintype "passive")
-			(uuid "ee0498df-8827-48b1-a644-acb4431d1130")
+			(uuid "e312748c-c323-428a-8b99-7e551f1319e4")
 		)
 		(pad "50" smd roundrect
 			(at -0.2 -3.4375 270)
@@ -15934,7 +16003,7 @@
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pinfunction "DVDD")
 			(pintype "passive")
-			(uuid "87add3c2-8c2c-4595-bbf2-be0096d8112b")
+			(uuid "11c508ca-126b-4c2c-94b9-4fb151476311")
 		)
 		(pad "51" smd roundrect
 			(at -0.6 -3.4375 270)
@@ -15944,7 +16013,7 @@
 			(net 51 "/MCU/QSPI_{D3}")
 			(pinfunction "QSPI_SD3")
 			(pintype "bidirectional")
-			(uuid "65cb7085-2c38-4797-9c8b-c394f8b1ab58")
+			(uuid "9a188c59-b296-48c4-8c2b-2155796e8067")
 		)
 		(pad "52" smd roundrect
 			(at -1 -3.4375 270)
@@ -15954,7 +16023,7 @@
 			(net 27 "/MCU/QSPI_{CLK}")
 			(pinfunction "QSPI_SCLK")
 			(pintype "output")
-			(uuid "feda9d2d-f989-43ec-b4c0-35e2a03fc695")
+			(uuid "46b93c55-e65b-4114-b0c1-ec26576655c9")
 		)
 		(pad "53" smd roundrect
 			(at -1.4 -3.4375 270)
@@ -15964,7 +16033,7 @@
 			(net 52 "/MCU/QSPI_{D0}")
 			(pinfunction "QSPI_SD0")
 			(pintype "bidirectional")
-			(uuid "8d9678b7-ec4e-4608-a43c-0174ce6f625c")
+			(uuid "2c49bf26-a90b-4a86-9ef2-ef47258e444a")
 		)
 		(pad "54" smd roundrect
 			(at -1.8 -3.4375 270)
@@ -15974,7 +16043,7 @@
 			(net 54 "/MCU/QSPI_{D2}")
 			(pinfunction "QSPI_SD2")
 			(pintype "bidirectional")
-			(uuid "e5fc5375-8f09-4264-8796-f90ee445c043")
+			(uuid "bc400bdb-7614-48f1-8d69-39e3bb20efe0")
 		)
 		(pad "55" smd roundrect
 			(at -2.2 -3.4375 270)
@@ -15984,7 +16053,7 @@
 			(net 53 "/MCU/QSPI_{D1}")
 			(pinfunction "QSPI_SD1")
 			(pintype "bidirectional")
-			(uuid "9727ae5e-3e34-418a-b936-3f0befab6574")
+			(uuid "df52290b-a97d-4945-a57d-9ab292e35c9b")
 		)
 		(pad "56" smd roundrect
 			(at -2.6 -3.4375 270)
@@ -15994,7 +16063,7 @@
 			(net 31 "/MCU/QSPI_{~{CS}}")
 			(pinfunction "QSPI_SS")
 			(pintype "bidirectional")
-			(uuid "28f798d6-3f04-49a9-9386-12382593f0d8")
+			(uuid "904f0876-deee-48f9-b474-2ac04e11aa92")
 		)
 		(pad "57" smd rect
 			(at 0 0 270)
@@ -16005,7 +16074,7 @@
 			(pinfunction "GND")
 			(pintype "power_in")
 			(zone_connect 2)
-			(uuid "223ac3c4-ec97-41d1-8c8d-2d41834b1caa")
+			(uuid "72a646cc-da82-41ec-a016-4f962346c84e")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/QFN-56-1EP_7x7mm_P0.4mm_EP3.2x3.2mm.wrl"
 			(offset
@@ -16028,7 +16097,7 @@
 		(property "Reference" "R3"
 			(at 0 1.4 -90)
 			(layer "F.SilkS")
-			(uuid "b7a3076d-783c-4350-9220-d04c664e8f49")
+			(uuid "1ba7b572-247f-4dd6-8995-2ecb77a4c1af")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16040,7 +16109,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d1bd6267-781c-4963-8361-2b12e297b3d9")
+			(uuid "d626349a-3c4a-4a55-9948-e78f6775cb31")
 			(effects
 				(font
 					(size 1 1)
@@ -16053,7 +16122,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "fdaf89cb-0574-457e-91b2-08aa16529745")
+			(uuid "c1ef451b-cf72-4931-9359-e58c9aa0241a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16066,7 +16135,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "64e98ec5-6c16-4bb8-a70d-340501886f02")
+			(uuid "5b3ace39-1958-444c-8631-ae4c3a68eb93")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16079,7 +16148,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "bff9973f-3be8-4eb4-a9ee-eebb944f9024")
+			(uuid "f6936901-6fc0-4865-8d06-a01683668152")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16100,7 +16169,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0362e854-71d4-4fbc-9802-efeaec03ca54")
+			(uuid "3f78d279-586c-4e1b-b3d6-00c4f5a828c1")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -16110,7 +16179,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c5d084ab-f2cf-44e2-9085-53ce26d8650e")
+			(uuid "e1eb08ff-09d7-41dd-b8b3-4bf58407d353")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -16120,7 +16189,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "da0b4371-df28-4e08-a921-c826f82e4087")
+			(uuid "be6e75d8-ac8e-4fa5-b669-4359e386fcdb")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -16130,7 +16199,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5fb027e1-298d-4b7f-b132-3e76b29009ea")
+			(uuid "26e2d706-5309-4ecd-a2a4-86e74ea13d38")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -16140,7 +16209,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f3699590-4656-4bbe-900d-437aa097b249")
+			(uuid "197be780-d393-4d2d-bd44-6fce2d28961a")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -16150,7 +16219,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3695aef6-9f35-4be1-8ade-e4d891c36349")
+			(uuid "5f502905-1d11-480b-a076-6ef6212b632c")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -16160,7 +16229,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "befba510-00dc-4436-a477-e5df50893aa1")
+			(uuid "aadafd2a-551f-44b4-a470-e51a60a16904")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -16170,7 +16239,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "aebb693d-0027-453c-aefb-a0d3384cdb47")
+			(uuid "659a4ce3-6bbd-46a0-aed3-04a68d772e43")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -16180,7 +16249,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "32b709b2-d969-4522-bc79-4a8140fc7665")
+			(uuid "6fd78f3b-86a7-405a-b401-98bf71d8e8ba")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -16190,12 +16259,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2bb3241b-c439-4744-9852-6d9c7826e30e")
+			(uuid "583b35c1-6fd9-4364-98f1-ed29267a94e0")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "ac06d5cb-ecc0-4e45-88c4-0f7f4f65562a")
+			(uuid "a017d79f-44d8-4680-b09d-385f200896c7")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -16210,7 +16279,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "86e4bd00-edae-4b3e-8d76-c050dd381b66")
+			(uuid "0a9713fc-2cef-4e4d-9ff5-7be86c7b7ed2")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 90)
@@ -16219,7 +16288,7 @@
 			(roundrect_rratio 0.25)
 			(net 20 "/MCU/~{RESET}")
 			(pintype "passive")
-			(uuid "69add1b5-2c49-4f9d-94a4-dbe2c5908394")
+			(uuid "f96d7af0-70df-4f09-ab03-a32fe6ba97ed")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -16242,7 +16311,7 @@
 		(property "Reference" "TP6"
 			(at -2.65 -1.65 0)
 			(layer "F.SilkS")
-			(uuid "8bfdc4dd-05ee-421f-8afe-0b91a59ec8c4")
+			(uuid "bd48fc40-bd08-4c6b-8099-bdb0238b67dc")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16254,7 +16323,7 @@
 			(at 0 2.05 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d8191e51-a2b4-4d2f-acf9-3162983245ce")
+			(uuid "569cfa04-22c0-4a3a-99c1-7e02d057409a")
 			(effects
 				(font
 					(size 1 1)
@@ -16267,7 +16336,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b3b8d4b4-7c8b-49f9-a6a5-85312467c2c4")
+			(uuid "b6d78b92-bccc-4806-8023-8e95ea5d8ff1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16280,7 +16349,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "77cce4b2-5efc-4f08-9a38-65d99c705ea4")
+			(uuid "f1e8f876-c406-4c6e-a0c6-d58f02ed3f2f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16293,7 +16362,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dd28635f-a232-45db-9fe9-20b5f74300bc")
+			(uuid "9d56672c-720c-4082-a8a8-ce7482a843cd")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16315,7 +16384,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "69b1b7ec-cb92-4f81-ab0c-aef214232956")
+			(uuid "49a81533-a56e-4141-80b1-c7981556a0eb")
 		)
 		(fp_circle
 			(center 0 0)
@@ -16326,7 +16395,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "e43e3ac0-214f-4131-a9a7-10ef162db6f3")
+			(uuid "b909c76e-3bd1-48e8-b14d-7d07b7a7aa66")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 0)
+			(layer "F.Fab")
+			(uuid "9471bb9d-7b3b-4fcd-b7d7-bdbb34e6e9d0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0)
@@ -16335,7 +16415,7 @@
 			(net 1 "GND")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "d33320e6-c561-48d8-a801-36d0bb9d48af")
+			(uuid "5e3e0ec1-9567-424a-90a0-0ebbf0b39508")
 		)
 	)
 	(footprint "TestPoint:TestPoint_Pad_D2.0mm"
@@ -16347,7 +16427,7 @@
 		(property "Reference" "TP2"
 			(at -2.1 -1.3 0)
 			(layer "F.SilkS")
-			(uuid "128ac9f5-728c-4d4c-8c60-bd87359ad2e7")
+			(uuid "3066738b-d3d3-49dc-a44c-182ef8db01fa")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16359,7 +16439,7 @@
 			(at 0 2.05 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5c3d9884-99bd-4b50-94d5-8c1b6326250f")
+			(uuid "173b7713-fde3-41d8-9fda-3d9c69ed042b")
 			(effects
 				(font
 					(size 1 1)
@@ -16372,7 +16452,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1ee54454-a989-428a-b649-4d35732c1782")
+			(uuid "f7b25e1c-c53f-4284-a67b-5738d24fadb9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16385,7 +16465,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9292e014-6e27-4e2b-9dcf-3d9d8c7f5078")
+			(uuid "7b8061e0-1ff3-435b-9831-7462a75a2323")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16398,7 +16478,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8fa3cf74-aa6a-446a-b65e-b6ed018d5b3b")
+			(uuid "79ea3f1c-d501-4a0a-befc-b966864316a9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16420,7 +16500,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "74fe10d1-333c-4a8f-8b17-d5c2167b8b3c")
+			(uuid "562199c4-9ad2-4202-9e7b-a3138fd0ede7")
 		)
 		(fp_circle
 			(center 0 0)
@@ -16431,7 +16511,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "8b318637-07d3-46fa-a24d-94f8ab0aef81")
+			(uuid "913db246-3ba6-4979-887b-8a2010045bc9")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 0)
+			(layer "F.Fab")
+			(uuid "47a088a8-0c0b-4dfd-b059-016142bd9963")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0)
@@ -16440,7 +16531,7 @@
 			(net 2 "+5V")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "f30d3711-b2c0-4eb5-9f42-72d788c50eb9")
+			(uuid "3117519f-21ce-4389-9c3f-e4fbc184cdd1")
 		)
 	)
 	(footprint "Capacitor_SMD:C_0603_1608Metric"
@@ -16452,7 +16543,7 @@
 		(property "Reference" "C34"
 			(at 2.8 0 -90)
 			(layer "F.SilkS")
-			(uuid "8693abdc-4a4f-4053-badd-67356f429385")
+			(uuid "4f857313-df4f-4d26-9f4a-fb0fdc8c7c3d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16464,7 +16555,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "eff1693d-b095-4346-b0a3-47c2d37d2e4e")
+			(uuid "87ec587f-905b-46ec-ae8b-89e622056372")
 			(effects
 				(font
 					(size 1 1)
@@ -16477,7 +16568,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2546adee-7fd9-4d1c-8500-fddec5a0bae1")
+			(uuid "016e6d12-51af-4523-bd81-34e9c3396ad0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16490,7 +16581,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e6c70782-e670-4487-85e6-36f21b4121f6")
+			(uuid "cb41dc84-3913-4728-b024-eee2d30b2017")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16503,7 +16594,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "95dcf4b6-0ce9-41c0-824b-5a3e130b0a6a")
+			(uuid "b9d347d1-1c24-4c98-b5b6-fc737ebf7227")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16537,7 +16628,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1e55a069-bc96-4549-8849-740ae882f052")
+			(uuid "439dbeca-25c2-4dca-8128-c5eda244da19")
 		)
 		(fp_line
 			(start -0.14058 -0.51)
@@ -16547,7 +16638,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c9fe5d8e-7189-4e30-9f20-e8ad9f1ede2d")
+			(uuid "067752d3-e5a7-451d-ba78-d977ea1de35d")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -16557,7 +16648,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "96d5ad41-2a51-4303-b36c-18465163774f")
+			(uuid "3eb8b80d-6e79-445d-8702-3ce5cd442ad8")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -16567,7 +16658,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8261c8da-0dae-40b7-99ca-b80f21c15571")
+			(uuid "9cfa6588-b507-4800-9b16-88f96b3a0ae3")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -16577,7 +16668,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2b04bf6f-c37c-4324-891b-d9a4a6fecab5")
+			(uuid "e6bad010-63df-4486-b6ca-5b4e5bb2ae36")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -16587,7 +16678,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e9b29aab-cc79-4c8a-892e-817726493e7e")
+			(uuid "84bf4872-09cb-4dc9-9284-90d3fbfe7ef8")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -16597,7 +16688,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d77ad993-3001-4df3-b2ac-be89979f62fd")
+			(uuid "f20464d0-93e8-4f16-a0b2-f2a9a924b7ef")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -16607,7 +16698,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e90c7ce6-546a-49c7-8d54-115b5d28a078")
+			(uuid "4d15236b-2d7d-44df-be7a-f564317ad982")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -16617,7 +16708,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "57b163e7-6373-4e5a-9ba5-e94afbd3cdc1")
+			(uuid "afa5a4c5-cf68-4483-bd76-909c2ea4f389")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -16627,12 +16718,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "509183a6-fe41-45d4-8da7-b0ef5db83e7b")
+			(uuid "3dad5bc7-e385-499f-96d9-94d3fff22ad3")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "3d49d064-f607-4484-ae9c-3a61453c2190")
+			(uuid "bb6f7dcb-788d-479f-8ebf-f358aab9c81b")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -16647,7 +16738,7 @@
 			(roundrect_rratio 0.25)
 			(net 16 "Net-(U7-CPO)")
 			(pintype "passive")
-			(uuid "314d8ed8-ca7d-408f-b3e3-486ca39be54b")
+			(uuid "0175b024-b902-4a07-8c01-399ca0201dcd")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0 270)
@@ -16656,7 +16747,7 @@
 			(roundrect_rratio 0.25)
 			(net 17 "Net-(U7-CPI)")
 			(pintype "passive")
-			(uuid "41d170f9-b4f6-4833-aad4-05fdd9fe1050")
+			(uuid "f8a13a60-45b0-4405-a051-5a41ee871595")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -16679,7 +16770,7 @@
 		(property "Reference" "R27"
 			(at 1.9 0.3 90)
 			(layer "F.SilkS")
-			(uuid "06307239-3d07-4eda-993c-a0c768157fe6")
+			(uuid "317e456f-37b7-483b-9f3b-0511ed8175eb")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16691,7 +16782,7 @@
 			(at 0 1.17 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ce89e141-6d89-4725-b632-da39e6109ba2")
+			(uuid "ce4d1995-b4e5-4e2a-8b79-4e19517f9a8b")
 			(effects
 				(font
 					(size 1 1)
@@ -16704,7 +16795,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e17ee43d-addf-4fd9-ab84-5a4c04a17dd9")
+			(uuid "c3fedff4-a481-46eb-b4b4-1f6fad516f5b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16717,7 +16808,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "506065c9-489b-4281-97ed-1c3f1e22df49")
+			(uuid "318bc67a-b06f-4995-96ed-776254154c5b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16730,7 +16821,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c9dee415-6fd9-43a9-95ea-b7c785bfbc17")
+			(uuid "50c31f10-e7c9-46de-beaf-7d672b7a640a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16751,7 +16842,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e77cd6d5-f06f-4169-bf69-c31f0a8a464f")
+			(uuid "fcd4cb15-59a7-4b9e-b5e6-7412ca4b6003")
 		)
 		(fp_line
 			(start -0.153641 -0.38)
@@ -16761,7 +16852,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "9c16fb46-0afc-4fd0-9f74-a7b2e31316c7")
+			(uuid "463fa65a-4a28-48da-a474-29ff9da8378a")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -16771,7 +16862,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5b66f6dc-f72e-446f-853e-58bc27763cc8")
+			(uuid "9eb9165f-546b-4fa9-b561-6753b10ab141")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -16781,7 +16872,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "aa09c142-e8e9-49d7-bc63-37fa367aa07f")
+			(uuid "457b22ad-f47b-45d5-b2e4-e3097fb4458e")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -16791,7 +16882,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "7878c001-5121-43a1-b4a8-1c0f3bd0ade1")
+			(uuid "f4fbf3a6-dbee-48cd-a6db-b8e147aabccf")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -16801,7 +16892,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a73dc03d-3055-42f0-a1f6-694725be2350")
+			(uuid "3db913a5-5c5a-4474-978f-51baa83e1856")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -16811,7 +16902,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "79097301-b798-44b6-9b54-c306404ba913")
+			(uuid "4823c9b1-ab77-4175-92de-dc442a4ed2e4")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -16821,7 +16912,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e284c11b-c8e2-4001-8970-c4d42a592c2f")
+			(uuid "572c044f-545f-4bf4-8417-96da02f75141")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -16831,7 +16922,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "936d0a49-8a8e-414d-8c7a-9a216da41e3b")
+			(uuid "715cb2e9-9167-4a00-a6b4-7bcc94b7c52b")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -16841,12 +16932,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "db7b6fb0-3b50-4070-b2ba-769b18bc3bf6")
+			(uuid "3d99eacb-4a86-43fe-ba9f-23a8d0cab1d0")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "5cbcb38c-1169-4935-a5cc-38b78b6d964f")
+			(uuid "8ca8c511-ef98-4668-833e-26ca10e6d8ca")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -16861,7 +16952,7 @@
 			(roundrect_rratio 0.25)
 			(net 90 "Net-(U2-SWD)")
 			(pintype "passive")
-			(uuid "e0526b8c-06a4-4230-b5c9-39a2c5388fec")
+			(uuid "1fb14b9b-17d9-479b-8aa7-3a524070df3b")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0 270)
@@ -16870,7 +16961,7 @@
 			(roundrect_rratio 0.25)
 			(net 18 "Net-(J1-Pin_2)")
 			(pintype "passive")
-			(uuid "aad3d83e-ebf4-4f65-9074-9c63cbd59c48")
+			(uuid "a2ea477b-6ab9-434e-bdd4-0d8e1e73f71b")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -16893,7 +16984,7 @@
 		(property "Reference" "R33"
 			(at 0 1.37 90)
 			(layer "F.SilkS")
-			(uuid "81952f83-93ce-4d58-8761-0341ca5d82ea")
+			(uuid "8b8dda9b-8496-423e-b48f-b111d26be518")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -16904,7 +16995,7 @@
 		(property "Value" "0"
 			(at 0 1.65 90)
 			(layer "F.Fab")
-			(uuid "e9e0f481-b614-4ac4-a27d-2c2c67410e4e")
+			(uuid "7c32f5b2-fb3b-4b7d-a06f-6240120953bd")
 			(effects
 				(font
 					(size 1 1)
@@ -16917,7 +17008,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f5d39d30-c0ea-4b45-a902-9623aae24246")
+			(uuid "b77daf93-2dc2-47fa-95a9-df1f27839543")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16930,7 +17021,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a6e51096-44ad-4a16-80a2-607a67b1ad33")
+			(uuid "5b1dd23c-b8b8-4be8-a6cb-a9551208fd6a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16943,7 +17034,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "223fdfa6-c32c-4445-b7a3-e47af842b945")
+			(uuid "7c15281c-6ad4-4fa7-867d-ffd21dd1d708")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -16964,7 +17055,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6f4e62ef-4ed1-40bd-b4b5-09aff5580677")
+			(uuid "74091df2-e6e8-4a96-b014-99c39818c647")
 		)
 		(fp_line
 			(start -0.227064 -0.735)
@@ -16974,7 +17065,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "732e8686-cb84-4718-88bc-d510b4ddd94b")
+			(uuid "07e51ee7-bcf7-4bab-ad47-1517c45fa2d1")
 		)
 		(fp_line
 			(start -1.68 0.95)
@@ -16984,7 +17075,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "82f062cf-26e0-4732-9474-1670394e86b2")
+			(uuid "59641962-887f-4861-be04-8e61c00a4201")
 		)
 		(fp_line
 			(start 1.68 0.95)
@@ -16994,7 +17085,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c4c3e440-6520-4031-8788-dd4a6f0db914")
+			(uuid "fb50e2d2-fffd-4493-8f55-65da40cb4712")
 		)
 		(fp_line
 			(start -1.68 -0.95)
@@ -17004,7 +17095,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5b7e50bc-2dca-4e4a-8504-509b264dfb1d")
+			(uuid "1b36b511-8442-4708-b48f-559c9edd1214")
 		)
 		(fp_line
 			(start 1.68 -0.95)
@@ -17014,7 +17105,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "23c89933-fcc3-4a61-839b-78dc74fe0087")
+			(uuid "60afee2a-904c-4a4d-ab24-6bcbb5d96246")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -17024,7 +17115,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d5f17de1-5a65-4432-8d2d-266eefefcc90")
+			(uuid "dabc0781-f91c-42d6-b1e1-46f1a1290e27")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -17034,7 +17125,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9333169f-baf5-4f58-aabc-049c0980f3c6")
+			(uuid "a22937ab-417f-4807-a8a4-59a86f374769")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -17044,7 +17135,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5f79bebf-9fa0-417a-9bb4-753751ce6f93")
+			(uuid "3488a1be-75f0-4b01-9792-3e8dce0e374c")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -17054,12 +17145,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e681bcaa-e864-485a-9668-0493f8ab389f")
+			(uuid "ad82d90f-66a0-4dd1-ba39-0e9aea793060")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "edb2bc8a-1e59-4434-8948-b62b37556d3e")
+			(uuid "8939ff9c-0566-46fa-9a1f-b9f3d5a30347")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -17074,7 +17165,7 @@
 			(roundrect_rratio 0.243902)
 			(net 50 "/Touch Sensors/STOP")
 			(pintype "passive")
-			(uuid "4d29b937-0c2a-437a-95e7-1bfd16eef3e0")
+			(uuid "3be61016-68ae-4f23-9eb8-bae3e89731cd")
 		)
 		(pad "2" smd roundrect
 			(at 0.9125 0 270)
@@ -17083,7 +17174,7 @@
 			(roundrect_rratio 0.243902)
 			(net 95 "Net-(U4-CS2)")
 			(pintype "passive")
-			(uuid "26466fa2-a9f8-45c1-93cd-49ba5fa9dd97")
+			(uuid "f179fed1-7f2d-4238-90f8-6601f9284f19")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0805_2012Metric.wrl"
 			(offset
@@ -17106,7 +17197,7 @@
 		(property "Reference" "R18"
 			(at 0 -1.2 0)
 			(layer "F.SilkS")
-			(uuid "fc4ead21-7be0-4496-bc42-df1a147f4564")
+			(uuid "ac2d779a-1c89-47d1-9329-00e37a3cd73c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -17118,7 +17209,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e1d3b165-ed66-46db-92ce-aa9e14d7bcf7")
+			(uuid "ccfe0e95-67fb-46bc-a292-d9bf5f48f8c8")
 			(effects
 				(font
 					(size 1 1)
@@ -17131,7 +17222,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "332363db-3772-46c4-85dd-d70db9906744")
+			(uuid "5fe47232-8ac7-4674-8d86-863e479fb1d6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17144,7 +17235,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d702efcd-bd36-42fb-8e26-0c3bed80a786")
+			(uuid "d477d0bb-943a-492d-85eb-16bdef905ad6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17157,7 +17248,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "99aaa199-42d6-4b21-ae4c-c0448395fcee")
+			(uuid "0c4b9111-ee6a-475b-a700-abe72ca6ba33")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17178,7 +17269,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6e62dceb-1727-4680-81b3-6ecaa860abf1")
+			(uuid "6d04945b-6b97-4e92-a61e-e7be5b07da25")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -17188,7 +17279,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "59c3f110-38c8-4256-971c-97ee17740d55")
+			(uuid "1f12b3f5-7b22-4d3b-848f-bd22b622cdfe")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -17198,7 +17289,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "283e25da-77aa-475d-a017-8b13c4cde606")
+			(uuid "67d3c6a6-2edf-4140-a6ee-817967060e3a")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -17208,7 +17299,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "bc5ff227-ee65-4ffb-868d-eeb3958d65d4")
+			(uuid "925b2a80-192a-49ec-be14-5558155d061e")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -17218,7 +17309,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "82275b49-444d-4a65-8660-30e9d7b0b36d")
+			(uuid "d3c9e186-9f49-43b9-a0aa-053a6435ff00")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -17228,7 +17319,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4edb9ef6-6547-410c-b0f5-cd379513e19e")
+			(uuid "6651cca4-a5e3-44ce-a360-fc2e05f5c2b8")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -17238,7 +17329,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "be5a816e-3cc1-4ff4-904d-78a48833945d")
+			(uuid "8ea0c57b-fa8a-4d7f-b32c-01aaf04ea5bf")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -17248,7 +17339,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "96df83d9-d3e9-4f09-bf01-a64d2becb236")
+			(uuid "13f1131e-7c0f-46ee-9af0-ef3b569db8d5")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -17258,7 +17349,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "31a9a76e-290a-4db0-95ed-74ad4ee05915")
+			(uuid "a60f5494-41f5-4337-95ee-1a3b6fcd1e41")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -17268,12 +17359,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "63e8f362-fd78-4f6c-872a-0b42b7add19e")
+			(uuid "8e95d21a-cf4c-453f-aec8-c2cedaf46d68")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "14074044-5319-4e85-8312-81d434f44a3f")
+			(uuid "99e37615-fd3f-4673-bdd8-09869ad60798")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -17288,7 +17379,7 @@
 			(roundrect_rratio 0.25)
 			(net 41 "/MCU/LTC44_{EN}")
 			(pintype "passive")
-			(uuid "220d5a48-9d6c-4776-9d61-a507edecb615")
+			(uuid "13d3e2f4-8517-4987-a039-5dd80febfc9f")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -17297,7 +17388,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "93e89783-f91e-4ab2-a346-452b2d84e878")
+			(uuid "a4ffca44-5ec9-4317-9547-dcf9302b5cfe")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -17318,9 +17409,9 @@
 		(descr "Resistor SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: IPC-SM-782 page 72, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf), generated with kicad-footprint-generator")
 		(tags "resistor")
 		(property "Reference" "R10"
-			(at -3.05 -1.35 -90)
+			(at -2.6 0 270)
 			(layer "F.SilkS")
-			(uuid "65f345b3-d60c-4eb7-b81c-0beaa5be1824")
+			(uuid "06a82254-94af-4ebc-8471-3f05d6ee14c6")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -17332,7 +17423,7 @@
 			(at 0 1.43 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "861c1fe2-f52f-4a76-a424-5eddb3701801")
+			(uuid "184cb996-49a5-42c0-b71f-8d90996145bc")
 			(effects
 				(font
 					(size 1 1)
@@ -17345,7 +17436,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4b2c63cd-a526-4774-8d70-7d1cd9e2b0c7")
+			(uuid "f6fea6ec-bf16-4c5f-806f-3afaa5293cb3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17358,7 +17449,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6d34d8ba-42a8-483b-99d3-2c10d4c8bd8a")
+			(uuid "da11e700-1ebb-4e5e-9d9b-135facf36c26")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17371,7 +17462,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "fa71959e-055c-4018-bd80-297e60bf8448")
+			(uuid "aa2ea793-d11f-4870-9be9-0b6bcfc72bbe")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17404,7 +17495,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b853a287-acf9-4424-ab03-77c45bca6d03")
+			(uuid "631a85cc-0e59-43ad-b17b-c3868208d894")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -17414,7 +17505,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4c035dd5-acb5-4a5e-b249-a1b0b8d9056c")
+			(uuid "4e5d58a7-e191-4888-9e07-0d304cd1bb5e")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -17424,7 +17515,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "53a92bed-7132-4e2d-9861-ed07ac06d4a2")
+			(uuid "ad930248-c5cf-4cd3-bdc2-4666f76ed1aa")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -17434,7 +17525,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "210b54c0-04d2-485b-8346-cd1c538c9991")
+			(uuid "4eb70788-0a96-4fc9-80a6-e9699180d96b")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -17444,7 +17535,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "989f00e0-9f87-468a-bf38-7f4dd5c53f2e")
+			(uuid "16292932-b325-4693-b6ab-b13a07c5b927")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -17454,7 +17545,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ab235334-126f-4ced-a8c6-97dc1b66213f")
+			(uuid "f30bac52-ef3b-431d-9a37-fb33de33a7fe")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -17464,7 +17555,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ae131bca-54d5-42ba-989f-d4a4881ad403")
+			(uuid "915a6738-7e49-4cc1-99b1-022bd4ab9b79")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -17474,7 +17565,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "217a1e42-d392-4b1b-b676-b744eb2e0a01")
+			(uuid "384b06af-8b91-4d93-82db-90226fd04ac4")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -17484,7 +17575,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "569c6085-4f10-470c-aa76-e32c6f6670e0")
+			(uuid "703960d5-8d6a-439b-a7f6-84e40ce162c1")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -17494,12 +17585,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "193a5422-3b34-4db8-94af-a61371301077")
+			(uuid "6bdcacbf-428c-4bcd-affd-d6fba82b4b99")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "aa9d81d0-7947-4580-ad7c-b9b44c83c19e")
+			(uuid "390ff032-f9b6-4421-ac5f-5706c44247c0")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -17514,7 +17605,7 @@
 			(roundrect_rratio 0.25)
 			(net 9 "VBUS")
 			(pintype "passive")
-			(uuid "41c2e739-71b6-4934-a4aa-36e14aec6e17")
+			(uuid "e5cbbab7-0e17-4fbd-a189-7669962596c8")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 270)
@@ -17523,7 +17614,7 @@
 			(roundrect_rratio 0.25)
 			(net 34 "Net-(U6-PFI)")
 			(pintype "passive")
-			(uuid "dbf47deb-7ab8-4484-a632-9bfb2683c802")
+			(uuid "425c9935-ca82-48b0-ac05-6ab627620d08")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -17547,7 +17638,7 @@
 			(at -7.4 -1.125 90)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "27412132-ca55-4c30-b405-3e3847e60b94")
+			(uuid "36a636e1-58b6-4493-806a-2aa6bee10aca")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -17560,7 +17651,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "549b20db-5447-453c-a0cd-809ecbc924c8")
+			(uuid "ff35993b-2ffc-4daa-9197-2aa25dac947d")
 			(effects
 				(font
 					(size 1 1)
@@ -17573,7 +17664,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a7961f8b-ff0b-496a-8936-09b0973e3418")
+			(uuid "367565de-30be-4a19-bf75-e3875e4b2165")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17586,7 +17677,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "91f41b1a-a683-4dd8-b636-cc047071fa43")
+			(uuid "37af4b4c-91de-443d-9f9e-c0d1d69aece9")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17599,7 +17690,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c4fb11c5-b3b7-479c-a508-8117db8b3223")
+			(uuid "78561611-82dc-45cc-b2ee-220b576bcce5")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17620,7 +17711,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "0d3b8899-1f30-4638-955c-1780453a7f36")
+			(uuid "74056ebe-2b2c-474c-917a-04bc9ca37a13")
 		)
 		(fp_line
 			(start -3.76 -4.515)
@@ -17630,7 +17721,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "9868206a-231c-40cf-a4d3-35e6cb39f137")
+			(uuid "6ed1ed5f-d8c2-421f-b4b5-91413ab02aff")
 		)
 		(fp_line
 			(start 4.58 -0.435)
@@ -17640,7 +17731,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "b6c7e70d-7082-4d9f-a911-097cc22161b9")
+			(uuid "bbc89545-6c88-456c-8d79-7ab8bec6d809")
 		)
 		(fp_line
 			(start -4.58 -0.435)
@@ -17650,7 +17741,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "35de730c-19d7-4913-8d4c-21eb6ef36132")
+			(uuid "9dcb333d-34ac-4474-abc6-9540788ed32e")
 		)
 		(fp_line
 			(start -5 3.675)
@@ -17660,7 +17751,7 @@
 				(type default)
 			)
 			(layer "Dwgs.User")
-			(uuid "80d88f65-93f9-46e8-bb21-5dc783ec027d")
+			(uuid "cb928cd2-3404-4146-8f6a-3aecbdb80bb3")
 		)
 		(fp_line
 			(start 4.25 -4.76)
@@ -17670,7 +17761,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "295493cf-d41c-4911-bcaf-f55ee85cfa71")
+			(uuid "94d6fb45-7055-4456-8fb5-05ca60d38519")
 		)
 		(fp_line
 			(start -4.25 -4.76)
@@ -17680,7 +17771,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "078c836d-b934-4270-98f9-ba9d3f6ea676")
+			(uuid "feee67e1-be37-4b49-86e1-e3de9c6f427c")
 		)
 		(fp_line
 			(start 6.7 -4.61)
@@ -17690,7 +17781,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "bedebe04-4cd0-484c-94d5-5771c266039d")
+			(uuid "9df2a959-90db-499a-8647-66d5a17eea3e")
 		)
 		(fp_line
 			(start 4.25 -4.61)
@@ -17700,7 +17791,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "847120ca-74fa-48c7-89ae-0a9b3f3c7632")
+			(uuid "a7b65b7c-8dfd-4f22-b42d-15dc5be20e65")
 		)
 		(fp_line
 			(start -4.25 -4.61)
@@ -17710,7 +17801,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "a1ed82ec-14ba-4f26-9d06-4a55d06e30ed")
+			(uuid "e08967c1-c9a3-41fd-b842-e9226b71dc35")
 		)
 		(fp_line
 			(start -6.7 -4.61)
@@ -17720,7 +17811,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "eb8d4de5-fb67-4ed6-b82b-e054d4e4856d")
+			(uuid "d45217f3-6ff9-4dfc-813b-b9ddbc96f590")
 		)
 		(fp_line
 			(start 6.7 -1.6)
@@ -17730,7 +17821,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "2b6da79f-9777-4861-a9f2-311a83c47547")
+			(uuid "5c75e92b-859c-4bec-92d5-23baa4823c13")
 		)
 		(fp_line
 			(start 4.97 -1.6)
@@ -17740,7 +17831,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "714f9e47-5e18-449b-90bf-eb4c5194bc86")
+			(uuid "7963a5a4-813d-4560-a997-74e6cebf532d")
 		)
 		(fp_line
 			(start -4.97 -1.6)
@@ -17750,7 +17841,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "0450fcbf-e11d-483e-b0e6-318a4dff306a")
+			(uuid "aecdb5b0-bdac-42b4-ba6c-c268e9d053e7")
 		)
 		(fp_line
 			(start -6.7 -1.6)
@@ -17760,7 +17851,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "56785fc8-69cb-4f4c-8cdf-a7300f94cf32")
+			(uuid "59c4071e-f9e5-4241-bacf-e3c7c1f99d63")
 		)
 		(fp_line
 			(start 6.7 -0.68)
@@ -17770,7 +17861,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "e00b929b-8199-400e-8712-ee8c860a3080")
+			(uuid "84155f7c-6f4b-44f2-aa4d-794cf4b9cbaf")
 		)
 		(fp_line
 			(start 4.97 -0.68)
@@ -17780,7 +17871,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "f1daa05e-b477-4e4c-b591-85171ea460ad")
+			(uuid "9b889ad3-1e1d-42db-b2af-2aff7b72aa07")
 		)
 		(fp_line
 			(start -4.97 -0.68)
@@ -17790,7 +17881,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "4277d700-3911-4750-a76b-fa07f1ca8e9c")
+			(uuid "8259863b-64c6-4fc0-91a5-c14d47c689f9")
 		)
 		(fp_line
 			(start -6.7 -0.68)
@@ -17800,7 +17891,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "39859938-2ad0-4cec-8fd4-c278f93986d8")
+			(uuid "5cfa400e-447e-4b96-9fe6-79a8efc2bc70")
 		)
 		(fp_line
 			(start 6.7 2.33)
@@ -17810,7 +17901,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "8d20f926-6292-4a3e-89db-d39f1027d537")
+			(uuid "cb74515f-a741-4e3d-9f52-d836f841a9c3")
 		)
 		(fp_line
 			(start 4.97 2.33)
@@ -17820,7 +17911,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "8f7e0d7d-11b6-4422-9fc1-f960c864d9f1")
+			(uuid "855071c0-9e6c-4b11-ba36-33b2932abab2")
 		)
 		(fp_line
 			(start -4.97 2.33)
@@ -17830,7 +17921,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "c23690b4-4317-42b4-99ec-96801beffef9")
+			(uuid "9870cf79-ae60-4d5a-8030-da1b98a32f79")
 		)
 		(fp_line
 			(start -6.7 2.33)
@@ -17840,7 +17931,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "a4e275f9-0ac0-4486-88ff-c0a654194878")
+			(uuid "81be6150-8af7-467a-a6d0-4616ce4688cc")
 		)
 		(fp_line
 			(start 4.97 4.18)
@@ -17850,7 +17941,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "ddc5e7f9-ea0f-4817-a9a0-fb3e15cab89c")
+			(uuid "977f73e2-2c93-4479-990a-ea90099da9ae")
 		)
 		(fp_line
 			(start -4.97 4.18)
@@ -17860,7 +17951,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "52b197b8-0707-4f51-80ee-2a3f51ab7d15")
+			(uuid "dfcb0df8-89b6-42c6-b509-e9d35bd1e537")
 		)
 		(fp_line
 			(start -3.7 -3.675)
@@ -17870,7 +17961,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "4d0e0b51-1649-4e90-8b14-cb1db8ded1cc")
+			(uuid "c2816e06-51c1-407a-8d6c-d49f18973966")
 		)
 		(fp_line
 			(start -3.2 -3.095)
@@ -17880,7 +17971,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "ae5a5ca6-9592-4d19-be56-c3afda9e0f7e")
+			(uuid "5e266e80-9d1f-4bc4-8707-608d0eb8e3c6")
 		)
 		(fp_rect
 			(start -4.47 -3.675)
@@ -17891,13 +17982,13 @@
 			)
 			(fill none)
 			(layer "F.Fab")
-			(uuid "ba2a860b-4b16-4256-b4f4-1732e802c4cd")
+			(uuid "eb5bd398-b6d9-4742-96d8-14c738c3fd5c")
 		)
 		(fp_text user "PCB Edge"
 			(at 0 3.075 90)
 			(unlocked yes)
 			(layer "Dwgs.User")
-			(uuid "a263e9e1-f3b3-4b76-ba55-6ffa7468f59f")
+			(uuid "3009df15-4ac7-4eba-87d0-f0048f55d018")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -17910,7 +18001,7 @@
 			(at 0 0 90)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "5338282d-4840-4c67-858e-f51497a2512e")
+			(uuid "8e1a2d6b-6e3a-450a-b6a2-f72742571e70")
 			(effects
 				(font
 					(size 1 1)
@@ -17923,14 +18014,14 @@
 			(size 0.65 0.65)
 			(drill 0.65)
 			(layers "F&B.Cu" "*.Mask")
-			(uuid "be51931c-994c-4ea5-be39-0a91984707e0")
+			(uuid "48171ab0-b066-46e1-9990-ce5a0f307946")
 		)
 		(pad "" np_thru_hole circle
 			(at 2.89 -2.605 90)
 			(size 0.65 0.65)
 			(drill 0.65)
 			(layers "F&B.Cu" "*.Mask")
-			(uuid "3af2f640-198d-48da-b62f-a943568ab21a")
+			(uuid "e5ee6a72-8921-4a4c-b218-99f0d512426c")
 		)
 		(pad "A1" smd roundrect
 			(at -3.2 -3.68 90)
@@ -17941,7 +18032,7 @@
 			(pinfunction "GND")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "3440ce76-0f14-4934-8e6e-462b982981cc")
+			(uuid "1fe8ff10-6086-497c-9e7e-6c2582901847")
 		)
 		(pad "A4" smd roundrect
 			(at -2.4 -3.68 90)
@@ -17952,7 +18043,7 @@
 			(pinfunction "VBUS")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "7f7707d4-8f67-404f-9b81-3f3998c23fa8")
+			(uuid "e2a0e80e-fd0f-4aa8-94a8-a9c4979b03c3")
 		)
 		(pad "A5" smd roundrect
 			(at -1.25 -3.68 90)
@@ -17963,7 +18054,7 @@
 			(pinfunction "CC1")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "6709199f-43f2-4693-8678-8145e0ebb733")
+			(uuid "3e283793-9e08-4366-b432-51376cf0ace6")
 		)
 		(pad "A6" smd roundrect
 			(at -0.25 -3.68 90)
@@ -17974,7 +18065,7 @@
 			(pinfunction "D+")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "df99bbb8-64c4-4b5a-8620-3d9f34c87701")
+			(uuid "501eaeaf-12c8-493a-b658-9f5d93c17957")
 		)
 		(pad "A7" smd roundrect
 			(at 0.25 -3.68 90)
@@ -17985,7 +18076,7 @@
 			(pinfunction "D-")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "a2a0ca90-837f-47ec-ae7e-8c033ddcc223")
+			(uuid "e9329d77-9058-4036-b63a-7827f0a0febb")
 		)
 		(pad "A8" smd roundrect
 			(at 1.25 -3.68 90)
@@ -17996,7 +18087,7 @@
 			(pinfunction "SBU1")
 			(pintype "bidirectional+no_connect")
 			(thermal_bridge_angle 45)
-			(uuid "7f27c307-04c0-4e46-b378-480033b7ccf5")
+			(uuid "19433f6b-e6e2-4645-b50a-026de1e4659e")
 		)
 		(pad "A9" smd roundrect
 			(at 2.4 -3.68 90)
@@ -18007,7 +18098,7 @@
 			(pinfunction "VBUS")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "beb0a5ed-d8bb-4fa9-a2f2-f98ed3f29836")
+			(uuid "2cbbc855-c6aa-444b-865d-e71ced132c54")
 		)
 		(pad "A12" smd roundrect
 			(at 3.2 -3.68 90)
@@ -18018,7 +18109,7 @@
 			(pinfunction "GND")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "5147c5d1-287d-415e-832c-929d56edd132")
+			(uuid "831c312a-87d0-4c92-93eb-200a3428fb1e")
 		)
 		(pad "B1" smd roundrect
 			(at 3.2 -3.68 90)
@@ -18029,7 +18120,7 @@
 			(pinfunction "GND")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "1b0af4fb-d5f9-4a61-8b45-5c9fb6f1bf2b")
+			(uuid "ae5957d3-c741-4458-91be-4bca4e42d250")
 		)
 		(pad "B4" smd roundrect
 			(at 2.4 -3.68 90)
@@ -18040,7 +18131,7 @@
 			(pinfunction "VBUS")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "b8e2c1aa-6029-4ff9-8efe-5b4df12f701e")
+			(uuid "48fe7854-2e97-4cdf-92ed-634c0dcc9f5e")
 		)
 		(pad "B5" smd roundrect
 			(at 1.75 -3.68 90)
@@ -18051,7 +18142,7 @@
 			(pinfunction "CC2")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "5ce75b91-82f4-4fb5-b234-7a4fe3e6f1ac")
+			(uuid "2387f672-84bf-4179-bd4a-537c8c24d85b")
 		)
 		(pad "B6" smd roundrect
 			(at 0.75 -3.68 90)
@@ -18062,7 +18153,7 @@
 			(pinfunction "D+")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "9387aec0-b59a-424b-8bef-456eb59619f9")
+			(uuid "d7d3fa7e-d7b6-4b44-a7ee-8438c610c192")
 		)
 		(pad "B7" smd roundrect
 			(at -0.75 -3.68 90)
@@ -18073,7 +18164,7 @@
 			(pinfunction "D-")
 			(pintype "bidirectional")
 			(thermal_bridge_angle 45)
-			(uuid "82ebb826-92cf-4483-aa64-85a8c85003c2")
+			(uuid "930baedf-c60a-45e0-929d-5dee1f74702f")
 		)
 		(pad "B8" smd roundrect
 			(at -1.75 -3.68 90)
@@ -18084,7 +18175,7 @@
 			(pinfunction "SBU2")
 			(pintype "bidirectional+no_connect")
 			(thermal_bridge_angle 45)
-			(uuid "4dbe37cb-7a2f-49b4-8d0b-328f94b5f468")
+			(uuid "f0567969-dc7c-4ceb-b78c-dbfd983ed7c7")
 		)
 		(pad "B9" smd roundrect
 			(at -2.4 -3.68 90)
@@ -18095,7 +18186,7 @@
 			(pinfunction "VBUS")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "6542eb79-7905-41df-858c-3cb352f07464")
+			(uuid "5b4b300c-c732-40e9-afbd-cc43417bebc0")
 		)
 		(pad "B12" smd roundrect
 			(at -3.2 -3.68 90)
@@ -18106,7 +18197,7 @@
 			(pinfunction "GND")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "ed38c6ee-f3e1-4590-8a96-7de03720765c")
+			(uuid "eb10f84e-3fa9-492c-8e99-11b6f60f8547")
 		)
 		(pad "S1" smd roundrect
 			(at -5.11 -3.105 90)
@@ -18117,7 +18208,7 @@
 			(pinfunction "SHIELD")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "e4732889-2b22-4898-bc85-cd9c89928d5d")
+			(uuid "d2447b08-93e7-48bc-8e31-de6200a72582")
 		)
 		(pad "S1" smd roundrect
 			(at -5.11 0.825 90)
@@ -18128,7 +18219,7 @@
 			(pinfunction "SHIELD")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "33981d44-24f4-485e-80a8-26288efd3a0e")
+			(uuid "b19bb380-df9b-4bda-a533-c8118d957b64")
 		)
 		(pad "S1" smd roundrect
 			(at 5.11 -3.105 90)
@@ -18139,7 +18230,7 @@
 			(pinfunction "SHIELD")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "0d4d4438-dba9-434f-8782-3ed9e84e406c")
+			(uuid "bb96201a-470e-4f8f-993a-dc9304a70702")
 		)
 		(pad "S1" smd roundrect
 			(at 5.11 0.825 90)
@@ -18150,7 +18241,7 @@
 			(pinfunction "SHIELD")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "6d7e00a4-d3e0-4fc3-bcdb-9600d60763bd")
+			(uuid "064024c8-5cae-4fdf-affe-30e243e31abc")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Connector_USB.3dshapes/USB_C_Receptacle_GCT_USB4110.wrl"
 			(offset
@@ -18172,7 +18263,7 @@
 			(at 0 -5.1 180)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "fe5d578f-f258-4585-9132-f55b4c7dc6b7")
+			(uuid "b0b6c257-7f12-4c78-b373-23ff58d906df")
 			(effects
 				(font
 					(size 1 1)
@@ -18185,7 +18276,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "00c471f4-44a3-4558-8705-ead445112bac")
+			(uuid "d8c7e059-25ea-428a-ba7e-dfc34c0094b6")
 			(effects
 				(font
 					(size 1 1)
@@ -18197,7 +18288,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b8abe1f9-4edb-48fb-bd74-2127a4a6c48d")
+			(uuid "b4df1680-33d1-4f9f-bf92-4aa681b607f7")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18209,7 +18300,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b37edc09-a4b4-49d7-85c0-82e42917eddc")
+			(uuid "aaacc82a-ac45-4172-b2c7-9b86bf794061")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18221,7 +18312,7 @@
 			(at 0 0 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8bc50e7b-c7bd-4422-b62e-87093fc4b961")
+			(uuid "0c4baf31-34fe-4038-a203-979623e37ae6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18242,7 +18333,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "3451ca5f-2499-41cc-8427-6378005bce2c")
+			(uuid "1fdb5892-2971-41d3-9d97-77c484274682")
 		)
 		(fp_line
 			(start 4.6 -2.5)
@@ -18252,7 +18343,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "ecd584e8-ec50-4636-8971-dfd48ee5c99b")
+			(uuid "136b7887-4320-42ac-8b16-00fea9c5ab6b")
 		)
 		(fp_line
 			(start 3.9 -4.2)
@@ -18262,7 +18353,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "c8e6bc26-1aba-4865-ba43-eed42bca8a6e")
+			(uuid "70769964-7fc1-4699-aea3-cddf042b69cb")
 		)
 		(fp_line
 			(start 2.1 2.5)
@@ -18272,7 +18363,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "44dff415-151f-4ded-862e-889bab1d4c7f")
+			(uuid "9fda4e4a-f1d8-43a9-8cd4-4cc721bdfd3c")
 		)
 		(fp_line
 			(start -3 2.5)
@@ -18282,7 +18373,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "05ab2518-056d-4e1d-ad26-b95a37ca32e1")
+			(uuid "d6894502-92da-41fc-9406-354f5d58583c")
 		)
 		(fp_line
 			(start -3.8 -2.5)
@@ -18292,7 +18383,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "1b8c8ba4-8eda-49d0-9129-607f5599e020")
+			(uuid "5d39d495-2835-46a9-8fd8-3a15926279d5")
 		)
 		(fp_line
 			(start -3.8 -4.1)
@@ -18302,7 +18393,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "fd3e4279-8e2b-4bbd-a14a-625d49badbe8")
+			(uuid "0bbe0981-8cd1-4049-8201-737a34dfbc4b")
 		)
 		(fp_line
 			(start -3.8 -4.2)
@@ -18312,7 +18403,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "e7009446-93d4-4ad8-bad6-a21f985036aa")
+			(uuid "14c5e271-8697-4010-adfa-dd5a13e27274")
 		)
 		(fp_line
 			(start -4.75 3.2)
@@ -18322,7 +18413,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "2a57a96c-543b-4e41-a45e-942903b98238")
+			(uuid "bdeddcce-7376-4ec7-84ef-38fe0c8a6d87")
 		)
 		(fp_line
 			(start -5.45 3.6)
@@ -18332,7 +18423,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "6c6a648d-c7ba-4577-a193-61de6a593f97")
+			(uuid "0f941b9d-bb2a-43cb-bbcb-b37fc49968eb")
 		)
 		(fp_line
 			(start -5.45 2.8)
@@ -18342,7 +18433,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "b9756625-ac9d-4da8-8cdb-b7f7c5c9185c")
+			(uuid "eceee6bb-8e1e-440c-a7f8-909adf4dc3f5")
 		)
 		(fp_line
 			(start -6.5 2.5)
@@ -18352,7 +18443,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "ff0523b9-e235-48a3-997f-6ea49afb4db8")
+			(uuid "41598e43-d100-4105-bac7-a290309170fa")
 		)
 		(fp_line
 			(start -6.5 2.5)
@@ -18362,7 +18453,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "1597ea4e-2614-450a-9489-46ea9f29b382")
+			(uuid "cd5915bf-5547-4ce8-b3c1-1acfe8b1a12e")
 		)
 		(fp_line
 			(start -6.5 -2.5)
@@ -18372,7 +18463,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "3b94614b-8bd3-4521-a70f-7e69b27a8dc9")
+			(uuid "4727bddd-caa8-4a12-9833-c59759c84d11")
 		)
 		(fp_rect
 			(start -7 4)
@@ -18383,7 +18474,7 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "8a97a2ad-9b69-4cc0-926c-678df43a6821")
+			(uuid "208564ac-ac73-49d8-8960-d64c64e7a2e4")
 		)
 		(fp_line
 			(start 6.5 -2.5)
@@ -18393,7 +18484,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "fe71868c-d6d3-4487-bda8-80967ed17ef7")
+			(uuid "b264573f-d59b-446c-95f8-4190c27820c5")
 		)
 		(fp_line
 			(start 6 -2)
@@ -18403,7 +18494,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "eb6af156-4143-450b-b97a-9e329753d810")
+			(uuid "1be04897-cf6a-47c6-84ad-0396ed212e3e")
 		)
 		(fp_line
 			(start 3.8 -2.5)
@@ -18413,7 +18504,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "1633e7cd-f92e-40e7-af91-28425140cad4")
+			(uuid "7a98f364-3026-4b7b-be23-082f7217bca8")
 		)
 		(fp_line
 			(start 3.8 -4.1)
@@ -18423,7 +18514,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "7dc696fa-10a8-457c-af11-7f3393e9e577")
+			(uuid "baac7a3c-f8e8-4866-a8f6-b62c379e88f2")
 		)
 		(fp_line
 			(start 3 2.5)
@@ -18433,7 +18524,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "056a5643-8bec-40b4-99aa-a1364c27e373")
+			(uuid "fc6552c4-baff-4cfd-af0e-56659f58270f")
 		)
 		(fp_line
 			(start 3 2)
@@ -18443,7 +18534,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "445a943b-d04b-4a08-8cb5-9a2ba9315084")
+			(uuid "727073ad-0315-43a7-990f-3cb92ef40aea")
 		)
 		(fp_line
 			(start 3 2)
@@ -18453,7 +18544,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "c1788623-7366-4970-b415-56e1c0baf840")
+			(uuid "1db50f2d-a17e-468e-a3af-8bd90e1301ae")
 		)
 		(fp_line
 			(start 3 -2)
@@ -18463,7 +18554,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "fb298daf-120c-4c91-8584-769e745d88d7")
+			(uuid "132f9f34-4917-4845-8b82-1fdb9c9f070d")
 		)
 		(fp_line
 			(start 3 -3)
@@ -18473,7 +18564,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "41f1efa8-fba4-480c-9888-eeb3e7b53524")
+			(uuid "a1d2303f-89dc-415d-b0aa-7361350f4ae9")
 		)
 		(fp_line
 			(start 2 2.5)
@@ -18483,7 +18574,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "6d7966b3-ba8c-4fff-9539-5a2e71cc43d3")
+			(uuid "32d4df7a-8ae1-4ef2-9a17-7d99020b78ac")
 		)
 		(fp_line
 			(start 2 2.5)
@@ -18493,7 +18584,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "78182852-33ed-4e71-8ade-0c6bc4da0860")
+			(uuid "4dc37792-bbf6-4d21-babe-62c5186e96ea")
 		)
 		(fp_line
 			(start 2 2)
@@ -18503,7 +18594,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "e469df79-cfff-4ab0-851a-960b29ef8c1b")
+			(uuid "84ae6a0f-011a-4031-b67b-ef26fb0fdd32")
 		)
 		(fp_line
 			(start -2 2.5)
@@ -18513,7 +18604,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "e311e609-4bbf-4fc8-8297-05b3796c499e")
+			(uuid "c3f883d3-327a-459c-9bce-87a563744f4f")
 		)
 		(fp_line
 			(start -2 2)
@@ -18523,7 +18614,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "69fd9d9e-9e0f-4aaf-8b63-3c50081c851a")
+			(uuid "e01ae3a9-5c51-4f7a-af96-59e9f0febd2f")
 		)
 		(fp_line
 			(start -3 2.5)
@@ -18533,7 +18624,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "3253855e-0089-42dd-80f4-8209c0956458")
+			(uuid "14cd1b13-6815-4a8d-b110-f21364f9b259")
 		)
 		(fp_line
 			(start -3 2.5)
@@ -18543,7 +18634,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "f6588f16-1627-4275-a104-b523538b440b")
+			(uuid "44ed8a46-2f82-4f94-8da0-0e67b9818a0f")
 		)
 		(fp_line
 			(start -3 2)
@@ -18553,7 +18644,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "63f71626-db41-4d35-853d-3b66c57dbf36")
+			(uuid "975d6ee9-8fef-46e3-aabe-77eef968a923")
 		)
 		(fp_line
 			(start -3 -2)
@@ -18563,7 +18654,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "d27a13e2-78b9-4188-8b1d-df1c38adc2cd")
+			(uuid "b2b3be5f-f0c8-446b-a7f6-72d97ff42c2d")
 		)
 		(fp_line
 			(start -3 -3)
@@ -18573,7 +18664,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "2865c93f-44c1-4fda-8f57-8db0ac3241a6")
+			(uuid "5fa12332-9c90-4bf3-88d1-013e8394166d")
 		)
 		(fp_line
 			(start -3.3 -2)
@@ -18583,7 +18674,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "15d4f72a-fbd3-4b7f-92ff-6446566cbec1")
+			(uuid "188cf0af-4f29-468b-83f8-1e7e8c08bf14")
 		)
 		(fp_line
 			(start -3.8 -2.5)
@@ -18593,7 +18684,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "4e9f5f07-a2fb-41bf-b1e7-6c2b40de2890")
+			(uuid "0edff8ba-0000-41ff-8868-8f81dcba855f")
 		)
 		(fp_line
 			(start -3.8 -4.1)
@@ -18603,7 +18694,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "fe6a7a1b-8e1f-4568-b22a-98dc28fa6710")
+			(uuid "c6580bed-92f9-4789-a6b3-4cacf6309ce9")
 		)
 		(fp_line
 			(start -6 2)
@@ -18613,7 +18704,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "f300c447-5742-40d5-b438-d7f0220a6152")
+			(uuid "7a825111-598d-4195-adf6-28331093e2c1")
 		)
 		(fp_line
 			(start -6 2)
@@ -18623,7 +18714,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "a1e920b7-970d-49b8-852f-3cd785a7bae4")
+			(uuid "d872a3c9-bb61-4fd0-8d6b-86bb0cc6da58")
 		)
 		(fp_line
 			(start -6 -2)
@@ -18633,7 +18724,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "89d1ffcd-fbe6-4124-ae77-0e4154fda56d")
+			(uuid "7eb15e74-4b4b-4d69-ae59-67edd27bbaf6")
 		)
 		(fp_line
 			(start -6.5 2.5)
@@ -18643,7 +18734,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "0c43c2a9-a352-4204-83c2-e14eaa1192e0")
+			(uuid "4913e2bf-b422-46be-8b5f-fce668f39aab")
 		)
 		(fp_line
 			(start -6.5 -2.5)
@@ -18653,13 +18744,13 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "40590c6c-f912-4786-a432-fbb6f9b32397")
+			(uuid "28369319-a3ee-4554-bc99-2374a15b23ba")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "2a5119f2-d8b3-4d70-82ed-bb27e510fd71")
+			(uuid "efa2478e-8b8e-4ebd-b39e-4d97baefc758")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -18676,7 +18767,7 @@
 			(pinfunction "Pin_1")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "a4646f41-2848-4d2f-824f-7546e0cab450")
+			(uuid "a8918b17-8cf8-4294-ad35-22e8e9443c79")
 		)
 		(pad "2" smd roundrect
 			(at -1.27 -2.1 180)
@@ -18687,7 +18778,7 @@
 			(pinfunction "Pin_2")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "3d373723-9e53-429b-ba61-944e139768af")
+			(uuid "f2c304a5-df89-4881-93c7-2078de4e6dd3")
 		)
 		(pad "3" smd roundrect
 			(at 1.27 2.1 180)
@@ -18698,7 +18789,7 @@
 			(pinfunction "Pin_3")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "e14a640a-9c61-42cd-a56e-3e0ee9874551")
+			(uuid "f3217524-ca94-40b9-911d-866e73b36efd")
 		)
 		(pad "4" smd roundrect
 			(at 3.81 -2.1 180)
@@ -18709,7 +18800,7 @@
 			(pinfunction "Pin_4")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "8968b923-6348-4903-b445-aa275acd5fed")
+			(uuid "a1198885-dd35-4ab0-9a4a-65e2c09c8612")
 		)
 		(model "${OE_3DMODEL_DIR}/MOLEX_1719730004_1x04_P2.54mm_Vert_Lock.STEP"
 			(offset
@@ -18732,7 +18823,7 @@
 		(property "Reference" "R21"
 			(at -1.4125 -1.65 0)
 			(layer "F.SilkS")
-			(uuid "58f65b3b-3631-4f16-99e3-f405270a60a7")
+			(uuid "8e515462-6e16-48ca-8c78-96b54a045daa")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -18744,7 +18835,7 @@
 			(at 0 1.82 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0cf08798-0b84-4251-9d8a-21e7e07b4022")
+			(uuid "bfdcf28e-824d-4eb3-9702-4490ff4e5101")
 			(effects
 				(font
 					(size 1 1)
@@ -18757,7 +18848,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d09d65f6-9fb0-4939-81ad-10cde38221f1")
+			(uuid "b999df82-7487-49ef-acd1-ad3e97a20381")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18770,7 +18861,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "06af2efb-bf6d-4aaf-b945-6693c5625163")
+			(uuid "0859babc-cbd0-4b1b-bb57-b099fd1e543e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18783,7 +18874,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "392d8d0e-ec7c-4da3-b163-0bc5c9133a2d")
+			(uuid "0582d9e6-7688-430b-a0bd-85b8b29fe88a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18817,7 +18908,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b4c8ab72-1969-493a-af10-a43265297740")
+			(uuid "12b53ea9-6aa1-4fbf-8ec7-7f5aa9810b68")
 		)
 		(fp_line
 			(start -0.727064 0.91)
@@ -18827,7 +18918,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1c946e9c-f479-4596-a576-200ee0297aac")
+			(uuid "9ef42f29-917a-4340-ab75-e84c78ff7ac2")
 		)
 		(fp_line
 			(start -2.28 -1.12)
@@ -18837,7 +18928,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "84f5c7dc-c8de-49d3-bd0f-32f98556acdb")
+			(uuid "8782921a-564e-4391-978f-dd4f64c31f4b")
 		)
 		(fp_line
 			(start -2.28 1.12)
@@ -18847,7 +18938,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "34ed8bbf-e125-4f9d-91ed-7d9bce88d708")
+			(uuid "6630d7d8-2663-43ca-9512-2296fedc3f78")
 		)
 		(fp_line
 			(start 2.28 -1.12)
@@ -18857,7 +18948,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a7964ba5-5011-40f0-b21e-2a020888ad31")
+			(uuid "cf3e761c-04e4-4b93-8fa8-62282b48fd4b")
 		)
 		(fp_line
 			(start 2.28 1.12)
@@ -18867,7 +18958,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ee07551f-3184-457c-b51e-b60ff640416e")
+			(uuid "c628f356-98c6-471a-b990-d60599a99ec4")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -18877,7 +18968,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e44533bd-5b03-4327-bb50-2518137d51d5")
+			(uuid "04928896-271e-4db4-8e7e-9653dc027330")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -18887,7 +18978,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b69e3877-7943-47ad-a655-1ebfb15308d4")
+			(uuid "35b80e2f-1436-4f25-966a-5e7292d57982")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -18897,7 +18988,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "42e45a50-294d-4e84-badb-b713f6f4316f")
+			(uuid "2cd55fb5-0e8f-428a-83ca-3258d039e7b8")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -18907,12 +18998,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "3c7f766c-49bb-4fda-9871-04a175271a7c")
+			(uuid "e8bb9f57-db2e-4fba-82dc-906f09713b70")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "c13e2ef0-b48e-474a-8200-9a10c223f94d")
+			(uuid "84ffac33-96c8-401a-a2b7-3dbea2506ed7")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -18927,7 +19018,7 @@
 			(roundrect_rratio 0.222222)
 			(net 43 "Net-(U7-BRA)")
 			(pintype "passive")
-			(uuid "2eec56bb-62bd-47fa-8dde-24c9216f48f2")
+			(uuid "eb8c091d-38fe-4e4d-8d34-9fe537842c36")
 		)
 		(pad "2" smd roundrect
 			(at 1.4625 0)
@@ -18936,7 +19027,7 @@
 			(roundrect_rratio 0.222222)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "36e665f4-d8f8-4ff5-a8aa-7e65be3b7d8d")
+			(uuid "7f329f74-d2d3-4d3e-9b78-b1d628135a10")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_1206_3216Metric.wrl"
 			(offset
@@ -18959,7 +19050,7 @@
 		(property "Reference" "U1"
 			(at 0 -3.56 0)
 			(layer "F.SilkS")
-			(uuid "14f9a7ce-14f9-4c41-8192-9f3553f09fd0")
+			(uuid "a7cee1ff-f605-46b3-89a6-e46b1e9e6cec")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -18971,7 +19062,7 @@
 			(at 0 3.56 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "20590753-46fb-474c-8ef6-604627833fbb")
+			(uuid "5f0c3708-da98-4cee-919b-385ea71f6409")
 			(effects
 				(font
 					(size 1 1)
@@ -18984,7 +19075,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "479dc168-8c74-49da-932a-e0dab4d51b5f")
+			(uuid "32634991-673e-49e4-b78e-5f1e4b23c100")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -18992,12 +19083,12 @@
 				)
 			)
 		)
-		(property "Datasheet" "http://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
+		(property "Datasheet" "https://www.winbond.com/resource-files/w25q128jv_dtr%20revc%2003272018%20plus.pdf"
 			(at 0 0 0)
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b46b1e58-0308-4537-9120-5f1749eecca9")
+			(uuid "d64b62a3-d52c-43eb-9dde-728332529a6a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19010,7 +19101,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "db4ae087-94e2-4671-8c20-afcb4ed390b3")
+			(uuid "7bc8d0ac-bc76-4b34-b9df-e19a143e2fc8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19031,7 +19122,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "c9fae088-20da-45e3-9f3b-9bdbf9098226")
+			(uuid "dca88e58-373b-4b89-915e-c67a840ce860")
 		)
 		(fp_line
 			(start -2.725 2.725)
@@ -19041,7 +19132,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a0a3f1d0-e7d3-490f-bd1d-93b734ed0c08")
+			(uuid "3d10c31d-fc5a-4fdc-9f3a-610a47da446c")
 		)
 		(fp_line
 			(start 0 -2.725)
@@ -19051,7 +19142,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "113c4f12-c22a-41a5-b875-f72b98b0d277")
+			(uuid "abdc6f17-9113-43a3-9b85-cd0894620708")
 		)
 		(fp_line
 			(start 0 -2.725)
@@ -19061,7 +19152,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8433cf2e-ee85-432d-89f4-f0ce5f8cd749")
+			(uuid "1f5473e8-3e4c-4999-9cb9-fba59d82a32b")
 		)
 		(fp_line
 			(start 0 2.725)
@@ -19071,7 +19162,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "4e079b85-23d9-48cc-9a9b-923c595d0e94")
+			(uuid "042a85cd-de7a-41ba-afb2-dc5ee82fc7a7")
 		)
 		(fp_line
 			(start 0 2.725)
@@ -19081,7 +19172,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "05f09484-e709-4899-926a-80bb65957f77")
+			(uuid "8165d415-d959-46b6-902f-d152fcae1442")
 		)
 		(fp_line
 			(start 2.725 -2.725)
@@ -19091,7 +19182,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d28d654c-98d9-4939-a8b0-6ea48944616e")
+			(uuid "5a75ea0c-9b06-43ff-a97c-536bb9bf5dd0")
 		)
 		(fp_line
 			(start 2.725 2.725)
@@ -19101,7 +19192,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "983960c9-b691-42fe-ad8c-7af7e6a136ca")
+			(uuid "4359e633-42b9-4bc6-8ba3-0f32d8aa110f")
 		)
 		(fp_poly
 			(pts
@@ -19113,7 +19204,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "1381e6ca-b725-45e1-931c-94f05978a481")
+			(uuid "de6267ac-e58f-40a4-9514-b2329073b708")
 		)
 		(fp_line
 			(start -4.65 -2.86)
@@ -19123,7 +19214,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "43fbafd5-75b6-4cd6-9f6d-74142f861fe3")
+			(uuid "937bb36e-792e-48b7-9211-1e66f8d65022")
 		)
 		(fp_line
 			(start -4.65 2.86)
@@ -19133,7 +19224,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "50a4f672-448d-4a5a-a05c-fafc56c40579")
+			(uuid "1d6e0f4a-c1ba-4070-b67b-c8237b731772")
 		)
 		(fp_line
 			(start 4.65 -2.86)
@@ -19143,7 +19234,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "35af8f4b-6bf5-4545-8b94-567b3fd1c89d")
+			(uuid "8bc80a8f-8a63-4a2b-8d6e-421a923a4029")
 		)
 		(fp_line
 			(start 4.65 2.86)
@@ -19153,7 +19244,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9ee5f553-6ff5-4fdd-912e-2f43be03b2fc")
+			(uuid "8372944e-7bb6-447f-9adf-2dcc6cffdd76")
 		)
 		(fp_line
 			(start -2.615 -1.615)
@@ -19163,7 +19254,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "46b5ea21-4652-445d-951c-be8816de603d")
+			(uuid "6fd60bf7-2420-489f-b876-67d2cde27083")
 		)
 		(fp_line
 			(start -2.615 2.615)
@@ -19173,7 +19264,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8f87a827-c0e1-4848-8062-846baf8b5814")
+			(uuid "2a380fc7-b231-4230-be58-ad81b0a2dcd3")
 		)
 		(fp_line
 			(start -1.615 -2.615)
@@ -19183,7 +19274,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "863474c9-2dc8-4204-a13c-78ffa8d67813")
+			(uuid "efa5e767-fc14-4c98-babe-caca5e2f9dba")
 		)
 		(fp_line
 			(start 2.615 -2.615)
@@ -19193,7 +19284,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "90fd71c8-89f6-4b8c-a68d-080fe0ae1b4b")
+			(uuid "26c72515-96b7-4e07-95a5-6507e63521b3")
 		)
 		(fp_line
 			(start 2.615 2.615)
@@ -19203,12 +19294,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "76440426-1e0e-4721-8ea8-22858cc49b91")
+			(uuid "55af3cf2-8a3c-4b89-8655-1e9f29f581e4")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "2c0875fe-319b-4228-8959-447caec142c4")
+			(uuid "d0c82eab-10fd-44e7-878b-a24dc63a3333")
 			(effects
 				(font
 					(size 1 1)
@@ -19224,7 +19315,7 @@
 			(net 31 "/MCU/QSPI_{~{CS}}")
 			(pinfunction "~{CS}")
 			(pintype "input")
-			(uuid "86053f54-5983-48be-96d2-43e5a01e85e0")
+			(uuid "64bb0f90-110e-4a25-b456-355822a32320")
 		)
 		(pad "2" smd roundrect
 			(at -3.6 -0.635)
@@ -19234,7 +19325,7 @@
 			(net 53 "/MCU/QSPI_{D1}")
 			(pinfunction "DO(IO1)")
 			(pintype "bidirectional")
-			(uuid "f3919c0a-7945-4c1c-bb2f-22d188a9c5ff")
+			(uuid "67624c7a-1819-43a2-88d8-c478006f0754")
 		)
 		(pad "3" smd roundrect
 			(at -3.6 0.635)
@@ -19244,7 +19335,7 @@
 			(net 54 "/MCU/QSPI_{D2}")
 			(pinfunction "IO2")
 			(pintype "bidirectional")
-			(uuid "f6a63070-3c0f-4082-b28c-bda8cede190b")
+			(uuid "5bcb5aa9-3a05-4286-a6ac-9189c92576a7")
 		)
 		(pad "4" smd roundrect
 			(at -3.6 1.905)
@@ -19254,7 +19345,7 @@
 			(net 1 "GND")
 			(pinfunction "GND")
 			(pintype "power_in")
-			(uuid "03b30de4-33d4-4197-89cb-6866a10d6ec1")
+			(uuid "d43b3785-04f0-45d7-8f30-ec807c46a2db")
 		)
 		(pad "5" smd roundrect
 			(at 3.6 1.905)
@@ -19264,7 +19355,7 @@
 			(net 52 "/MCU/QSPI_{D0}")
 			(pinfunction "DI(IO0)")
 			(pintype "bidirectional")
-			(uuid "54903132-6cff-4389-9455-3bcb82025930")
+			(uuid "63931360-c999-403b-a7f8-b6fdf18f3e12")
 		)
 		(pad "6" smd roundrect
 			(at 3.6 0.635)
@@ -19274,7 +19365,7 @@
 			(net 27 "/MCU/QSPI_{CLK}")
 			(pinfunction "CLK")
 			(pintype "input")
-			(uuid "cf9cd0a9-6ba7-46ec-a532-8b3931dd9b95")
+			(uuid "a50b87db-fe6c-44c7-ad38-d173dd0a8358")
 		)
 		(pad "7" smd roundrect
 			(at 3.6 -0.635)
@@ -19284,7 +19375,7 @@
 			(net 51 "/MCU/QSPI_{D3}")
 			(pinfunction "IO3")
 			(pintype "bidirectional")
-			(uuid "05fb564d-4acd-46fa-b473-d9a8a159dbfa")
+			(uuid "836c79e0-e485-43f0-8878-88e12102431e")
 		)
 		(pad "8" smd roundrect
 			(at 3.6 -1.905)
@@ -19294,7 +19385,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VCC")
 			(pintype "power_in")
-			(uuid "c5679990-94d1-4509-8f7d-e8c7688a0d63")
+			(uuid "3fac502d-021f-4394-bbcf-b63f9e80efcb")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_SO.3dshapes/SOIC-8_5.23x5.23mm_P1.27mm.wrl"
 			(offset
@@ -19315,9 +19406,9 @@
 		(descr "SMD pad as test Point, diameter 2.0mm")
 		(tags "test point SMD pad")
 		(property "Reference" "TP5"
-			(at -0.7 2.4 360)
+			(at -0.7 2.4 0)
 			(layer "F.SilkS")
-			(uuid "86603ebb-1cb2-43c2-bc7d-2b28109fea89")
+			(uuid "a9eb5df4-c055-49b3-8d9f-34b10afcf456")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -19329,7 +19420,7 @@
 			(at 0 2.05 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "94a23a2f-0e98-4203-9549-87dfda7ca844")
+			(uuid "cc722a47-5014-4ef8-a68e-70a21713376e")
 			(effects
 				(font
 					(size 1 1)
@@ -19342,7 +19433,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c0ffb439-bd45-474d-917a-40d3c1468bcb")
+			(uuid "377406a0-5164-415d-a21f-5c0b50de6459")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19355,7 +19446,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3f98a9cc-f8e2-4e94-95ac-cd4412575200")
+			(uuid "45b71b40-78d8-4d93-b560-dfe3c2b80cb7")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19368,7 +19459,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "48831f14-b511-413e-86a7-75547738aa7c")
+			(uuid "ebc809d8-cac0-4df2-a308-113b4c18f341")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19390,7 +19481,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "8717e8c4-3677-4261-a00f-be94d237d2fa")
+			(uuid "c537bc54-a581-4655-b881-5a8e51459184")
 		)
 		(fp_circle
 			(center 0 0)
@@ -19401,7 +19492,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "0f443697-8083-455b-8b4b-4dfa94b03ef5")
+			(uuid "72502394-8fdd-4c9c-b267-66571ed54722")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 -90)
+			(layer "F.Fab")
+			(uuid "20bad6be-bf4b-435b-9301-734a32724bc9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0 270)
@@ -19410,7 +19512,7 @@
 			(net 1 "GND")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "9d961f01-7ac2-4c8b-bec1-436e4c622d25")
+			(uuid "4cfa06d3-2e87-4c93-9868-4a49e80647c2")
 		)
 	)
 	(footprint "Capacitor_SMD:C_0402_1005Metric"
@@ -19422,7 +19524,7 @@
 		(property "Reference" "C10"
 			(at -0.9 1.1 0)
 			(layer "F.SilkS")
-			(uuid "415de005-f67b-43cd-912c-103b1395bc8a")
+			(uuid "e51202ed-3bf9-4936-947f-6a81e8ab9acb")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -19434,7 +19536,7 @@
 			(at 0 1.16 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9328b66c-adec-4302-8003-b26a1255b85e")
+			(uuid "a6033437-ce5b-4bbe-86a9-a27c474457b8")
 			(effects
 				(font
 					(size 1 1)
@@ -19447,7 +19549,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ed31c779-3bc1-49d0-9838-a2f26e23b09b")
+			(uuid "f58efe1c-4047-42bd-bb5e-605529bf85ce")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19460,7 +19562,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9d07d84d-21ac-4905-9c42-a3dce646d719")
+			(uuid "ed111d87-b84e-4657-aef7-92f91bb23e01")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19473,7 +19575,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "400495d1-5840-4ccc-9de3-48e6f6a1b0f6")
+			(uuid "8be9980d-e345-4dd3-81ea-34396f22cb57")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19506,7 +19608,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a85353aa-5663-448f-be0d-bd3f574d3be7")
+			(uuid "ea48b922-d4b2-4f76-af2b-51ad63a1de2a")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -19516,7 +19618,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b5692aa1-c77a-4555-92d3-a35a4c76bb00")
+			(uuid "f7cf7c4b-9ece-49ec-bfb9-119c76521cde")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -19526,7 +19628,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4f0d0f18-c0ee-4f37-b7a3-c82b1e5ef8f2")
+			(uuid "236719eb-c670-4ec4-b2b8-c5697add127a")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -19536,7 +19638,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "36d5a66a-a2cb-48f4-8ad3-1c3e766437d7")
+			(uuid "fb57793b-45c5-492e-a99d-26a9c899a2ff")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -19546,7 +19648,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "dfe29894-c92a-44b2-8591-47fcaefb4968")
+			(uuid "3748d6ab-eddd-4e98-9d80-642ac1ba8af9")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -19556,7 +19658,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "11f2774d-4406-4967-822d-fd592f2dfcc3")
+			(uuid "0b8de45b-62f0-4bd6-bdbf-74e0adefde5f")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -19566,7 +19668,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "73d1dde6-3b5f-46b5-9b36-16bbb3fb978c")
+			(uuid "426b0421-7471-4186-899c-5e544dc6d348")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -19576,7 +19678,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5f8906f2-13fe-42a7-b7eb-85a551afb608")
+			(uuid "0448c3fe-11a3-4344-95f8-180789020691")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -19586,7 +19688,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "801ec307-8cd9-44e6-be00-f8367bd52147")
+			(uuid "e336ea90-f336-4e32-a546-cd545dc956dd")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -19596,12 +19698,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "13097360-1880-48a3-a0d9-ff17bcb2fac3")
+			(uuid "f0d23a0d-c75d-494e-befe-617cc1bc27bd")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "456920e2-cddb-4cd6-80b2-ecb8ca97b440")
+			(uuid "b8a27e6b-fbdd-48d2-9761-dcab614abfd8")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -19616,7 +19718,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "ed14bf24-0be9-48a6-9444-bc8040a4ab0a")
+			(uuid "99ac8db5-3ea6-4701-b555-22880246c191")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0)
@@ -19625,7 +19727,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "0a4b9c8a-3f75-47a9-89ad-62e753dd2a05")
+			(uuid "67faeb69-8d04-4276-8e6e-9f2985b9fdca")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -19648,7 +19750,7 @@
 		(property "Reference" "C7"
 			(at 0 -1.1 -90)
 			(layer "F.SilkS")
-			(uuid "46adc2ea-433c-4bc5-ab1a-f5f1ddc5dd44")
+			(uuid "15401616-2d9a-4ef8-8ae1-b0ad0f199588")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -19660,7 +19762,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "593dc4b7-400a-46fd-a14c-a34719870035")
+			(uuid "6e18021c-4ee7-4279-933d-83ea4481df55")
 			(effects
 				(font
 					(size 1 1)
@@ -19673,7 +19775,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e4463dec-91f1-4c14-b4b0-5180b6697873")
+			(uuid "c0e9b460-4396-4bd9-986d-935fa1a24eaa")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19686,7 +19788,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dac6571c-62b9-4e30-a5e5-5388c7144d52")
+			(uuid "87586a3a-dad6-4a4b-be4f-39a22da18a89")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19699,7 +19801,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "93bf95fe-4f8b-447e-bae4-472edd5c42d4")
+			(uuid "84ed9957-7fa8-4012-bd49-9aa151d6a368")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19732,7 +19834,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "72143274-e19d-4fd3-82b3-08cb9f1b9ae2")
+			(uuid "dbe9cd78-94fd-4ecf-a7e2-ad6c54ed739f")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -19742,7 +19844,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "f98943b4-a2c0-4c6b-a38d-426c9e560d87")
+			(uuid "15ddcf56-26ce-40b1-9121-4572a75d3fca")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -19752,7 +19854,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b87acde9-bfd7-49bc-95f8-b487a216cf35")
+			(uuid "b468cd90-a2cd-4fb5-a26a-5dd982c54ead")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -19762,7 +19864,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f9aec04a-aeeb-4289-bf2f-398ebd82a802")
+			(uuid "341fd337-545d-418c-9227-7a920b8907c7")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -19772,7 +19874,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f9bd85e2-9c8c-499c-920d-2abfd87ba36c")
+			(uuid "362919ec-cd4d-4857-99da-bd787635bc19")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -19782,7 +19884,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8ac99014-10cb-4d5c-b481-1855e5d8b4ee")
+			(uuid "ccb69c1f-0e5e-4e0b-917f-334137bb0380")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -19792,7 +19894,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a74e4371-eb12-4ee4-807f-495a20dabda6")
+			(uuid "d6e57c0c-aea1-4657-b469-2f2e9fd07367")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -19802,7 +19904,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c7fb0502-d718-4bf1-bc81-83724c6d406f")
+			(uuid "26ac1646-1621-47bb-817f-3a9dbc49045e")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -19812,7 +19914,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "50fdf86f-574c-451d-b8e0-084643e8773c")
+			(uuid "3d11a576-aa27-4910-b17e-615e7f5bf4e2")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -19822,12 +19924,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d6a3aaae-7589-42c0-b159-d86717302b09")
+			(uuid "8773eea4-a340-4acc-86ea-50bf458a14e5")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "e34991c1-da5f-4340-ad53-f531447db638")
+			(uuid "30e7adc2-aafb-41e5-9dd9-1a194f9cb7cb")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -19842,7 +19944,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "3c18047a-3d24-44e5-8e9f-5df81b299def")
+			(uuid "48965ce3-b016-4bcd-a4fb-7381dcb9d05e")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -19851,7 +19953,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "40c30a19-3a62-4b4f-aa4e-6d7039eba9e3")
+			(uuid "e73ee203-505b-40e2-8cb4-94010ff725c0")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -19874,7 +19976,7 @@
 		(property "Reference" "TP3"
 			(at -3 0.3 0)
 			(layer "F.SilkS")
-			(uuid "dab2042b-d88a-4933-be60-23c13eaaf1b9")
+			(uuid "57e31dee-0428-4641-8107-f1733849b434")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -19886,7 +19988,7 @@
 			(at 0 2.05 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "eb71e4aa-ad97-4e77-a8b9-f45e23f3cf3e")
+			(uuid "65a00fc0-b380-451c-89c4-78074500821a")
 			(effects
 				(font
 					(size 1 1)
@@ -19899,7 +20001,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e799bd7b-b294-4905-9fed-d603f90610b2")
+			(uuid "e3a6595e-c8f6-498b-9f19-bb912e0f0cc0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19912,7 +20014,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ce4e757c-789e-4884-84b4-17380956751d")
+			(uuid "195a88dc-9f78-4316-ba60-8df3b2344a8d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19925,7 +20027,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ddd51e9e-eca7-4e40-a50b-858ca106aee2")
+			(uuid "c127770e-c707-4e87-a788-9ccaa597c087")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -19947,7 +20049,7 @@
 			)
 			(fill none)
 			(layer "F.SilkS")
-			(uuid "27a8615e-1cf8-4591-87f1-6b8f98a4cebe")
+			(uuid "b28f9ec6-08ce-48a3-bb71-e7f07cec2c90")
 		)
 		(fp_circle
 			(center 0 0)
@@ -19958,7 +20060,18 @@
 			)
 			(fill none)
 			(layer "F.CrtYd")
-			(uuid "23efb1dc-0906-4e5c-b464-78f8e9efb2f5")
+			(uuid "f9e6ab5d-a66f-4b81-8a79-757ed103a591")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2 0)
+			(layer "F.Fab")
+			(uuid "0a5c9f6c-b440-4049-8a3b-aefda303db77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
 		)
 		(pad "1" smd circle
 			(at 0 0)
@@ -19967,7 +20080,7 @@
 			(net 82 "+12V")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "e40cc7f8-18bf-46de-b8fc-a03b70c1a070")
+			(uuid "bf1206c4-dd5f-4880-9571-52c19ad7ada6")
 		)
 	)
 	(footprint "Package_DFN_QFN:DFN-10-1EP_3x3mm_P0.5mm_EP1.65x2.38mm"
@@ -19979,7 +20092,7 @@
 		(property "Reference" "U8"
 			(at 0 2.5 -90)
 			(layer "F.SilkS")
-			(uuid "777fb2a3-b652-4b33-95fe-6356e74a7e45")
+			(uuid "25584f8f-7786-42c6-9c3f-770f775e9deb")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -19991,7 +20104,7 @@
 			(at 0 2.45 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6fd2ffde-9bb1-453e-abc8-6e0e0974bd46")
+			(uuid "5dc2bca8-d37e-491a-af14-912d3b111fdb")
 			(effects
 				(font
 					(size 1 1)
@@ -20004,7 +20117,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c8a5acc9-c5e4-4f70-bfc3-2bbbc00fbfa3")
+			(uuid "7d8cf021-1877-490f-b029-7deb5a90f7ea")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20017,7 +20130,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "aacc670a-1ca0-4cc6-abe7-0e94b77e73ec")
+			(uuid "9b7138bd-4420-4d8c-b99f-6e5facc8d639")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20030,7 +20143,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "79e0c4e5-8708-48e0-8ba2-3c110bc4d8e8")
+			(uuid "d25a42a7-a63e-409c-91b6-aab1a769eac6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20050,7 +20163,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "538a9b6b-fe14-43f7-9125-72bc0805d992")
+			(uuid "ab36076b-1baa-4fcb-b61e-e1c7cefbe947")
 		)
 		(fp_line
 			(start -1.5 -1.61)
@@ -20060,7 +20173,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "814d9008-a29f-441c-bbec-177ef6477fe6")
+			(uuid "1d1dd136-36db-4a41-a0ae-edcbaa10aa6b")
 		)
 		(fp_poly
 			(pts
@@ -20072,7 +20185,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "8ef39382-1d6a-452b-a4e5-68de142980cf")
+			(uuid "c0abe3f5-0644-45da-a8fd-16e41b4ac8c0")
 		)
 		(fp_line
 			(start -2.13 1.75)
@@ -20082,7 +20195,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ed575f73-b593-47f7-87d0-89e41c189129")
+			(uuid "06f3237d-a2e7-483c-8cfa-38e4234ddc35")
 		)
 		(fp_line
 			(start 2.13 1.75)
@@ -20092,7 +20205,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a54237aa-808e-4d8e-a52c-5e1ac5df77cf")
+			(uuid "88ddacd4-41ca-443e-aad2-7adbc34c2333")
 		)
 		(fp_line
 			(start -2.13 -1.75)
@@ -20102,7 +20215,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "607e5e62-bd0c-4940-ae79-a41829aee0a6")
+			(uuid "56ac3b5a-ff73-42f0-8320-a57fabc8f4d7")
 		)
 		(fp_line
 			(start 2.13 -1.75)
@@ -20112,7 +20225,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b9b83308-e885-4f65-b50b-650ec2a09539")
+			(uuid "9ddecf89-0e43-4deb-8635-d1e579898366")
 		)
 		(fp_line
 			(start -1.5 1.5)
@@ -20122,7 +20235,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5b33df0d-f895-4a64-9a68-a05f1818736f")
+			(uuid "5fa89948-a2a5-40c0-9d78-b6c7a3030b1e")
 		)
 		(fp_line
 			(start 1.5 1.5)
@@ -20132,7 +20245,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7ccb4ab8-39a9-4b5a-9473-bd1062f3e3f7")
+			(uuid "a9f6714d-364e-4536-9160-dd9f5a7d9d55")
 		)
 		(fp_line
 			(start -1.5 -0.75)
@@ -20142,7 +20255,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d4abf756-5774-4fa4-a144-85ad2a0c115d")
+			(uuid "273deb1d-7861-42a7-aedf-878c0072ad38")
 		)
 		(fp_line
 			(start -0.75 -1.5)
@@ -20152,7 +20265,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "80d4da25-b002-4619-accf-6f59ea80a268")
+			(uuid "547dfd4c-78c7-4609-8ee9-05e14c144a0a")
 		)
 		(fp_line
 			(start 1.5 -1.5)
@@ -20162,12 +20275,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7722eb7d-81a7-43a9-a0f4-88d35f31cc59")
+			(uuid "e3cefac5-1cb4-400c-998f-e24c9ea71b52")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "1d12caa4-c5e1-4e3c-a3c8-ebaee007496f")
+			(uuid "9a48f273-96e4-46fe-8794-e669a4beed4f")
 			(effects
 				(font
 					(size 0.75 0.75)
@@ -20180,28 +20293,28 @@
 			(size 0.67 0.96)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "0f969a5b-903c-49f8-ab4c-0e1fb7ea2fba")
+			(uuid "fe915edf-eee8-4109-8cb2-86c153f14469")
 		)
 		(pad "" smd roundrect
 			(at -0.41 0.595 270)
 			(size 0.67 0.96)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "3c0fd921-ab1b-4e3e-8672-91ae09c5b3c8")
+			(uuid "5fc705c3-5bed-4791-aa9e-a04962ccfdfc")
 		)
 		(pad "" smd roundrect
 			(at 0.41 -0.595 270)
 			(size 0.67 0.96)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a8020253-fb8b-44f2-8c9e-d2da6478b2c1")
+			(uuid "4f23cdf1-254b-4548-b022-780149f3fb15")
 		)
 		(pad "" smd roundrect
 			(at 0.41 0.595 270)
 			(size 0.67 0.96)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "1602c2d7-63d6-4616-8d40-dc2fb0fa3fec")
+			(uuid "a49a0ba8-4547-402c-bfa6-e0f225d3dfe9")
 		)
 		(pad "1" smd roundrect
 			(at -1.45 -1 270)
@@ -20211,7 +20324,7 @@
 			(net 46 "/MCU/IS31_{EN}")
 			(pinfunction "SDB")
 			(pintype "input")
-			(uuid "40e4e5c3-8af0-4df4-8088-310d2b6ec559")
+			(uuid "1eb38c6f-5583-4002-bd00-646c500f0fef")
 		)
 		(pad "2" smd roundrect
 			(at -1.45 -0.5 270)
@@ -20221,7 +20334,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VCC")
 			(pintype "power_in")
-			(uuid "35052215-13de-4a65-8244-8a1e1d4f833d")
+			(uuid "11c92dcc-8c33-4309-aa8c-cb3d2f0db7c4")
 		)
 		(pad "3" smd roundrect
 			(at -1.45 0 270)
@@ -20231,7 +20344,7 @@
 			(net 4 "Net-(D1-RK)")
 			(pinfunction "OUT1")
 			(pintype "input")
-			(uuid "53c4b66c-a995-4568-ae5c-1a1046d15a09")
+			(uuid "234c27d8-f827-497e-b21b-326f407d1120")
 		)
 		(pad "4" smd roundrect
 			(at -1.45 0.5 270)
@@ -20241,7 +20354,7 @@
 			(net 6 "Net-(D1-GK)")
 			(pinfunction "OUT2")
 			(pintype "input")
-			(uuid "60fcc2f5-558d-4478-a4aa-2a8062fae1b5")
+			(uuid "87259099-5178-49fb-b5ed-a0f28ec91cd6")
 		)
 		(pad "5" smd roundrect
 			(at -1.45 1 270)
@@ -20251,7 +20364,7 @@
 			(net 5 "Net-(D1-BK)")
 			(pinfunction "OUT3")
 			(pintype "input")
-			(uuid "e79ddbc3-2e27-4c7b-9936-6a4cc7eb1246")
+			(uuid "20f26628-7ce1-4fc0-9b12-2135b2b996bc")
 		)
 		(pad "6" smd roundrect
 			(at 1.45 1 270)
@@ -20261,7 +20374,7 @@
 			(net 1 "GND")
 			(pinfunction "GND")
 			(pintype "power_in")
-			(uuid "31a64fca-f039-49a8-82e6-979c1d0e2c99")
+			(uuid "74ae6dde-7c5b-4e2e-bf32-6eba521e5d96")
 		)
 		(pad "7" smd roundrect
 			(at 1.45 0.5 270)
@@ -20271,7 +20384,7 @@
 			(net 1 "GND")
 			(pinfunction "AD")
 			(pintype "input")
-			(uuid "5bb86c86-eaba-4da5-b5f8-0ecf7273df00")
+			(uuid "c912b107-6882-4cec-8157-a301b627858e")
 		)
 		(pad "8" smd roundrect
 			(at 1.45 0 270)
@@ -20281,7 +20394,7 @@
 			(net 93 "/RGB Driver/SCL")
 			(pinfunction "SCL")
 			(pintype "open_collector")
-			(uuid "6eb778d9-b013-49aa-ae63-9fb8256e5202")
+			(uuid "52474575-ccd0-4d13-8107-ab31167eb2a5")
 		)
 		(pad "9" smd roundrect
 			(at 1.45 -0.5 270)
@@ -20291,7 +20404,7 @@
 			(net 29 "/MCU/SDA")
 			(pinfunction "SDA")
 			(pintype "open_collector")
-			(uuid "c7e39fa6-fad7-4493-a56e-a79c9cd13a17")
+			(uuid "eb478fb5-7010-4c8c-947a-04911b7fc0e9")
 		)
 		(pad "10" smd roundrect
 			(at 1.45 -1 270)
@@ -20301,7 +20414,7 @@
 			(net 45 "/MCU/IS31_{BM}")
 			(pinfunction "VBM")
 			(pintype "open_collector")
-			(uuid "930615bd-c9ba-4846-b907-a7da92f79317")
+			(uuid "c5db07c7-3c48-4b26-8277-a7cc570b818b")
 		)
 		(pad "11" smd rect
 			(at 0 0 270)
@@ -20312,7 +20425,7 @@
 			(pinfunction "GND")
 			(pintype "passive")
 			(zone_connect 2)
-			(uuid "0db9a61d-f093-48fb-abbb-3b4b1141a4e0")
+			(uuid "6e4d7bf9-16c6-4993-991c-1e0f5d068f86")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/DFN-10-1EP_3x3mm_P0.5mm_EP1.65x2.38mm.wrl"
 			(offset
@@ -20335,7 +20448,7 @@
 		(property "Reference" "U4"
 			(at 0.8875 -2.25 90)
 			(layer "F.SilkS")
-			(uuid "3c123613-4674-4559-bd92-96690060789a")
+			(uuid "d4359d94-7837-4890-bb1e-1cfc1dc67573")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -20347,7 +20460,7 @@
 			(at 0 2.575 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "437cac8c-22fc-4527-a9f0-b0cd3c3f5c50")
+			(uuid "dbacf46c-9db9-46ac-bf68-2613108d0b41")
 			(effects
 				(font
 					(size 1 1)
@@ -20360,7 +20473,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5bc52b7a-b97f-46e6-978c-098f863ed98c")
+			(uuid "43430305-003e-4953-b5b2-8d241492ac3c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20373,7 +20486,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b78293ef-6f29-4084-b919-f9d86f6acdd8")
+			(uuid "ead64cce-fac8-4662-9617-429317210cca")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20386,7 +20499,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "617d4d44-e97e-40c8-8a9a-f4333df32076")
+			(uuid "2f7e6f14-a972-46c3-bd5b-aedcc0cfcdf1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20407,7 +20520,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8245cca2-b8f9-47ff-bce3-0b4017b7b4a2")
+			(uuid "8240d3ff-295b-4e07-8418-a79446e2da20")
 		)
 		(fp_line
 			(start -1.5 1.61)
@@ -20417,7 +20530,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d910ca1c-cc0d-4063-ac2d-500beaa71ffb")
+			(uuid "b657402f-faee-4740-98d1-7bb35bf0c4ba")
 		)
 		(fp_poly
 			(pts
@@ -20429,7 +20542,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "63388abf-21f7-4d62-934d-3f1dc903a490")
+			(uuid "41b70664-afc4-4061-bbe7-d25afb4d42f7")
 		)
 		(fp_line
 			(start 2.15 -1.85)
@@ -20439,7 +20552,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "0b591d80-592f-4242-bf06-4aba6252bc95")
+			(uuid "f8695a68-c932-4c78-9554-30aa210f31db")
 		)
 		(fp_line
 			(start -2.15 -1.85)
@@ -20449,7 +20562,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "db25c4c9-c8b3-4985-8d14-26248c3e31db")
+			(uuid "7a4687d2-0791-4df2-bde3-61971f9c1542")
 		)
 		(fp_line
 			(start -2.15 -1.85)
@@ -20459,7 +20572,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a987f8ad-5a92-41b1-b196-4c17156ef065")
+			(uuid "282d8184-524a-4637-9281-f32f65d02748")
 		)
 		(fp_line
 			(start -2.15 1.85)
@@ -20469,7 +20582,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a78ae51d-b822-47b5-bce0-92c9ca0efc23")
+			(uuid "fe7794b2-4433-4790-8608-53bbd253d8fc")
 		)
 		(fp_line
 			(start 1.5 -1.5)
@@ -20479,7 +20592,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6d4e681e-635b-42bf-8104-9ec79565513b")
+			(uuid "bc884804-8acb-4e5e-b25b-ec08d3521304")
 		)
 		(fp_line
 			(start -0.75 -1.5)
@@ -20489,7 +20602,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ad47b644-c002-4373-9b42-ad990ae3eab8")
+			(uuid "38b4e789-4b6f-4d41-9184-3d95112a0193")
 		)
 		(fp_line
 			(start -1.5 -0.75)
@@ -20499,7 +20612,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "df11506b-8277-450a-8a63-b5f3f8d91a21")
+			(uuid "640be44b-935e-437d-af0a-81a2f9f607a6")
 		)
 		(fp_line
 			(start 1.5 1.5)
@@ -20509,7 +20622,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8cf7f00d-47e1-4539-94a7-738a4b0b6f7d")
+			(uuid "65a7b9d1-cebb-48a4-8319-0641ddaf44a8")
 		)
 		(fp_line
 			(start -1.5 1.5)
@@ -20519,12 +20632,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "dd32f83a-0128-48b5-8e68-fa6f28a83b24")
+			(uuid "e7bcd9ea-2083-4acf-a89f-aa14218a1214")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "ae3f4b2d-8048-4550-9cf0-cfa276ee247f")
+			(uuid "57b28f97-1eae-4ebc-a604-65c53d7a0141")
 			(effects
 				(font
 					(size 0.7 0.7)
@@ -20536,25 +20649,25 @@
 			(at -0.3875 -0.62 90)
 			(size 0.6 1.05)
 			(layers "F.Paste")
-			(uuid "1a8bc08c-51d7-4893-9fce-b6ef33596a44")
+			(uuid "45031ae5-7c56-442e-a644-631008a26b3b")
 		)
 		(pad "" smd rect
 			(at -0.3875 0.62 90)
 			(size 0.6 1.05)
 			(layers "F.Paste")
-			(uuid "5d825ebe-3494-4b04-aab6-1ac387fb79db")
+			(uuid "4f50967d-4d86-4752-8a4c-b8e9a96b1ee6")
 		)
 		(pad "" smd rect
 			(at 0.3875 -0.62 90)
 			(size 0.6 1.05)
 			(layers "F.Paste")
-			(uuid "c10bdb0c-31ab-4dd5-b719-878f81fa1b16")
+			(uuid "b14ee229-abbe-4118-b6c0-dea3c3e8b5c5")
 		)
 		(pad "" smd rect
 			(at 0.3875 0.62 90)
 			(size 0.6 1.05)
 			(layers "F.Paste")
-			(uuid "ecf0a28c-5eb1-4dbb-ac4b-cb7f227232b2")
+			(uuid "570ab8ef-6d92-427a-90ae-770d50f0abfe")
 		)
 		(pad "1" smd rect
 			(at -1.55 -1 90)
@@ -20563,7 +20676,7 @@
 			(net 94 "Net-(U4-CS1)")
 			(pinfunction "CS1")
 			(pintype "passive")
-			(uuid "d27d96fa-08ec-491b-864d-424792a0ff55")
+			(uuid "5e86cf75-b96c-4571-b060-9d805f715cba")
 		)
 		(pad "2" smd rect
 			(at -1.55 -0.5 90)
@@ -20572,7 +20685,7 @@
 			(net 69 "/MCU/ALERT#")
 			(pinfunction "ALERT#")
 			(pintype "open_collector")
-			(uuid "319c0374-9e2b-4cb7-8fca-2c295eb34e7a")
+			(uuid "35c06ec7-686e-468c-a46b-3e45938ac71c")
 		)
 		(pad "3" smd rect
 			(at -1.55 0 90)
@@ -20581,7 +20694,7 @@
 			(net 29 "/MCU/SDA")
 			(pinfunction "SMDATA")
 			(pintype "bidirectional")
-			(uuid "5cecc902-e93c-4029-a465-6347ab363aba")
+			(uuid "535951b3-915b-452f-80e7-ab16f3c86f3f")
 		)
 		(pad "4" smd rect
 			(at -1.55 0.5 90)
@@ -20590,7 +20703,7 @@
 			(net 93 "/RGB Driver/SCL")
 			(pinfunction "SMCLK")
 			(pintype "input")
-			(uuid "6d3a52c3-e4e0-4c86-90e1-55ed1f906edc")
+			(uuid "843edfae-5243-427b-b188-d3287b9a9848")
 		)
 		(pad "5" smd rect
 			(at -1.55 1 90)
@@ -20599,7 +20712,7 @@
 			(net 3 "+3.3V")
 			(pinfunction "VDD")
 			(pintype "power_in")
-			(uuid "8014a3a8-81d5-43bc-ae1e-3c1aa606b40e")
+			(uuid "c11296e5-1d8b-4fb0-8651-eaac63b39157")
 		)
 		(pad "6" smd rect
 			(at 1.55 1 90)
@@ -20608,7 +20721,7 @@
 			(net 71 "unconnected-(U4-CS6-Pad6)")
 			(pinfunction "CS6")
 			(pintype "passive+no_connect")
-			(uuid "4429272f-4fa1-4cb6-95ff-4ec8d6d64930")
+			(uuid "54997f85-8a9a-400d-99a6-202a54237d15")
 		)
 		(pad "7" smd rect
 			(at 1.55 0.5 90)
@@ -20617,7 +20730,7 @@
 			(net 72 "unconnected-(U4-CS5-Pad7)")
 			(pinfunction "CS5")
 			(pintype "passive+no_connect")
-			(uuid "1ea8a097-d87e-4963-b072-d87fb09a461e")
+			(uuid "47c76be7-fcd7-4157-b476-27df50d9f062")
 		)
 		(pad "8" smd rect
 			(at 1.55 0 90)
@@ -20626,7 +20739,7 @@
 			(net 97 "Net-(U4-CS4)")
 			(pinfunction "CS4")
 			(pintype "passive")
-			(uuid "a02f1a89-2437-4553-8871-490b2e089038")
+			(uuid "e718cc25-977f-4d9e-a6a9-1a2148b1aea9")
 		)
 		(pad "9" smd rect
 			(at 1.55 -0.5 90)
@@ -20635,7 +20748,7 @@
 			(net 96 "Net-(U4-CS3)")
 			(pinfunction "CS3")
 			(pintype "passive")
-			(uuid "0f74ec99-608f-406d-91e0-95147f6ea7c3")
+			(uuid "d2bc5db4-0790-445b-92da-63a8200219c6")
 		)
 		(pad "10" smd rect
 			(at 1.55 -1 90)
@@ -20644,7 +20757,7 @@
 			(net 95 "Net-(U4-CS2)")
 			(pinfunction "CS2")
 			(pintype "passive")
-			(uuid "e8a6a265-2f17-4dd6-aab1-807082362871")
+			(uuid "102c0c87-3bdd-40f7-9de3-999a0a836e05")
 		)
 		(pad "11" smd rect
 			(at 0 0 90)
@@ -20653,7 +20766,7 @@
 			(net 1 "GND")
 			(pinfunction "GND")
 			(pintype "power_in")
-			(uuid "6ed44a14-465b-461d-a5b9-385a9f7630b0")
+			(uuid "e8eb25a3-77e7-4f0f-a768-a339636f4b60")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_DFN_QFN.3dshapes/DFN-10-1EP_3x3mm_P0.5mm_EP1.55x2.48mm.wrl"
 			(offset
@@ -20676,7 +20789,7 @@
 		(property "Reference" "C2"
 			(at 1.7 0 180)
 			(layer "F.SilkS")
-			(uuid "1a03b774-0b47-4d8e-aeea-29163143b9eb")
+			(uuid "8964d2f5-d07a-4f6c-a3a6-c4bff99fe346")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -20688,7 +20801,7 @@
 			(at 0 1.16 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c9603f6c-4a41-4371-b1ae-019333328b80")
+			(uuid "2baf2e48-5d2e-4822-9f9c-09d0e46f85ee")
 			(effects
 				(font
 					(size 1 1)
@@ -20701,7 +20814,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6ccf137a-7273-4fab-a3a2-85d8c399e772")
+			(uuid "dc43df04-4554-41b4-beb1-9332026ad9f0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20714,7 +20827,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "27e424e9-41c1-472c-9fbe-8aad8f7f8955")
+			(uuid "5f7e3fcd-e077-4149-9bc0-7a7799b50f39")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20727,7 +20840,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "217feaa3-2dfb-4877-a214-e5219ef1030d")
+			(uuid "39acbd68-7122-4367-bf1f-6a0349288ffa")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20760,7 +20873,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "90297712-378e-4664-94e8-fcb2ca4611b4")
+			(uuid "c3c27a69-c69a-46ea-a626-bde6a7d342cc")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -20770,7 +20883,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b813423c-07b2-4932-b01b-57cc335d6e0f")
+			(uuid "0ba35068-2e28-4ac1-a375-39d42bcb0d47")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -20780,7 +20893,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "060f6724-21de-4f67-87c5-bf200c07eb20")
+			(uuid "7525b5c2-d6a6-4479-954c-c26c243eb8a8")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -20790,7 +20903,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "95150b29-1a64-443c-8dc4-c667f36c5d89")
+			(uuid "71c1373e-a0e3-43bf-9983-c29014ddf210")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -20800,7 +20913,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "d39096c3-f104-4544-9859-8ca0265f1e6a")
+			(uuid "d3d1f222-914d-4dac-87a5-819dde1cfc92")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -20810,7 +20923,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5329fe7d-8740-46ec-b491-abc752ea2a2d")
+			(uuid "d8a7ee8f-0f48-44ea-82b2-2e6c27722935")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -20820,7 +20933,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7fd94261-3a0a-416d-b5d8-67b9142413cc")
+			(uuid "d0eb8794-c335-423a-b5cd-1af5ed12b943")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -20830,7 +20943,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8d29fca7-93b1-44eb-9085-47bb8c39e823")
+			(uuid "754de424-de91-4a06-bff5-a664d59cf3db")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -20840,7 +20953,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8eda0244-9a98-49d2-8550-acf95e15f089")
+			(uuid "1a86f757-9133-4a1d-a32b-ff35e6750560")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -20850,12 +20963,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "bce70036-ad07-4b12-b361-de660f2a95ec")
+			(uuid "edc7ab00-b7eb-476e-b64f-05ef1190b14e")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "53ede3c6-2a0e-45fc-8f79-b1a410b4a907")
+			(uuid "e4aec514-1596-44a1-b80e-c6b5d2784936")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -20870,7 +20983,7 @@
 			(roundrect_rratio 0.25)
 			(net 8 "Net-(U2-VREG_VOUT)")
 			(pintype "passive")
-			(uuid "3f7bd312-a06c-449c-a100-b2308a476056")
+			(uuid "23907959-66a8-4bd2-8eb0-ad49410e9b22")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 180)
@@ -20879,7 +20992,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "dd9dd9f5-45cb-494b-8c07-b71ae042d27b")
+			(uuid "287396e7-00b4-4432-ae82-a3bc3c4b013a")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -20902,7 +21015,7 @@
 		(property "Reference" "C38"
 			(at -3 0.1 0)
 			(layer "F.SilkS")
-			(uuid "828a5bbc-b9ef-4cfa-ae8d-ba89933b024f")
+			(uuid "c7b7879e-e2f3-4c3d-bf30-2e9c926dd25d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -20914,7 +21027,7 @@
 			(at 0 1.43 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "82ec2598-c0ef-4e31-a9ac-e71cf5a80d8e")
+			(uuid "07735628-2fb0-4ce2-9ecb-142082b0312a")
 			(effects
 				(font
 					(size 1 1)
@@ -20927,7 +21040,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "42a78a69-8c9e-4505-9a57-e94d94556e92")
+			(uuid "c1b74c5c-5194-4f44-bd74-2a5e15798766")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20940,7 +21053,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5732cbb4-db29-43b2-92ba-ceba98fadbda")
+			(uuid "856387b9-898e-4930-9f22-5c1f0e1d1672")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20953,7 +21066,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b9d56044-97d7-409b-8e0f-df31a156be7e")
+			(uuid "9db30db8-48e9-48ea-b24c-853c16680494")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -20974,7 +21087,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "2b4bd113-85fe-4da1-8f92-4478f72b5a9b")
+			(uuid "8af5db01-fbd4-497a-a61e-e78810fe3257")
 		)
 		(fp_line
 			(start -0.14058 -0.51)
@@ -20984,7 +21097,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5eb9810b-69d2-42d0-a0eb-ef136b917b5f")
+			(uuid "dabecf68-e2a5-48ff-bed8-7b42b956150a")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -20994,7 +21107,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "1d922cbb-3cd8-4d23-952b-20c5f1a49e57")
+			(uuid "b865ab37-d54c-4c21-9ddc-2e933af4e16c")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -21004,7 +21117,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "140b0b8a-99b4-45c9-b612-ed49207883cc")
+			(uuid "27d1f1a6-7fe9-4900-bd6b-f252e41ea502")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -21014,7 +21127,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "98081e41-45f1-440c-b18d-2750a89e2619")
+			(uuid "fa9c605d-e612-442e-9250-5ceebebc79a8")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -21024,7 +21137,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "827853e5-5d0f-469b-b12b-5b18c5fadffe")
+			(uuid "753434a0-2d43-4980-8f8c-b89327742f55")
 		)
 		(fp_line
 			(start 0.8 0.4)
@@ -21034,7 +21147,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9c0ec45c-42e1-42d9-8dff-6e174a6bcd89")
+			(uuid "ef237e80-7ed8-4373-a8ad-96628c997c03")
 		)
 		(fp_line
 			(start 0.8 -0.4)
@@ -21044,7 +21157,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ee0ac1f2-b7b7-4cc0-bfea-118d456ecb73")
+			(uuid "e0b78025-64bc-4f30-a1fe-cb267229cd9c")
 		)
 		(fp_line
 			(start -0.8 0.4)
@@ -21054,7 +21167,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0001357f-7622-499a-aef7-7663c669aa3e")
+			(uuid "0e95da6c-e73d-46c9-844c-6df81982e9fb")
 		)
 		(fp_line
 			(start -0.8 -0.4)
@@ -21064,12 +21177,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2b696e5a-fc90-494a-8f24-a27a1a018469")
+			(uuid "e019b5aa-ac3a-4426-93c4-6e8794966f7c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "f7654466-0362-4ecd-a083-227fb0b0ce5e")
+			(uuid "47d529c1-10aa-480a-9498-5eaf210fb7a8")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -21084,7 +21197,7 @@
 			(roundrect_rratio 0.25)
 			(net 9 "VBUS")
 			(pintype "passive")
-			(uuid "3fa698b5-6039-4880-bc38-f1db5487e430")
+			(uuid "35a6e0b1-9524-404f-b33a-cbb5b11d017d")
 		)
 		(pad "2" smd roundrect
 			(at 0.775 0 180)
@@ -21093,7 +21206,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "90ef5d09-7d72-44c6-8751-e20f2aea4921")
+			(uuid "3056e064-78ec-4ea1-b26a-67278a8d5fdf")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0603_1608Metric.wrl"
 			(offset
@@ -21116,7 +21229,7 @@
 		(property "Reference" "C23"
 			(at 0 -1.85 -90)
 			(layer "F.SilkS")
-			(uuid "7cd9e053-5890-4760-b379-4e91dc1f440b")
+			(uuid "d0e44546-864f-4236-8272-6dd054c8ea0f")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -21128,7 +21241,7 @@
 			(at 0 1.85 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4f43517a-8b69-40e2-934d-880e0c47a5c7")
+			(uuid "96f2d0c9-d685-4938-9b89-a01506c7a9e6")
 			(effects
 				(font
 					(size 1 1)
@@ -21141,7 +21254,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2b97f92f-e473-4bc5-89ef-b071fd486317")
+			(uuid "736e6ca3-8dc7-4b36-8244-edd76237078e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21154,7 +21267,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "32b11815-e016-4871-8953-a7fa80e40eda")
+			(uuid "278e1970-354b-4805-be69-d6e2f83092de")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21167,7 +21280,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9825e90c-d2aa-45d6-a805-32be138f1d7f")
+			(uuid "05025db9-7316-42a4-b8f2-4d620c061ec4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21188,7 +21301,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6e53280b-520c-4b92-b79c-bff94f37bafe")
+			(uuid "40e314a9-564b-4fa9-8567-0bdf7b1afc9a")
 		)
 		(fp_line
 			(start -0.711252 -0.91)
@@ -21198,7 +21311,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0bec0b56-8350-4096-9080-547ad35f2e3f")
+			(uuid "d1644a20-5c6f-4b0e-b2e7-3cdf41e2a0a9")
 		)
 		(fp_line
 			(start -2.3 1.15)
@@ -21208,7 +21321,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e1e9b58e-e29e-491a-9576-b57dd42a546d")
+			(uuid "628e459b-5053-40ca-aa7b-5edbc4ab2e41")
 		)
 		(fp_line
 			(start 2.3 1.15)
@@ -21218,7 +21331,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c3792ff3-96d6-440d-a74a-d1aad4ebdfbd")
+			(uuid "3e7cd3cd-1c93-4120-99f1-a9cb572b90f3")
 		)
 		(fp_line
 			(start -2.3 -1.15)
@@ -21228,7 +21341,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "6adfd60f-54f6-4979-9338-83a01cb31313")
+			(uuid "77c626ac-b851-4df3-96fe-c98f13fedc87")
 		)
 		(fp_line
 			(start 2.3 -1.15)
@@ -21238,7 +21351,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f1990494-2b37-4519-a831-c037d3afb558")
+			(uuid "2638e185-f217-4693-98ee-d94a8baef21f")
 		)
 		(fp_line
 			(start -1.6 0.8)
@@ -21248,7 +21361,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "dd682e9b-506f-41cc-898c-7a445b6199aa")
+			(uuid "d49c267f-6ac3-4de6-9773-ed29f6bb486a")
 		)
 		(fp_line
 			(start 1.6 0.8)
@@ -21258,7 +21371,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0e6d25a4-0cb3-493c-8bea-4dd618eb6a4f")
+			(uuid "48546f71-1415-47a6-ac20-9e0e53171767")
 		)
 		(fp_line
 			(start -1.6 -0.8)
@@ -21268,7 +21381,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0d5006f0-7081-4ce2-890b-81ac2defa5dc")
+			(uuid "87fb8c24-6d36-4a68-9060-21f75281d750")
 		)
 		(fp_line
 			(start 1.6 -0.8)
@@ -21278,12 +21391,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "839c416c-1a44-4279-81a5-ab42b2c9522c")
+			(uuid "fac88333-f19d-4281-b408-2f898cb78d77")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "e02c46db-0509-417a-a6b4-85943ec48754")
+			(uuid "a641d5a8-8848-4524-8225-b53afed14e87")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -21298,7 +21411,7 @@
 			(roundrect_rratio 0.217391)
 			(net 82 "+12V")
 			(pintype "passive")
-			(uuid "90f4bb0e-e82c-4e43-a486-f123fad0a74c")
+			(uuid "83f78dce-2c26-471e-b36f-09c53ee15802")
 		)
 		(pad "2" smd roundrect
 			(at 1.475 0 270)
@@ -21307,7 +21420,7 @@
 			(roundrect_rratio 0.217391)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "b86919ed-1729-427b-b444-18a97133a10d")
+			(uuid "f3436647-2f27-46dd-beaf-66b66b96044e")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_1206_3216Metric.wrl"
 			(offset
@@ -21330,7 +21443,7 @@
 		(property "Reference" "Y1"
 			(at -2.8 0.82 0)
 			(layer "F.SilkS")
-			(uuid "ef52fc01-9af5-4b41-8e3c-e060fffcb7f0")
+			(uuid "54566fdc-07e6-46b2-a159-b56cf30af27b")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -21342,7 +21455,7 @@
 			(at 0 2.45 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "9619982d-9eb5-4192-bbd5-64583d61ed4d")
+			(uuid "347ebebe-1c7e-4e18-96aa-a58c2161c655")
 			(effects
 				(font
 					(size 1 1)
@@ -21355,7 +21468,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a2e2be4c-e2de-46cf-b662-43b62550d2d0")
+			(uuid "2cdac4c9-9d18-479f-8648-bd4122b711b3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21368,7 +21481,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c26507e1-e41e-4b0f-a445-2beef9b4f81d")
+			(uuid "64863592-f015-499a-b02e-34eba208beac")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21381,7 +21494,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "648af9f4-cd97-451b-9fb2-125980325456")
+			(uuid "8639dd79-9356-4400-804b-4633ac39209c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21402,7 +21515,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "91c5dfa8-b29e-40ba-ae06-1eed48a5bdd9")
+			(uuid "a72bc7ef-da55-4d04-b7e2-69b156010d10")
 		)
 		(fp_line
 			(start -2 1.65)
@@ -21412,7 +21525,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "64d82d30-c484-4990-95f9-f7df84017b9a")
+			(uuid "ec474cb2-6380-41ed-824c-888926a1e88b")
 		)
 		(fp_line
 			(start -2.1 -1.7)
@@ -21422,7 +21535,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "371a0f73-4e0b-45b4-b623-694f14f8ea21")
+			(uuid "c048937d-50f6-486e-93f3-5198389af253")
 		)
 		(fp_line
 			(start -2.1 1.7)
@@ -21432,7 +21545,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5b2091c6-73e9-4e60-85d0-59b4f6002396")
+			(uuid "e9004abc-040c-4dd9-8b60-9ac5221b27b9")
 		)
 		(fp_line
 			(start 2.1 -1.7)
@@ -21442,7 +21555,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "39770d78-734b-4796-ab44-a6b7ef6ff83f")
+			(uuid "9e7372ed-a04b-4038-967a-ecd5a59835d4")
 		)
 		(fp_line
 			(start 2.1 1.7)
@@ -21452,7 +21565,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ef862ec6-3083-4024-b672-33cd42c8097a")
+			(uuid "f2893ca8-849c-4354-b629-e0f54f3a30c2")
 		)
 		(fp_line
 			(start -1.6 -1.05)
@@ -21462,7 +21575,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "877d22ab-f166-46f4-85d8-2ad2eab3875a")
+			(uuid "cbb99c5f-094a-4c26-81d6-ebccfa6a415b")
 		)
 		(fp_line
 			(start -1.6 0.25)
@@ -21472,7 +21585,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6f00b6b0-b0ed-4077-8d63-73c3c6156f4a")
+			(uuid "2117d7e7-c744-4fba-b920-29b20f77eb4e")
 		)
 		(fp_line
 			(start -1.6 1.05)
@@ -21482,7 +21595,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "714a5171-3863-4664-bce4-299360811231")
+			(uuid "28c6aea6-5a68-4b41-9906-aeab9c33b9d3")
 		)
 		(fp_line
 			(start -1.4 -1.25)
@@ -21492,7 +21605,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "4fccaccc-a0bd-49d9-8c9c-729e967e21a4")
+			(uuid "c669f291-f053-4994-84f9-271d13dd30a6")
 		)
 		(fp_line
 			(start -1.4 1.25)
@@ -21502,7 +21615,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "430e0bcb-6756-4848-91ed-2366e030af58")
+			(uuid "2ed58013-3f49-4207-beef-17b95873c428")
 		)
 		(fp_line
 			(start 1.4 -1.25)
@@ -21512,7 +21625,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7bf6da65-9db3-41ab-9115-ec93588dfbe0")
+			(uuid "c1e553b4-bb9e-4389-931b-ffbbacb86d93")
 		)
 		(fp_line
 			(start 1.4 1.25)
@@ -21522,7 +21635,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "33be9647-b083-4e82-8dba-2052f7523f88")
+			(uuid "60e54606-4976-47f7-9cde-171f91331cd6")
 		)
 		(fp_line
 			(start 1.6 -1.05)
@@ -21532,7 +21645,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5925c5e4-ebca-47ff-bb85-483e3a6e7248")
+			(uuid "94875de6-623f-4adb-a723-8f0c6e73e170")
 		)
 		(fp_line
 			(start 1.6 1.05)
@@ -21542,12 +21655,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7f8110df-8b7b-4ffe-beae-b1e0e8b2b5f2")
+			(uuid "1b8ce0a4-cff0-4686-bc9c-07cc624406ed")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "e3372401-9bd4-4b02-82e3-b9d0ee9721e1")
+			(uuid "811e2a42-dd09-4482-952a-eeb9c09c3b40")
 			(effects
 				(font
 					(size 0.7 0.7)
@@ -21562,7 +21675,7 @@
 			(net 11 "Net-(C15-Pad1)")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "5b624156-0bb8-4ff3-b4fe-ef8f44eb1031")
+			(uuid "68256a34-de0f-4035-8015-a7e70e388d4b")
 		)
 		(pad "2" smd rect
 			(at 1.1 0.8)
@@ -21571,7 +21684,7 @@
 			(net 1 "GND")
 			(pinfunction "2")
 			(pintype "passive")
-			(uuid "e184d4a1-6d10-4467-bbae-f1ec2c29d0ea")
+			(uuid "7849bfa7-bf3c-41b4-b57c-5fc3ae5b3737")
 		)
 		(pad "3" smd rect
 			(at 1.1 -0.8)
@@ -21580,7 +21693,7 @@
 			(net 10 "Net-(U2-XIN)")
 			(pinfunction "3")
 			(pintype "passive")
-			(uuid "ce4ca791-ba89-4388-a255-355e96c04284")
+			(uuid "9d72f934-d6b4-4c74-8d11-a5bbf583a2d2")
 		)
 		(pad "4" smd rect
 			(at -1.1 -0.8)
@@ -21589,7 +21702,7 @@
 			(net 1 "GND")
 			(pinfunction "4")
 			(pintype "passive")
-			(uuid "a6cad89d-05e4-4f89-8700-6a41b26ab3ca")
+			(uuid "0c3e352f-6fba-4cd6-8495-6bc521688a7c")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Crystal.3dshapes/Crystal_SMD_Abracon_ABM8AIG-4Pin_3.2x2.5mm.wrl"
 			(offset
@@ -21612,7 +21725,7 @@
 		(property "Reference" "C25"
 			(at 0 -1.4 90)
 			(layer "F.SilkS")
-			(uuid "c2c01516-b50e-4fc2-86e8-68b558d1a6db")
+			(uuid "0e1b4240-6d58-4452-8be7-702c3c8fd7a8")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -21624,7 +21737,7 @@
 			(at 0 1.68 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f574050f-0e1f-433b-823e-5d82a7feceb6")
+			(uuid "60ee0277-6d33-45c5-b716-06d0b44df7e5")
 			(effects
 				(font
 					(size 1 1)
@@ -21637,7 +21750,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dd1e0818-091f-41ae-8088-08a4bf7018ca")
+			(uuid "385f74bb-bc1b-472e-a798-79454b29ba2e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21650,7 +21763,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6985938c-b2e0-4cbe-82ff-8b1296ba3e8e")
+			(uuid "d71e1b2b-076c-42e1-9bc5-920320edf107")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21663,7 +21776,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b73b32fe-47c2-4770-9fab-61e0c81273d1")
+			(uuid "f9f7674a-4f00-49dd-a815-12df321f53d6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21684,7 +21797,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "319a4aea-5a42-4b7c-a281-b6d424801c65")
+			(uuid "2dfd1a73-e2a5-44d2-bf2e-f0a31758ce4f")
 		)
 		(fp_line
 			(start -0.261252 0.735)
@@ -21694,7 +21807,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d4952b85-5db4-4818-92a1-7a080ab8bd9f")
+			(uuid "d976260f-f7e8-404b-b3a5-8ad69c252730")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -21704,7 +21817,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "95304918-c605-4eb1-aa5a-a1ff8d7144d7")
+			(uuid "ffb6da3f-3406-403d-878d-d86f28366b17")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -21714,7 +21827,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "dfc064c8-4aa9-4139-b917-c84ae5b54c5f")
+			(uuid "97596145-62a0-43c0-bfc9-7df48547a6f5")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -21724,7 +21837,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9d5345a1-7cba-4c83-9539-550286b0df60")
+			(uuid "04350b69-07c5-4931-9641-bf0ee9500cb8")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -21734,7 +21847,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "25b14908-7687-48a2-995a-1f6c0875c38f")
+			(uuid "b0a07bab-580c-4198-accc-7aa7817ff163")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -21744,7 +21857,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c1252892-07cd-40bd-b0b6-ba4a879ec42f")
+			(uuid "dcb882be-3266-4e65-8b16-ffc57dee29d6")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -21754,7 +21867,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9989abb4-9a3c-4bf2-a930-9d122c60381a")
+			(uuid "bd3041bf-a3f2-4765-bae4-6eede119b887")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -21764,7 +21877,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "a2efdc63-0bf4-496a-aa98-3a8495f5b0f3")
+			(uuid "0209d13c-18c3-4c9d-b570-4cb0fe030d91")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -21774,12 +21887,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b59d7ab9-ec5b-4ae7-87f3-5b482c6830ae")
+			(uuid "7443f40c-c299-44be-947a-92984e89118f")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "32f388fd-a6bc-4cb9-93f6-ddf1c4c0c4e2")
+			(uuid "31e430a2-eb18-4a35-8c1f-1f000dc89833")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -21794,7 +21907,7 @@
 			(roundrect_rratio 0.25)
 			(net 9 "VBUS")
 			(pintype "passive")
-			(uuid "a40eccd0-d529-4103-92ac-d00a90c363d2")
+			(uuid "e3ae50d1-8615-49a9-8563-51fc42c38eeb")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 90)
@@ -21803,7 +21916,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "6b4750ae-79e7-4a96-9ebe-20b80242d944")
+			(uuid "bcfb24d8-ec8b-45d6-99c5-2e751848da21")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -21826,7 +21939,7 @@
 		(property "Reference" "R16"
 			(at 0 -1.2 0)
 			(layer "F.SilkS")
-			(uuid "8889a98d-8492-42de-a621-2703f7bcdcb5")
+			(uuid "1ec4d17a-559b-4f19-b702-b00af2c6f9d8")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -21838,7 +21951,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2e313a25-ccdc-4884-88b1-5944530aa473")
+			(uuid "170c8291-6213-430a-8475-c46bad097c07")
 			(effects
 				(font
 					(size 1 1)
@@ -21851,7 +21964,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6a53c4e8-59d4-4324-8e51-fffaaea519e8")
+			(uuid "b8b86f5b-2a63-49ed-ba5b-3d1d2df08a49")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21864,7 +21977,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "0ef2bf2e-b264-4fca-bcbc-2d80f5360d84")
+			(uuid "70d3ff55-ece0-49f6-9046-28a233aebc71")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21877,7 +21990,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "042dbdb1-e7be-4b06-8cce-bfb4eee93250")
+			(uuid "a5f56fac-cae0-4a03-be78-0cf79b161af0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -21898,7 +22011,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "e9c496ed-d394-457c-967b-779ac01ac0f5")
+			(uuid "3ec72a4e-1a47-4b3d-97a8-cb37a7facb86")
 		)
 		(fp_line
 			(start -0.237258 0.5225)
@@ -21908,7 +22021,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "3ca86ed5-1337-4b4f-a783-5f3144a8f970")
+			(uuid "78eb7163-263f-406a-8eab-7c2f44c669fa")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -21918,7 +22031,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2a9d0db6-7337-4571-a4d9-ab3dc39bdd43")
+			(uuid "4ebbc2a8-2404-4c89-81d1-25cbe4b20773")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -21928,7 +22041,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ce0b4b58-bf75-42bd-8884-9dc1f9f414e0")
+			(uuid "f5cbd6f5-81cf-4e75-b339-805d3033ad5c")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -21938,7 +22051,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "547d528b-e0ee-40b9-b3a6-516d82f7fabe")
+			(uuid "fd387183-09a7-482d-babc-54710cf3efbb")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -21948,7 +22061,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2f811601-98b5-41f8-9eca-b22ad9feae16")
+			(uuid "6e116dd8-e929-409b-b28e-c4dffc1f2d54")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -21958,7 +22071,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "749484a1-0cdc-434f-a867-ebbf3f033541")
+			(uuid "376a4615-25f2-4d1d-bcef-96918b138576")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -21968,7 +22081,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d3800b79-2e97-413d-88b6-e63cc7e543e1")
+			(uuid "4e95bc47-583a-4afd-97bb-630a57d0efc9")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -21978,7 +22091,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "98d51fc1-7321-4047-80ae-ae7e07cd0c17")
+			(uuid "086dbe0c-b897-448d-9b0a-7000abaa1c30")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -21988,12 +22101,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "37c67e50-51dd-465a-9457-8c048154b321")
+			(uuid "831af41b-c4e0-4110-8039-eb0eb96f9ebc")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "34a55e1c-b426-49de-9cfd-84775d463c4b")
+			(uuid "8bc79686-0205-45ee-9ebd-ca025ea930a8")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -22008,7 +22121,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "a9311f6d-4c06-41ff-9b61-d9d2b2a6f69d")
+			(uuid "dee12598-828c-459e-b086-5651b5af9809")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0)
@@ -22017,7 +22130,7 @@
 			(roundrect_rratio 0.25)
 			(net 39 "/MCU/LTC44_{CURR}")
 			(pintype "passive")
-			(uuid "66493f8b-8262-4a14-933d-be67dbdbd5e3")
+			(uuid "82e19e01-14c3-45ef-911e-65c57f36dadf")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -22040,7 +22153,7 @@
 		(property "Reference" "C19"
 			(at 2.3 0 90)
 			(layer "F.SilkS")
-			(uuid "a2ef2fd6-26bc-48bf-bb97-1d80d585b878")
+			(uuid "1b0dd8bd-a139-49a9-ac49-41201ec43459")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -22052,7 +22165,7 @@
 			(at 0 1.16 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "18b7c5e9-7476-41eb-8e80-dbd736766be6")
+			(uuid "30337715-cf50-41c6-81c0-2e972e9d3a7c")
 			(effects
 				(font
 					(size 1 1)
@@ -22065,7 +22178,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c2129616-da3b-403d-bcf7-516f4660bd60")
+			(uuid "fe2168fc-1cd3-4b8f-bcf1-451ed7304db8")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22078,7 +22191,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "3bfa6d6a-bc77-4f83-9c72-35ec6e90d26d")
+			(uuid "a6a7fff7-1977-4d38-be5b-74c7162ae576")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22091,7 +22204,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dd1c6c84-c303-4e54-bf4e-41ec47396caa")
+			(uuid "fd1a4f23-a2d8-41e0-a90b-f737017c93c4")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22112,7 +22225,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "60cca1d3-da2c-4826-a613-20e8d9e44847")
+			(uuid "e75a55c2-699b-4ef3-ba62-5b8cdb5cb288")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -22122,7 +22235,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "34aec82c-fa43-401e-9e32-4c6bab4bcfcd")
+			(uuid "d03dce23-a6d0-4377-9b18-eca11a3499da")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -22132,7 +22245,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "b38ff150-2a9a-46a7-82db-69a7e9fc6a2e")
+			(uuid "41ca6899-127b-42f9-88ad-ab078f0cfe08")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -22142,7 +22255,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "7815a596-2b1f-424e-8e60-67ed67bd0c0f")
+			(uuid "3f328fe2-047e-4b10-aca6-00f399312cf2")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -22152,7 +22265,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8903ae8a-6da7-4df6-a351-025b9cd5b64a")
+			(uuid "8e900b4c-48ba-4438-a46f-e1b9f4dd3b2a")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -22162,7 +22275,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "333c45b2-171a-4e16-a516-12b7bed3aef4")
+			(uuid "9841255f-e143-4931-a252-6f482b0db8c3")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -22172,7 +22285,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "97783d8f-2fb2-45f9-afcc-55f6bae16d86")
+			(uuid "4525ede3-dc18-4b92-bf64-83b7bece0435")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -22182,7 +22295,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d2500600-4556-4417-84f4-8b9c2954d591")
+			(uuid "c47bf03b-8bd6-46c5-a7f4-09d63bfe3259")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -22192,7 +22305,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d372617f-41cf-4d4d-a3ca-98f2305dbd97")
+			(uuid "a135bf66-cdfe-47cc-83c6-f612595b69f0")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -22202,12 +22315,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "70b22730-c5cd-4984-9965-ae169e4daa25")
+			(uuid "e1947aa4-84c2-43f8-a416-1c1600ddaadb")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "126f6385-3790-40a0-ab0e-714d24d51354")
+			(uuid "35dd0639-cead-4afb-808d-586e22324179")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -22222,7 +22335,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "1372d54d-5fc9-43a8-a4a1-83378c085000")
+			(uuid "51cb3b65-9e47-4001-9dfc-9f992aafaffe")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 90)
@@ -22231,7 +22344,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "11ebddbb-56f8-40ce-8403-499da27d2998")
+			(uuid "2441069e-758c-4adb-be92-5d1ebcf8b54a")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -22254,7 +22367,7 @@
 		(property "Reference" "U6"
 			(at 0 -2.95 90)
 			(layer "F.SilkS")
-			(uuid "591afe89-ee5f-4bb4-9b6d-964b5cf3274b")
+			(uuid "550a597f-7c11-4dd0-8041-e46c1870cf2a")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -22266,7 +22379,7 @@
 			(at 0 2.95 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "db332fd0-ff5b-425f-99d0-81a5c6b9e246")
+			(uuid "d8d3e0f1-9c5b-4b0e-a11e-02f24d8e1fe3")
 			(effects
 				(font
 					(size 1 1)
@@ -22279,7 +22392,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e899574f-774e-4522-afdf-50303900fba6")
+			(uuid "e65922d0-c21a-49fa-98cb-d1758b3abe47")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22292,7 +22405,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b442c425-b5da-432f-90df-e739cd2c8b09")
+			(uuid "78d55d95-1042-4778-96fd-1cd8b267a373")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22305,7 +22418,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "4843cc89-eaea-4e52-82a0-5b004c5bf0e0")
+			(uuid "a45d5dec-b403-40e9-a70e-1defa2175a52")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22325,7 +22438,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6ec0e1df-6cc7-4fd8-8963-1f09ae978866")
+			(uuid "a73ebf2a-0cb0-4141-a354-2f2e2a5aa791")
 		)
 		(fp_line
 			(start 0 -2.11)
@@ -22335,7 +22448,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "bc33b7de-9f65-4871-a160-b21ec9065140")
+			(uuid "3a1f002d-6113-4d54-b199-29639d735f67")
 		)
 		(fp_line
 			(start 0 2.11)
@@ -22345,7 +22458,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "65716199-d98e-481d-88e1-0999a7114819")
+			(uuid "1de6cc11-d29f-4855-823d-13b6ea1c6a9e")
 		)
 		(fp_line
 			(start 0 2.11)
@@ -22355,7 +22468,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "92d9c84d-6b74-457f-802e-e9f523e86de8")
+			(uuid "e43467b1-9e93-4004-8248-d3926e287282")
 		)
 		(fp_poly
 			(pts
@@ -22367,7 +22480,7 @@
 			)
 			(fill solid)
 			(layer "F.SilkS")
-			(uuid "a1d76c22-c5c1-4096-964c-ebe8403937cf")
+			(uuid "ab62fdc4-a9cb-4b00-b79b-5d3ccce1f981")
 		)
 		(fp_line
 			(start 3.12 -2.25)
@@ -22377,7 +22490,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fee908d5-6ac7-4bde-8528-1c9fa2fba1ca")
+			(uuid "065402c3-27fd-4a33-9c2d-4d3d41351362")
 		)
 		(fp_line
 			(start -3.12 -2.25)
@@ -22387,7 +22500,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c011cd62-3eaf-48aa-a357-0b9495059380")
+			(uuid "194180f3-7ba1-4d2a-8099-fdc3851d4dd7")
 		)
 		(fp_line
 			(start 3.12 2.25)
@@ -22397,7 +22510,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ddd4bb34-6a1f-47c3-a301-80f023f7b600")
+			(uuid "e9c9ad62-4201-4308-8e24-6cb1d7928600")
 		)
 		(fp_line
 			(start -3.12 2.25)
@@ -22407,7 +22520,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "fdfa19c9-173d-49ef-8137-708224dcfcf9")
+			(uuid "f57e4d69-def3-421c-a2c8-a0296d38aa84")
 		)
 		(fp_line
 			(start 1.5 -2)
@@ -22417,7 +22530,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d10d2c03-f43a-44ad-9ad9-ca43b9493df3")
+			(uuid "b055cac7-d23a-4dbc-a56d-18ec5c274472")
 		)
 		(fp_line
 			(start -0.75 -2)
@@ -22427,7 +22540,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b62b4b67-1062-4844-891f-347e02d10381")
+			(uuid "7114341b-7787-4ac2-a1ba-ff398612c0ce")
 		)
 		(fp_line
 			(start -1.5 -1.25)
@@ -22437,7 +22550,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5b73aa3e-f685-4974-8ed2-31043b868657")
+			(uuid "8bd49e1d-068a-4ab4-87f0-9495d16176de")
 		)
 		(fp_line
 			(start 1.5 2)
@@ -22447,7 +22560,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0ceec84c-6622-4f1d-865c-b004a2497a49")
+			(uuid "331b37c4-d54d-4db8-8a80-e29146d31824")
 		)
 		(fp_line
 			(start -1.5 2)
@@ -22457,12 +22570,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "f6cc8eef-67a4-41af-830f-97c5145c23c0")
+			(uuid "42225fe5-4395-4ae6-8101-763e234a3706")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "4339e5f6-a3ea-45f9-9e99-2275e8df69d8")
+			(uuid "8ce5ffb7-7320-43b4-81e3-4a18295a9329")
 			(effects
 				(font
 					(size 0.75 0.75)
@@ -22475,28 +22588,28 @@
 			(size 0.67 1.15)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "2226c68d-7ea0-4a69-882f-16fcc127de22")
+			(uuid "fabef9a5-0d83-4d34-b050-5f088766f4b5")
 		)
 		(pad "" smd roundrect
 			(at -0.41 0.71 90)
 			(size 0.67 1.15)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a5d3577b-08e2-41de-8bc1-aa58dcc9b3d4")
+			(uuid "334c684f-484a-41c8-8ec8-65db7da89cc2")
 		)
 		(pad "" smd roundrect
 			(at 0.41 -0.71 90)
 			(size 0.67 1.15)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "a16688f7-1845-472c-a6ab-d7afdd3ea07c")
+			(uuid "06c82888-46de-449b-93ec-d8fa8e29cc19")
 		)
 		(pad "" smd roundrect
 			(at 0.41 0.71 90)
 			(size 0.67 1.15)
 			(layers "F.Paste")
 			(roundrect_rratio 0.25)
-			(uuid "90543887-7628-4d53-910b-5cbebcde5e01")
+			(uuid "6269a058-9b7b-408e-ad88-2be3847ed9eb")
 		)
 		(pad "1" smd roundrect
 			(at -2.15 -1.625 90)
@@ -22506,7 +22619,7 @@
 			(net 2 "+5V")
 			(pinfunction "VOUT")
 			(pintype "power_out")
-			(uuid "47c0cb62-05b5-43a7-a8a4-b5d630429bcd")
+			(uuid "26ca2a58-8390-4b2a-a1b0-db4f2dd4544d")
 		)
 		(pad "2" smd roundrect
 			(at -2.15 -0.975 90)
@@ -22516,7 +22629,7 @@
 			(net 2 "+5V")
 			(pinfunction "VOUT")
 			(pintype "passive")
-			(uuid "c7159cb2-9f2c-4a08-a4a1-78aac98d4d4c")
+			(uuid "8df6f490-0494-45ae-a634-600ce436df26")
 		)
 		(pad "3" smd roundrect
 			(at -2.15 -0.325 90)
@@ -22526,7 +22639,7 @@
 			(net 39 "/MCU/LTC44_{CURR}")
 			(pinfunction "PROG")
 			(pintype "output")
-			(uuid "9b88704e-737d-477e-86fd-f2e3cca62c84")
+			(uuid "e6804d4b-73aa-408a-9fb3-c808b2a3dfd6")
 		)
 		(pad "4" smd roundrect
 			(at -2.15 0.325 90)
@@ -22536,7 +22649,7 @@
 			(net 40 "/MCU/LTC44_{SEL}")
 			(pinfunction "SEL")
 			(pintype "input")
-			(uuid "fe4e1380-1bad-4424-9ba5-0ec8e77598c2")
+			(uuid "e40f99c1-74db-4609-9462-004908bc6993")
 		)
 		(pad "5" smd roundrect
 			(at -2.15 0.975 90)
@@ -22546,7 +22659,7 @@
 			(net 35 "Net-(U6-FB)")
 			(pinfunction "FB")
 			(pintype "input")
-			(uuid "16c9422d-2b00-4e77-bc28-1ff1cee5786e")
+			(uuid "0a3be778-380f-4a36-99f4-537eebe1587e")
 		)
 		(pad "6" smd roundrect
 			(at -2.15 1.625 90)
@@ -22556,7 +22669,7 @@
 			(net 41 "/MCU/LTC44_{EN}")
 			(pinfunction "EN")
 			(pintype "input")
-			(uuid "b67fa8a1-9951-4957-8748-4541cca7e012")
+			(uuid "41213ba5-8027-4e68-8b3d-673051bd9326")
 		)
 		(pad "7" smd roundrect
 			(at 2.15 1.625 90)
@@ -22566,7 +22679,7 @@
 			(net 37 "Net-(U6-PFI_RET)")
 			(pinfunction "PFI_RET")
 			(pintype "input")
-			(uuid "c7462771-2937-4b46-b9e9-e71ba3cb27fc")
+			(uuid "20a9d197-c4b0-4017-bdf6-dd97b35516ed")
 		)
 		(pad "8" smd roundrect
 			(at 2.15 0.975 90)
@@ -22576,7 +22689,7 @@
 			(net 38 "/MCU/LTC44_{~{PFO}}")
 			(pinfunction "~{PFO}")
 			(pintype "open_collector")
-			(uuid "1c542f5c-fa24-464a-9141-fd03dfc8f564")
+			(uuid "c8253b97-b179-485e-9f17-c84053bafb70")
 		)
 		(pad "9" smd roundrect
 			(at 2.15 0.325 90)
@@ -22586,7 +22699,7 @@
 			(net 34 "Net-(U6-PFI)")
 			(pinfunction "PFI")
 			(pintype "input")
-			(uuid "05c5a578-3e73-4b69-a2cf-17876d288484")
+			(uuid "7d061bbe-5caa-41b1-b47e-b682a4682d70")
 		)
 		(pad "10" smd roundrect
 			(at 2.15 -0.325 90)
@@ -22596,7 +22709,7 @@
 			(net 12 "Net-(U6-VMID)")
 			(pinfunction "VMID")
 			(pintype "output")
-			(uuid "ff4e9ac0-b79b-4722-894c-89a7d85e6963")
+			(uuid "fa42a38a-2396-46d8-9c86-d7574ec6bd20")
 		)
 		(pad "11" smd roundrect
 			(at 2.15 -0.975 90)
@@ -22606,7 +22719,7 @@
 			(net 9 "VBUS")
 			(pinfunction "VIN")
 			(pintype "power_in")
-			(uuid "b36b9c7e-8478-4cdd-b87a-64be8024cef3")
+			(uuid "c7710b40-d4c3-4473-939b-b22324c1a8f6")
 		)
 		(pad "12" smd roundrect
 			(at 2.15 -1.625 90)
@@ -22616,7 +22729,7 @@
 			(net 9 "VBUS")
 			(pinfunction "VIN")
 			(pintype "passive")
-			(uuid "06a4e0b9-960a-40ee-8941-5d9fd4d8099d")
+			(uuid "e8cbbe05-0848-444c-ae1e-8a3b6e8eb357")
 		)
 		(pad "13" smd rect
 			(at 0 0 90)
@@ -22627,7 +22740,7 @@
 			(pinfunction "GND")
 			(pintype "power_in")
 			(zone_connect 2)
-			(uuid "6076adff-e118-427d-920d-7f9be9d4e180")
+			(uuid "d6e96e1b-ac43-4f5a-9bc5-d5c1496a7c3c")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Package_SO.3dshapes/MSOP-12-1EP_3x4mm_P0.65mm_EP1.65x2.85mm.wrl"
 			(offset
@@ -22650,7 +22763,7 @@
 		(property "Reference" "R17"
 			(at 2.8 0 180)
 			(layer "F.SilkS")
-			(uuid "0a5dcc73-1159-45c8-b2a5-c06202a628a1")
+			(uuid "299584b5-36bf-4601-a4fd-327e5304176c")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -22662,7 +22775,7 @@
 			(at 0 1.43 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ddecb52b-c807-4a29-9e95-644858d1601b")
+			(uuid "52fa8efe-6606-4350-bd14-c54b172fa305")
 			(effects
 				(font
 					(size 1 1)
@@ -22675,7 +22788,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c7835101-f06f-4721-a0d2-01b35ecbbb62")
+			(uuid "5875431d-0d17-4a13-91c1-5304ee4d9217")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22688,7 +22801,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c5e2f468-f185-4528-8505-6446e32832fb")
+			(uuid "14484bbc-d313-4b49-8f33-282d2984000e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22701,7 +22814,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "de2f2de4-7999-4d5f-b743-b7d99ec22991")
+			(uuid "1aadb8d2-c1b3-48dd-861c-85380827b2ad")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22722,7 +22835,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "5ac1ea1b-af69-4da0-baa1-02be50940f88")
+			(uuid "b5e3d493-84fa-4c10-8c19-b9dcf61596eb")
 		)
 		(fp_line
 			(start -0.237258 -0.5225)
@@ -22732,7 +22845,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "86d6a956-94f9-4f6f-828f-69b9bfca3e32")
+			(uuid "ad3a699b-4caf-421e-a004-1851e9dde33e")
 		)
 		(fp_line
 			(start 1.48 0.73)
@@ -22742,7 +22855,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9b8868cf-b9cf-4155-9782-b533cdf97f00")
+			(uuid "a1ace526-e4b8-47df-ba50-19cf27e38ba1")
 		)
 		(fp_line
 			(start 1.48 -0.73)
@@ -22752,7 +22865,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e402e09f-d1db-4b61-955d-5d9982ba120a")
+			(uuid "ddc1ca90-38da-4bac-acaa-5de9287d0665")
 		)
 		(fp_line
 			(start -1.48 0.73)
@@ -22762,7 +22875,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "ca36bfc8-ee4f-4d90-a3dd-ea0f5cb0ca16")
+			(uuid "ec2e9ede-4b7d-453d-8d4a-2306914350ae")
 		)
 		(fp_line
 			(start -1.48 -0.73)
@@ -22772,7 +22885,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "02b1392d-d32c-4d7b-8385-f4a00820ec11")
+			(uuid "2a109176-4066-461b-a7f4-147fc249378e")
 		)
 		(fp_line
 			(start 0.8 0.4125)
@@ -22782,7 +22895,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "2c2529b2-dec7-4ff1-88b6-d311627629d3")
+			(uuid "919cf2ba-b1c3-48e1-aacc-cc8619e8da36")
 		)
 		(fp_line
 			(start 0.8 -0.4125)
@@ -22792,7 +22905,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9666755a-330e-41e0-aca9-b63e6e9e09b4")
+			(uuid "bc97ae1e-9d92-49fa-9e94-61575edeb3a3")
 		)
 		(fp_line
 			(start -0.8 0.4125)
@@ -22802,7 +22915,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6c987a13-148e-4d9e-b0d5-97bf8a6547ec")
+			(uuid "f9d9ef1d-f4af-4e65-aa4e-9442b5a73974")
 		)
 		(fp_line
 			(start -0.8 -0.4125)
@@ -22812,12 +22925,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "cfe44f9f-a222-44d5-800b-84fec65a0f6f")
+			(uuid "1b471573-669e-482e-b69c-1c2894ec963c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "95d3d6b1-21b1-4752-a801-7a8ec8ed27d8")
+			(uuid "f5d480b3-b045-4385-b4d5-de713796b81f")
 			(effects
 				(font
 					(size 0.4 0.4)
@@ -22832,7 +22945,7 @@
 			(roundrect_rratio 0.25)
 			(net 40 "/MCU/LTC44_{SEL}")
 			(pintype "passive")
-			(uuid "2d74916b-4ccd-4b12-89f2-c30e038ba745")
+			(uuid "8767b7d2-8ee6-4304-8b1e-445fd2fa4b95")
 		)
 		(pad "2" smd roundrect
 			(at 0.825 0 180)
@@ -22841,7 +22954,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "41f459ff-1bc4-484f-81f7-3dbdda152ce7")
+			(uuid "4af44390-b696-4a56-901c-0c3d6712fbe0")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0603_1608Metric.wrl"
 			(offset
@@ -22864,7 +22977,7 @@
 		(property "Reference" "R8"
 			(at -2 0 0)
 			(layer "F.SilkS")
-			(uuid "11fbc6c1-4776-4aa6-859e-ce888aa5d400")
+			(uuid "07aad9b2-86b5-4ed1-9d20-d2b9af43c941")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -22876,7 +22989,7 @@
 			(at 0 1.17 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "dd661cb6-3c57-46f4-852e-378c6b2a415b")
+			(uuid "26904c99-da23-47f2-8419-1c219ef2785b")
 			(effects
 				(font
 					(size 1 1)
@@ -22889,7 +23002,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f6782f19-1bfa-4097-a847-356950a274ce")
+			(uuid "a5c717bc-541d-4ad1-a3cc-97aff2effa89")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22902,7 +23015,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e42dfe28-f8e7-4eab-89c9-85c855b00b4d")
+			(uuid "c00b0274-eb32-461e-9552-1ac503fd3203")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22915,7 +23028,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c5226d8e-376e-47e8-af99-568d7ab85bda")
+			(uuid "7f12d660-dcd8-4112-834b-ae934f39ae7c")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -22936,7 +23049,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "7bb8bb05-7640-4bd8-936a-6b2417ba6db6")
+			(uuid "0806ccda-2a9c-4823-813d-281ac088f9d7")
 		)
 		(fp_line
 			(start -0.153641 0.38)
@@ -22946,7 +23059,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "05eacbe0-6256-4e9e-9470-398b8cecc309")
+			(uuid "1dec5d42-9a81-44eb-a0f3-18c0ca94fe80")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -22956,7 +23069,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "39c1bf5a-ce2a-42d4-8dbc-adaa1ac3afc9")
+			(uuid "4f075cea-916d-4492-9e5b-a191346a5dda")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -22966,7 +23079,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "bc9816cc-ff22-4e5e-8e0c-63175a089901")
+			(uuid "35b353d2-8085-40f9-ac97-d818e19e06fd")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -22976,7 +23089,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "73c6c317-9d2b-4c36-acf7-5709b4a186a8")
+			(uuid "53011c18-14b1-4e99-9c09-ac1848029f37")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -22986,7 +23099,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e20df751-25a8-4bf1-a981-1a27fee601db")
+			(uuid "b5b676e0-ce60-405a-8607-7452fecf2918")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -22996,7 +23109,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "6548f724-0fb2-4d48-9dd5-d7a8746f17f9")
+			(uuid "e8ef3761-56d7-49e6-981e-cad0c24e591d")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -23006,7 +23119,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c53859d9-96fd-4cb8-8b4e-6842a4f6a8fc")
+			(uuid "3fdfa41a-d94c-47b8-9dd8-8ef41a6ead3e")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -23016,7 +23129,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5e765b15-c4f1-42fd-8821-21cae8f190c9")
+			(uuid "52ca8cd2-5734-4d0b-a449-bf3533a8afc9")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -23026,12 +23139,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "5a9abb51-8a80-4f99-a71a-9bf5e210a99b")
+			(uuid "314be7da-c523-479b-9b2a-28e55aa6f4ca")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "f21ad0af-fa89-4b5f-aaa3-feb2d5e93f11")
+			(uuid "4c3d2b20-bd37-42ad-824a-857f2b15ee03")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -23046,7 +23159,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "1773b8ae-3d05-4c0e-8e1f-fc033f9a9773")
+			(uuid "8f4a090e-56e8-4570-ab1e-65abc5f5c613")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0)
@@ -23055,7 +23168,7 @@
 			(roundrect_rratio 0.25)
 			(net 21 "Net-(J2-CC1)")
 			(pintype "passive")
-			(uuid "56d72331-44a8-435e-b9c9-17cc3f3795f8")
+			(uuid "329565f3-d237-463b-af75-850c00483945")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -23078,7 +23191,7 @@
 		(property "Reference" "R7"
 			(at -0.5 1.1 180)
 			(layer "F.SilkS")
-			(uuid "f7e24d42-ceeb-4aea-8f4d-3b36351dd332")
+			(uuid "d210cd52-bf20-4893-8a09-ac39a81a3cfa")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -23090,7 +23203,7 @@
 			(at 0 1.17 180)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5b7bd0dd-9ba9-48dc-a300-c63a6a270077")
+			(uuid "dd63867b-c521-4c32-af4b-80ca6f1142a9")
 			(effects
 				(font
 					(size 1 1)
@@ -23103,7 +23216,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7c55ee2a-ccfe-4542-9ef8-eddbcc5abd9d")
+			(uuid "cdfebdae-85bb-41bf-8594-c58801c3e416")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23116,7 +23229,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e5363fbe-c2f7-43a8-8d42-ba341be1537b")
+			(uuid "7c70525f-6545-4715-bd42-6ffa355e5eb1")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23129,7 +23242,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a760cfbb-39e5-4baa-907a-012a150fb09f")
+			(uuid "ce456295-11c2-485c-919a-b0a637dbca7f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23162,7 +23275,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ddd13ca9-7733-4944-a833-6cb75c0f483f")
+			(uuid "735d0424-717e-4a83-812f-7327126ccccd")
 		)
 		(fp_line
 			(start -0.153641 -0.38)
@@ -23172,7 +23285,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "63eb0f42-adc3-424f-afee-01c75ac70fb1")
+			(uuid "82385b0d-8ae6-423b-ac2d-c8d993738524")
 		)
 		(fp_line
 			(start 0.93 0.47)
@@ -23182,7 +23295,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "9a7d3fd2-b63a-4cc8-aa87-7ceab153dbd4")
+			(uuid "e72b2f43-7d21-4bee-947c-5cfcd55040b7")
 		)
 		(fp_line
 			(start 0.93 -0.47)
@@ -23192,7 +23305,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8845bf5e-e937-40f9-a899-898d9eb675f4")
+			(uuid "d6add161-136b-4022-a914-bb4d671d3149")
 		)
 		(fp_line
 			(start -0.93 0.47)
@@ -23202,7 +23315,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "54adeba6-9b67-40ee-a25b-2b11818ca492")
+			(uuid "b1c42c57-adb9-4d82-9aa4-b97980a763c7")
 		)
 		(fp_line
 			(start -0.93 -0.47)
@@ -23212,7 +23325,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "5f1fb982-da43-4250-8bb3-982a6151fb4d")
+			(uuid "2f1587f3-74e3-468f-a78d-352f1d8eee78")
 		)
 		(fp_line
 			(start 0.525 0.27)
@@ -23222,7 +23335,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "09d64483-44e0-41db-a753-9380b2e7152f")
+			(uuid "32424ab8-ba96-4712-8b33-8ffa4e77f5ae")
 		)
 		(fp_line
 			(start 0.525 -0.27)
@@ -23232,7 +23345,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "8fd825bc-6f0a-40ba-9231-3c2cac36a3a0")
+			(uuid "c0873105-ef39-411b-9f1e-23dddd07f2bd")
 		)
 		(fp_line
 			(start -0.525 0.27)
@@ -23242,7 +23355,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7c0b7c62-b4e2-48ae-9989-8430e1ffb547")
+			(uuid "4a9278d7-67ed-4d9c-9dfe-8eee23bef5a4")
 		)
 		(fp_line
 			(start -0.525 -0.27)
@@ -23252,12 +23365,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "e1a49861-1dac-4e99-a39c-8bc4ada7b8a7")
+			(uuid "20b87e64-a389-4e4d-a1cd-1529ca613154")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 180)
 			(layer "F.Fab")
-			(uuid "0379b0d1-ecd4-4c74-9b3a-790fd02be3af")
+			(uuid "d279fc5c-3cb7-48d4-8cc3-a70f2ad90bcc")
 			(effects
 				(font
 					(size 0.26 0.26)
@@ -23272,7 +23385,7 @@
 			(roundrect_rratio 0.25)
 			(net 33 "Net-(U2-XOUT)")
 			(pintype "passive")
-			(uuid "ccd2dec2-6083-432c-81c9-3ce4edd2e11d")
+			(uuid "874fba4e-42d5-4295-b4c1-7c3bfd4578ce")
 		)
 		(pad "2" smd roundrect
 			(at 0.51 0 180)
@@ -23281,7 +23394,7 @@
 			(roundrect_rratio 0.25)
 			(net 11 "Net-(C15-Pad1)")
 			(pintype "passive")
-			(uuid "6949ea31-ea4b-434f-8276-9ca055ad0371")
+			(uuid "99f57d48-2d3b-4381-95d8-4582eabaa5a9")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
 			(offset
@@ -23304,7 +23417,7 @@
 			(at 3.7 1.395 0)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "ef90e14e-b7c8-494d-9ce9-1905798e6fb6")
+			(uuid "b02b6c59-a239-4f5e-84e8-843f293b849e")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -23317,7 +23430,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8380c9e9-7dca-4f9f-860d-ca0bcaac7275")
+			(uuid "f188ad25-5f93-4f50-bebe-fbe5c235ee76")
 			(effects
 				(font
 					(size 1 1)
@@ -23329,7 +23442,7 @@
 			(at 0 0 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "7722d403-fcb2-4f01-bf49-e6ffd5dc6948")
+			(uuid "7f8e47b8-431b-491b-9d78-4199834d32c3")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23341,7 +23454,7 @@
 			(at 0 0 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d64e56dc-368b-40f2-a8a4-42938ecf5f1a")
+			(uuid "433c18da-ab41-45c2-996d-8b27ba536d43")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23353,7 +23466,7 @@
 			(at 0 0 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6a12df46-84db-4cbe-baf3-b1ca37d13a38")
+			(uuid "526891a5-8891-4f87-9a39-4cdacf6f5367")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23374,7 +23487,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "c4ed0228-01fd-49ed-be99-df393fc95bde")
+			(uuid "e73a3e69-1875-42ef-b1fe-d38bee3fc0f0")
 		)
 		(fp_line
 			(start -1.8 -1.5)
@@ -23384,7 +23497,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "8871020c-3466-4970-a4e0-92c527bdcfd8")
+			(uuid "6caabd3d-24db-4a95-96f6-451a876c805b")
 		)
 		(fp_line
 			(start 1 -1.5)
@@ -23394,7 +23507,7 @@
 				(type default)
 			)
 			(layer "F.SilkS")
-			(uuid "2413cbd6-b7d1-43b7-9a5e-445d010991b1")
+			(uuid "456457c2-bb80-4121-89e5-5b7abe959fa1")
 		)
 		(fp_line
 			(start -2.7 1.8)
@@ -23404,7 +23517,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "4b50faa2-98ba-4a9e-8780-0e20ae4b9072")
+			(uuid "e00421e5-5d46-4041-a878-861fd781d206")
 		)
 		(fp_line
 			(start 2.7 1.8)
@@ -23414,7 +23527,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "5ab568c3-84ca-43da-aece-76658d8e8591")
+			(uuid "87e37a6e-6df4-4f06-bbc3-9d1ca0fe8a92")
 		)
 		(fp_line
 			(start -2.7 -2.4)
@@ -23424,7 +23537,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "c5604938-70e0-496f-8370-d11cef2fcf37")
+			(uuid "830022fd-405c-4dd6-8e2f-bdbb2f82c872")
 		)
 		(fp_line
 			(start -1.6 -2.4)
@@ -23434,7 +23547,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "3d82174e-1c25-4f5a-99c7-c2f47130a106")
+			(uuid "5ca77c4e-7424-41ae-bb68-b5ffcb8ab026")
 		)
 		(fp_line
 			(start 1.6 -2.4)
@@ -23444,7 +23557,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "4cb914ec-5292-4019-a71a-8d9649fd9a05")
+			(uuid "df772afd-6f96-414d-9a5d-5cc57667d65d")
 		)
 		(fp_line
 			(start 2.7 -2.4)
@@ -23454,7 +23567,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "55cb3b00-61ee-4913-9dd0-8a81627bc89d")
+			(uuid "017679ac-69d9-41ce-aff3-726d98f989d2")
 		)
 		(fp_line
 			(start -1.6 -3)
@@ -23464,7 +23577,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "c581e15d-0460-4fa3-9f90-da3d01753225")
+			(uuid "0c24fe16-53c5-47d6-9a3f-f4b28ddb92a3")
 		)
 		(fp_line
 			(start 1.6 -3)
@@ -23474,7 +23587,7 @@
 				(type default)
 			)
 			(layer "F.CrtYd")
-			(uuid "8ae93a73-63c2-4cfe-80bc-396d63394bf0")
+			(uuid "3c85eecd-bf75-4faf-9f75-8249a8f53593")
 		)
 		(fp_line
 			(start -1.75 1.4)
@@ -23484,7 +23597,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "4bc4be8c-4dfe-4fab-9599-78348e823b3e")
+			(uuid "5bb1b549-7b58-4378-b277-629cf5a8d17e")
 		)
 		(fp_line
 			(start 1.75 1.4)
@@ -23494,7 +23607,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "fe29ee03-fd90-43dc-88b9-cb087b09a047")
+			(uuid "fdd729a2-67e7-4ec8-b335-54bc4fe94c92")
 		)
 		(fp_line
 			(start -1.75 -1.4)
@@ -23504,7 +23617,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "884d7e70-9a12-4b82-ac2c-ca215ae4807e")
+			(uuid "334576ec-d490-4cbb-9b53-d78c8b9be7a1")
 		)
 		(fp_line
 			(start -0.8 -1.4)
@@ -23514,7 +23627,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "b74d5a2a-dd75-4715-bb40-3445ee27689e")
+			(uuid "c2e86161-daa6-4daf-935f-c4fcab12a2fb")
 		)
 		(fp_line
 			(start 0.9 -1.4)
@@ -23524,7 +23637,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "ff16065b-67db-4312-9892-ca3d1bcd04fa")
+			(uuid "9e6b63e0-bf2d-4746-a6b8-680c7038d54a")
 		)
 		(fp_line
 			(start 1.75 -1.4)
@@ -23534,7 +23647,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "8cd455d5-b0ea-4472-b04f-64d043d4b724")
+			(uuid "bc289777-2d2c-4aee-b127-5f8778bd10f0")
 		)
 		(fp_line
 			(start -0.8 -2.1)
@@ -23544,7 +23657,7 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "15f6025c-207b-42a4-b26d-5cbbd7b9ab59")
+			(uuid "6aec9e5b-98cf-4e0e-8324-74007260d070")
 		)
 		(fp_line
 			(start 0.9 -2.1)
@@ -23554,13 +23667,13 @@
 				(type default)
 			)
 			(layer "F.Fab")
-			(uuid "d5e93821-8eda-4a4f-ad51-8b3bd5ae82a3")
+			(uuid "ab7e7f1e-6912-4bc5-b30f-500d1536dd27")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(unlocked yes)
 			(layer "F.Fab")
-			(uuid "8b2e1016-7219-42bd-8110-df5955447f8a")
+			(uuid "e716b867-85cf-4152-bfd8-435c3e56c67b")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -23577,7 +23690,7 @@
 			(pinfunction "1")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "727ab406-f2a9-48b6-aae5-cc073ccdc554")
+			(uuid "e4fdcf33-e2d7-47e2-b21c-5c230ef98fe1")
 		)
 		(pad "2" smd roundrect
 			(at 1.8 0.725 270)
@@ -23588,7 +23701,7 @@
 			(pinfunction "2")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "5c60a5c4-277c-4feb-90ec-2cad92ce77b8")
+			(uuid "bbc8058a-76ca-4d24-9f61-a505c565f58b")
 		)
 		(pad "3" smd roundrect
 			(at 1.8 -0.725 270)
@@ -23599,7 +23712,7 @@
 			(pinfunction "K")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "eddb9304-b91c-43dc-95c2-7caac4d0f158")
+			(uuid "235221b1-83e5-400f-aec4-d61ba42921f9")
 		)
 		(pad "4" smd roundrect
 			(at -1.8 -0.725 270)
@@ -23610,7 +23723,7 @@
 			(pinfunction "A")
 			(pintype "passive")
 			(thermal_bridge_angle 45)
-			(uuid "9a0f48ac-0d73-4e24-b991-9911e9fb1d05")
+			(uuid "a16333d4-5088-4973-b905-2f9b5472171a")
 		)
 		(model "${OE_3DMODEL_DIR}/PANASONIC_EVQP7-JA-01P.STEP"
 			(offset
@@ -23633,7 +23746,7 @@
 		(property "Reference" "C13"
 			(at -0.3 2.2 0)
 			(layer "F.SilkS")
-			(uuid "ac79e566-bef1-4a6b-9000-24060e6af40d")
+			(uuid "016d24b2-9a7a-43fb-b4cc-b1aec1598090")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -23645,7 +23758,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "6084056e-752f-49ec-9717-77d28f42809f")
+			(uuid "42b33430-438c-4b13-a12a-32de90355b5e")
 			(effects
 				(font
 					(size 1 1)
@@ -23658,7 +23771,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "20b1f34b-e218-4a86-9ae7-9351f51ed1d6")
+			(uuid "80e0a621-e37e-441e-9368-807d2818e62b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23671,7 +23784,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1524b56b-3a20-4f12-aaa2-b6e2b8db9464")
+			(uuid "1b6706aa-ce69-4a98-8de8-6eab4d762d0e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23684,7 +23797,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "04731eb6-c2e8-49de-a75b-9a7d8e615aa4")
+			(uuid "08af6375-609e-49d1-9ff9-6406117138b6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23705,7 +23818,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1421232c-5944-4948-85b4-7089dc41fa32")
+			(uuid "2944e8b7-2944-4850-a8ff-dc8bb3418eab")
 		)
 		(fp_line
 			(start -0.107836 0.36)
@@ -23715,7 +23828,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6fe0950d-a329-4ef1-bb51-418fdb18a964")
+			(uuid "4ae4dfde-aae0-4165-8030-f8e57a7d30cb")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -23725,7 +23838,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "df96ecc8-a179-4f57-b971-f1d3e0f08b1c")
+			(uuid "7420d607-1c85-4ee2-921e-149e26df3922")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -23735,7 +23848,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "a54a4260-0b91-4926-9381-6f43aba12985")
+			(uuid "2367b906-62bf-46f3-baa0-a6812cefd896")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -23745,7 +23858,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2f34ed0c-ed02-4928-ab54-ed2a03c02855")
+			(uuid "fa2779f7-85ad-41f7-8b98-3d49cc0d7bcf")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -23755,7 +23868,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "07866ba7-8d35-464b-b114-7b3510b5f5db")
+			(uuid "8a437863-b785-4d8a-b6fd-a4043a2aa0d7")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -23765,7 +23878,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "03c1a85e-7393-40f6-900a-0f42535b6638")
+			(uuid "88d1af53-5b41-4d3f-a904-fdf2d6b9e068")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -23775,7 +23888,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "b4487d87-a5d7-4ec7-b38c-ab3da5112d0f")
+			(uuid "8750124c-8913-417a-a45a-8c7f2a76ffc0")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -23785,7 +23898,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "921b824e-e3f7-474e-a310-2260e22a09d8")
+			(uuid "d99be190-e421-4a71-9be9-cccbff89bed9")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -23795,12 +23908,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d88ff30b-627e-4539-9185-df31ede5b7f2")
+			(uuid "11acfab2-d0fd-4c28-9d97-85ff0588768b")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "a73e750a-438f-405a-b490-87be21cf65a5")
+			(uuid "b9257a50-4aab-4b65-93a0-a0055f3bb7ce")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -23815,7 +23928,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "ce164c54-1435-4db1-b095-f833810b1bb8")
+			(uuid "3c5e608f-e049-4f59-aab0-7b149d096a79")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 90)
@@ -23824,7 +23937,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "ec44aa50-9d91-4825-9d0e-b4e268993e5e")
+			(uuid "ba07b9f8-ba00-4846-945e-4e6436e1c6d5")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -23847,7 +23960,7 @@
 		(property "Reference" "C36"
 			(at 2.5125 -0.115 90)
 			(layer "F.SilkS")
-			(uuid "fd44c8ec-7b78-4dfc-b210-6cb898dcfc52")
+			(uuid "7ad70cfb-3301-481a-bad9-25848781597d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -23859,7 +23972,7 @@
 			(at 0 1.16 -90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "1faf3be4-95a1-4aeb-9e92-fcc6af0438a9")
+			(uuid "d6554a30-7c30-4aea-981a-852896b90428")
 			(effects
 				(font
 					(size 1 1)
@@ -23872,7 +23985,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "a5f604e0-515f-40c1-8fc0-fd02ab91fe80")
+			(uuid "5cc4818a-c90e-4194-bb33-944f113c1c4b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23885,7 +23998,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ab5f343f-7bf3-40c2-9aaf-6f2ed3839612")
+			(uuid "354dc8a0-11a4-4f6d-9d1a-f47de7fd4dc6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23898,7 +24011,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "01570039-3509-4a1a-9da0-6919a1998ffe")
+			(uuid "046a57e1-5c32-4bfe-9641-159c8c05968f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -23932,7 +24045,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "0235ee00-eb24-4da6-a4e7-165e9c4b6e76")
+			(uuid "b4b5605a-5533-423e-8c3b-7964ca874c14")
 		)
 		(fp_line
 			(start -0.107836 -0.36)
@@ -23942,7 +24055,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "9f05f14e-a337-4343-b6ec-edd12e7a7d7a")
+			(uuid "cd0b7f96-dd28-42a3-886e-913947399c0a")
 		)
 		(fp_line
 			(start -0.91 0.46)
@@ -23952,7 +24065,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "cef61edc-8d1f-4595-9752-3029b3f96104")
+			(uuid "b325c4c9-7850-4113-9620-5eb5a987f03e")
 		)
 		(fp_line
 			(start 0.91 0.46)
@@ -23962,7 +24075,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "aac4407d-4c71-44f5-9a62-886cc1a98abb")
+			(uuid "84c2a0a3-36ec-4d9e-ab17-5145285abad3")
 		)
 		(fp_line
 			(start -0.91 -0.46)
@@ -23972,7 +24085,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "df0a6e04-3282-470b-9d03-d67cd0c64f2d")
+			(uuid "6ae081c9-3148-46f1-871d-7a5615139b26")
 		)
 		(fp_line
 			(start 0.91 -0.46)
@@ -23982,7 +24095,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "dadf910b-3c5d-4f63-ac85-cce2d3d99673")
+			(uuid "ee9ab073-725c-4fd5-862c-d9f49076598d")
 		)
 		(fp_line
 			(start -0.5 0.25)
@@ -23992,7 +24105,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "fd79f33c-de93-403b-9338-e7cb8f4c3233")
+			(uuid "054412bb-ee1c-405f-9588-4f985b83c994")
 		)
 		(fp_line
 			(start 0.5 0.25)
@@ -24002,7 +24115,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "267bfdcc-2613-42b3-96f7-d56d49cdbf0d")
+			(uuid "ddbd08b0-9271-445a-81c1-a5a3c7d09719")
 		)
 		(fp_line
 			(start -0.5 -0.25)
@@ -24012,7 +24125,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "35c42a86-315c-490b-9733-8d64dbc0c79a")
+			(uuid "5aef311f-6be4-4a25-a538-cca652c2f623")
 		)
 		(fp_line
 			(start 0.5 -0.25)
@@ -24022,12 +24135,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "03b3e4f2-0c8a-41d9-a59f-72f52d660b6d")
+			(uuid "ab1bde52-9ab9-4302-929a-d4aabb3fa68c")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 -90)
 			(layer "F.Fab")
-			(uuid "1c2e022a-e4ca-4378-b157-5b2babced720")
+			(uuid "dc8ccdd6-4240-46ed-a10e-8c81685d65b8")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -24042,7 +24155,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "2b9f670a-6ded-405f-a8d9-2d4b829b6d78")
+			(uuid "037105c0-947d-4875-ace4-b4fe20ede138")
 		)
 		(pad "2" smd roundrect
 			(at 0.48 0 270)
@@ -24051,7 +24164,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "c857dedc-b5c8-40c0-8d50-337191f6b234")
+			(uuid "44268634-e5e2-4053-9d16-8c949eb887e0")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
 			(offset
@@ -24074,7 +24187,7 @@
 		(property "Reference" "C37"
 			(at -2.2075 -0.005 180)
 			(layer "F.SilkS")
-			(uuid "c7dafc81-5f2f-4593-8949-f36fcd85e271")
+			(uuid "b30b6e2b-f5eb-4b50-b2af-bfe04c60495d")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -24086,7 +24199,7 @@
 			(at 0 1.68 90)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "d98ae0da-e822-4817-8773-fcfe3a0ba2f5")
+			(uuid "4669ff69-df45-441d-878e-d9a97998fcb1")
 			(effects
 				(font
 					(size 1 1)
@@ -24099,7 +24212,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c311f1a1-8700-4027-986f-63d145ba6389")
+			(uuid "63e1b730-63d2-4b1c-ab6a-4586f734c4e0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24112,7 +24225,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "f475152c-4a6a-4556-a2bd-b538de2c32ec")
+			(uuid "dbc63d1d-2d8c-452a-ad94-7d6c298faa9d")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24125,7 +24238,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "8c32288a-7f07-468d-8dca-7f6ad1ac7ed8")
+			(uuid "4df321b3-9645-417d-8d92-b81ae27a3db0")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24146,7 +24259,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "583850c9-cbfb-441b-8d7a-a11b5e2eb981")
+			(uuid "955a1d5f-01df-4ea6-927e-f2b866ac5314")
 		)
 		(fp_line
 			(start -0.261252 -0.735)
@@ -24156,7 +24269,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "36bfed44-0606-484b-8371-a265750cb0c5")
+			(uuid "a295e4b9-a05f-4797-91fd-96dbc13d67b5")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -24166,7 +24279,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "eedc44b1-efd8-4357-8ac4-22c536d7d6ce")
+			(uuid "fca17f98-d1be-4b5b-bdc0-46a21cfdf22b")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -24176,7 +24289,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "45c028e2-41b3-4d5a-a8ad-a76448926155")
+			(uuid "c52db331-4e94-445d-a201-0631550ab567")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -24186,7 +24299,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "4e6ed20e-3fc8-40aa-97a0-81ff83a73fd0")
+			(uuid "341d90a4-4b7c-4aef-962f-9a2f384393ad")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -24196,7 +24309,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "afdad21d-af6f-4a0a-a9ed-43c4ecb788c5")
+			(uuid "d2e6811e-f2da-4793-8db1-4c1a8facbab2")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -24206,7 +24319,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "d06a3cb5-79ca-488a-8007-7901b773b24d")
+			(uuid "05a8326d-87f4-4998-82f2-9fc0a6cf60a6")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -24216,7 +24329,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "9806a7b4-9345-4feb-8021-87e526c7e839")
+			(uuid "abeffd63-4f4d-4893-b7ee-d5ff4426c69e")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -24226,7 +24339,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "7368ce6a-4de4-4cf6-82c7-e3dc05d1f2d5")
+			(uuid "1f06305f-b299-4636-b9a9-5ca9732b3c0f")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -24236,12 +24349,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "c7d7c5f3-c30e-4a5d-a988-cf52de4c4be8")
+			(uuid "b95cb0c5-e5c9-424b-a7e4-6316530b1168")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 90)
 			(layer "F.Fab")
-			(uuid "42c3535a-1282-44ec-a8e9-f28a7a115477")
+			(uuid "d6788161-529d-4aa7-871e-03b6435a120b")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -24256,7 +24369,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "332406b0-2b45-4062-b4ad-de5b1a37a93b")
+			(uuid "5c4aec67-f99a-40b9-a6ef-775988cf7a69")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 270)
@@ -24265,7 +24378,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "3ce6d104-c869-430a-8fb8-36e9be33b47f")
+			(uuid "b3111073-6bfe-4669-9801-ad2a42e102e1")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -24280,7 +24393,6 @@
 		)
 	)
 	(footprint "Capacitor_SMD:C_0805_2012Metric"
-		(locked yes)
 		(layer "F.Cu")
 		(uuid "f931dd4f-6fba-4ee2-8dfd-a74a68cd8809")
 		(at 123.5 64.1 180)
@@ -24289,7 +24401,7 @@
 		(property "Reference" "C35"
 			(at 0 -1.7 0)
 			(layer "F.SilkS")
-			(uuid "1d73aa1d-d226-4fcc-bfc6-2f2580d8cd8d")
+			(uuid "b2dede0f-deeb-44a7-84f9-a02c5773da60")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -24301,7 +24413,7 @@
 			(at 0 1.68 0)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "443163b4-7a0e-4ea3-bb61-d3c36e59b002")
+			(uuid "a01adde0-5125-4c57-87cd-da82d2aec5be")
 			(effects
 				(font
 					(size 1 1)
@@ -24314,7 +24426,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e01d1178-1f1d-42d7-913a-02438bdc7999")
+			(uuid "b2a1c82a-46ea-44bc-887b-8dcca5fe351f")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24327,7 +24439,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "ac659145-9277-47c0-b2f3-44215d04bc79")
+			(uuid "b0d119d3-790e-4df0-b451-0296fe13a682")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24340,7 +24452,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "e3855926-5d15-4a91-8f4a-95f4db310a6d")
+			(uuid "5c3301be-e1e6-4923-bab3-ddb646897a28")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24361,7 +24473,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "d34fd73c-b110-4da8-921c-9fe61c3ac776")
+			(uuid "74b3743e-3caf-41b5-9d89-5f355ebc0c1e")
 		)
 		(fp_line
 			(start -0.261252 -0.735)
@@ -24371,7 +24483,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "81d72cf7-b72c-499a-8d78-7498f7b1ce7e")
+			(uuid "489f3a67-02f2-4837-8a10-eb600b19962d")
 		)
 		(fp_line
 			(start 1.7 0.98)
@@ -24381,7 +24493,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "64c4d658-0b80-4eee-a915-5812c29d74ee")
+			(uuid "6b4db266-b8eb-4a64-96e0-b131280e39db")
 		)
 		(fp_line
 			(start 1.7 -0.98)
@@ -24391,7 +24503,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "2b3b9ef7-c03c-482d-83db-4ac33929ba7e")
+			(uuid "d8fdb27b-de24-43be-999b-25b20f3c0fff")
 		)
 		(fp_line
 			(start -1.7 0.98)
@@ -24401,7 +24513,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "e26a9aed-598e-4b45-b70e-4b2ac667f3c4")
+			(uuid "e6f90b0d-0d7d-465e-80af-100d1b8e2bbd")
 		)
 		(fp_line
 			(start -1.7 -0.98)
@@ -24411,7 +24523,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "39527b04-aebd-4153-9376-680096d026bb")
+			(uuid "c85b729f-2864-4bdb-a00f-225fad0d9fd2")
 		)
 		(fp_line
 			(start 1 0.625)
@@ -24421,7 +24533,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "aec649e4-2149-436e-a4c9-70aabecd5f8a")
+			(uuid "3593f4f8-bce0-406d-9808-3b4a385694f9")
 		)
 		(fp_line
 			(start 1 -0.625)
@@ -24431,7 +24543,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "ed1a33ed-11b6-4f07-961c-9164f19debe3")
+			(uuid "386ec1db-996f-4418-859a-510938df577d")
 		)
 		(fp_line
 			(start -1 0.625)
@@ -24441,7 +24553,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "088223df-59a2-462d-b400-76eb163a8021")
+			(uuid "4b7b390a-17ee-4bae-9590-e9596e228689")
 		)
 		(fp_line
 			(start -1 -0.625)
@@ -24451,12 +24563,12 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "549063d1-1634-4f1c-800b-9897be435eb7")
+			(uuid "61a15c41-bfe9-41f2-85f0-4ab375a3e686")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "1871dc41-3fc6-4f38-ad7e-2d7929fe5b71")
+			(uuid "4d1b028b-8ad5-46dc-a55f-4cde02d87fe7")
 			(effects
 				(font
 					(size 0.5 0.5)
@@ -24471,7 +24583,7 @@
 			(roundrect_rratio 0.25)
 			(net 3 "+3.3V")
 			(pintype "passive")
-			(uuid "0ca9fa9e-4689-4feb-a2d8-a08e100ec6e8")
+			(uuid "0ecee8c8-76a9-44aa-a730-ba070318838f")
 		)
 		(pad "2" smd roundrect
 			(at 0.95 0 180)
@@ -24480,7 +24592,7 @@
 			(roundrect_rratio 0.25)
 			(net 1 "GND")
 			(pintype "passive")
-			(uuid "f17c0ba1-d5c8-4b91-90e3-aed789ccc19a")
+			(uuid "8c76e37a-b9ad-4c3f-a13a-7e1effb413bd")
 		)
 		(model "${KICAD8_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0805_2012Metric.wrl"
 			(offset
@@ -24502,7 +24614,7 @@
 			(at 4.3 -0.1 90)
 			(unlocked yes)
 			(layer "F.SilkS")
-			(uuid "f2c1e747-2dce-44f1-88d8-2890aa6e0791")
+			(uuid "0dc1dc99-a5fe-4008-8603-4d9cc655ad55")
 			(effects
 				(font
 					(size 0.8 0.8)
@@ -24516,7 +24628,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "b774a2fc-d230-4f3f-9240-75849f481afa")
+			(uuid "17a0e18f-634a-439c-b2f5-8d9fd67c9582")
 			(effects
 				(font
 					(size 1 1)
@@ -24529,7 +24641,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "2b1bbf41-6e70-4537-a5d5-e8bbbcb4cec5")
+			(uuid "ab361744-a6de-4ba0-982f-08270419cfb6")
 			(effects
 				(font
 					(size 1 1)
@@ -24542,7 +24654,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "c4d2de12-581e-4205-96cc-8a424c16854c")
+			(uuid "ac9de565-68d2-49e9-9208-98941968ef84")
 			(effects
 				(font
 					(size 1 1)
@@ -24555,7 +24667,7 @@
 			(unlocked yes)
 			(layer "F.Fab")
 			(hide yes)
-			(uuid "5a32bff8-6faa-4be0-98f9-a0e912d3abf2")
+			(uuid "bbae5737-902d-4465-8e65-b3b35f35ad1d")
 			(effects
 				(font
 					(size 1 1)
@@ -24575,7 +24687,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "815b795e-e922-4b6d-a807-2338bf6bdfd3")
+			(uuid "39bbc232-44fc-48f6-a017-ba04a0028d22")
 		)
 		(fp_line
 			(start -3.18 -3.2)
@@ -24585,7 +24697,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "6a235497-bfb7-4d54-96ae-f2168aa6a2a2")
+			(uuid "5ec2682b-f506-408b-8337-34101f066180")
 		)
 		(fp_line
 			(start -3.18 -1.3)
@@ -24595,7 +24707,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "9e3b4013-9649-41f3-ad78-076d00653138")
+			(uuid "b2a88fda-362f-4754-8d0f-9b34ff317a8e")
 		)
 		(fp_line
 			(start -3.18 3.23)
@@ -24605,7 +24717,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "1e5d8c93-fd26-43eb-bbfd-cdc9b3869102")
+			(uuid "b5961380-6607-40ff-b4b8-3697a138c1fa")
 		)
 		(fp_line
 			(start -3.18 3.23)
@@ -24615,7 +24727,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "b4a9bffc-cea7-4c47-8b96-0f573a015dd6")
+			(uuid "17741ad4-369a-4f26-96e0-eff973275965")
 		)
 		(fp_line
 			(start 3.28 -3.23)
@@ -24625,7 +24737,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "db35647a-d38d-4301-b3e8-351e5414e1f6")
+			(uuid "bcfd5f17-8260-477a-b4fe-c6bc75b6b47d")
 		)
 		(fp_line
 			(start 3.28 -1.3)
@@ -24635,7 +24747,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "cebaea96-aed2-4a1c-ae14-086230e7e83d")
+			(uuid "9ce50b40-950e-4aa8-a0c5-d4b3cbb0166c")
 		)
 		(fp_line
 			(start 3.28 3.23)
@@ -24645,7 +24757,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "a8cbfb79-bc22-4625-a129-0b8f3d263300")
+			(uuid "10c1833b-5478-42bb-a26d-1ca87ff0094f")
 		)
 		(fp_line
 			(start -7 -3.4)
@@ -24655,7 +24767,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "f18887d7-e669-44d4-9601-15d5a6f0b605")
+			(uuid "27892320-be30-4bc0-af7a-b65276711bdd")
 		)
 		(fp_line
 			(start -7 -3.4)
@@ -24665,7 +24777,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "c807e918-9ffb-428a-9b9f-d7572d756890")
+			(uuid "01eafbdc-6307-407a-94f8-c502d53c7e20")
 		)
 		(fp_line
 			(start -7 3.4)
@@ -24675,7 +24787,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "3dfcdef0-536f-4a20-b88b-29ef236d7fe5")
+			(uuid "7b135d67-04c4-4471-8ddf-a205274d5d5e")
 		)
 		(fp_line
 			(start 7 3.4)
@@ -24685,7 +24797,7 @@
 				(type solid)
 			)
 			(layer "F.CrtYd")
-			(uuid "8cd88125-0bf8-4f35-a55a-6bddda78573a")
+			(uuid "561e25ce-a36f-4628-8515-b0dbee98d779")
 		)
 		(fp_line
 			(start -2.95 -3)
@@ -24695,7 +24807,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "296d22bd-851b-44c6-825c-83592202c486")
+			(uuid "6f315bbf-3592-4929-94ae-bf4a385d86f0")
 		)
 		(fp_line
 			(start -2.95 3)
@@ -24705,7 +24817,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "bad51ca3-4d56-499b-9e50-63f9a852128e")
+			(uuid "e9e92e52-5b31-4a84-9ce4-c03d1a4ef4e7")
 		)
 		(fp_line
 			(start 3.05 -3)
@@ -24715,7 +24827,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "662fa9e8-a656-4b72-8e25-c563ea660ec6")
+			(uuid "8f0a4389-d665-4a65-a2a9-6ecfb2ae9a45")
 		)
 		(fp_line
 			(start 3.05 3)
@@ -24725,7 +24837,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "cbe31201-c161-4704-8f57-a319710ad821")
+			(uuid "e849c295-7f0d-4f11-9914-ec697303f40d")
 		)
 		(fp_circle
 			(center 0.05 0)
@@ -24736,12 +24848,12 @@
 			)
 			(fill none)
 			(layer "F.Fab")
-			(uuid "014ed45a-6b5c-41ef-9736-b24d635a3b13")
+			(uuid "c1749c44-eb00-445a-a173-287a34bac8ad")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 0 0 0)
 			(layer "F.Fab")
-			(uuid "7d0d6c79-6e72-40df-90c4-e520b7e16925")
+			(uuid "1d181e1e-a768-46c7-8957-79737701ab5d")
 			(effects
 				(font
 					(size 1 1)
@@ -24750,40 +24862,40 @@
 			)
 		)
 		(pad "1" smd rect
-			(at -5.6 -2.25)
+			(at -4.55 -2.25)
 			(size 2.1 1.4)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(net 31 "/MCU/QSPI_{~{CS}}")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "5273282e-7e99-4f67-b094-eb976a457aea")
+			(uuid "432ebca2-6269-4118-9231-85bfb4cc60a0")
 		)
 		(pad "1" smd rect
-			(at 5.6 -2.25)
+			(at 4.55 -2.25)
 			(size 2.1 1.4)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(net 31 "/MCU/QSPI_{~{CS}}")
 			(pinfunction "1")
 			(pintype "passive")
-			(uuid "891c54ef-3ae8-45dc-af7e-c7d35fca99eb")
+			(uuid "3bd34f2c-ee30-48ff-bf24-f7b79d5e6674")
 		)
 		(pad "2" smd rect
-			(at -5.6 2.25)
+			(at -4.55 2.25)
 			(size 2.1 1.4)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(net 1 "GND")
 			(pinfunction "2")
 			(pintype "passive")
-			(uuid "e44e9cca-afc8-4d8c-92d6-b5fbe5e3369b")
+			(uuid "f302b020-e666-4dc4-b214-5a56e0d38883")
 		)
 		(pad "2" smd rect
-			(at 5.6 2.25)
+			(at 4.55 2.25)
 			(size 2.1 1.4)
 			(layers "F.Cu" "F.Paste" "F.Mask")
 			(net 1 "GND")
 			(pinfunction "2")
 			(pintype "passive")
-			(uuid "3e598f7e-3dfc-4b7a-93d1-b2df069655c7")
+			(uuid "d927b347-4999-4e5c-8e7a-b032958ecb65")
 		)
 	)
 	(footprint "LOGO"
@@ -26197,7 +26309,7 @@
 			(at 0 1.65 0)
 			(layer "B.SilkS")
 			(hide yes)
-			(uuid "6e194502-ab8a-4060-a1c9-f8b13c4c9bc5")
+			(uuid "ef7f884b-eec5-475f-8797-bf9298e36388")
 			(effects
 				(font
 					(size 1 1)
@@ -26209,7 +26321,7 @@
 		(property "Value" "~"
 			(at 0 -1.75 0)
 			(layer "B.Fab")
-			(uuid "d2ba4cea-b0d3-4308-a2a4-b3b3fc6ea8b7")
+			(uuid "9a76afde-7296-4141-94b7-3d1bc86163d0")
 			(effects
 				(font
 					(size 1 1)
@@ -26222,7 +26334,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "18fee682-cec9-4468-a7da-657f33bb0fca")
+			(uuid "06638c9d-9e7f-45d5-a567-5b1b9df6c2ef")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26235,7 +26347,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "790f3934-7dbe-4eaa-9dd1-35eff5f798e0")
+			(uuid "fd77d699-2f8e-4a92-8872-7950702cb39b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26248,7 +26360,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "77d00cde-88d4-40be-b5f3-3509605d54f0")
+			(uuid "1fa55cd6-2fd1-4e60-aece-33cf3e095f3b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26265,7 +26377,7 @@
 			(at -0.05 0 0)
 			(unlocked yes)
 			(layer "B.Fab")
-			(uuid "df388167-7169-4c3b-b4be-0d0870d5a2e8")
+			(uuid "4e6800d1-34db-4156-8745-5b133efee21f")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -26280,7 +26392,7 @@
 			(layers "B.Cu")
 			(net 50 "/Touch Sensors/STOP")
 			(pintype "passive")
-			(uuid "1160c5fc-c51a-40f2-bd06-f2dd60c6289d")
+			(uuid "01ccb039-86f8-468f-94e9-2307fb30d746")
 		)
 	)
 	(footprint "open-ephys:Touch_Center_2mm"
@@ -26293,7 +26405,7 @@
 			(at 0 1.65 0)
 			(layer "B.SilkS")
 			(hide yes)
-			(uuid "3cf144ad-36d8-4f8c-9f62-03e4ba55151a")
+			(uuid "c6fdffeb-1ec3-4525-8a28-cddb9f948f1c")
 			(effects
 				(font
 					(size 1 1)
@@ -26305,7 +26417,7 @@
 		(property "Value" "~"
 			(at 0 -1.75 0)
 			(layer "B.Fab")
-			(uuid "42423a05-fa36-4fb9-9159-57129fe7f1ab")
+			(uuid "e1a283c7-ac00-4226-b4b8-b0bcd9adb3a2")
 			(effects
 				(font
 					(size 1 1)
@@ -26318,7 +26430,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "8d2b4ff8-f464-4ad5-ada6-bc36dd78b418")
+			(uuid "4b3fd698-508a-4b96-af5c-c1345ad08e14")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26331,7 +26443,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "8635d2e6-e12b-4b0d-a3a2-2cf1b5a98421")
+			(uuid "b9ce19a8-6b3c-4e74-a665-a3135e38b65b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26344,7 +26456,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "ba5e0fe1-9a80-475f-b64a-569be45bcc20")
+			(uuid "5e74a0b5-c299-48c1-95fe-90374ca21c0b")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26361,7 +26473,7 @@
 			(at -0.05 0 0)
 			(unlocked yes)
 			(layer "B.Fab")
-			(uuid "91a21b97-84d1-4c98-b159-681988a0baef")
+			(uuid "b887af31-cef3-4c4f-bf94-aa960d3db926")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -26376,7 +26488,7 @@
 			(layers "B.Cu")
 			(net 49 "/Touch Sensors/CW")
 			(pintype "passive")
-			(uuid "8c8a7694-d02d-4f96-86a3-a399020d1968")
+			(uuid "947dca08-dd57-44ee-9ccf-b304015d8684")
 		)
 	)
 	(footprint "open-ephys:Touch_Center_2mm"
@@ -26389,7 +26501,7 @@
 			(at 0 1.65 0)
 			(layer "B.SilkS")
 			(hide yes)
-			(uuid "616fe8a9-b22c-47aa-90d6-672018742822")
+			(uuid "4df2f873-6a9e-4ded-b105-ad8970cedffb")
 			(effects
 				(font
 					(size 1 1)
@@ -26401,7 +26513,7 @@
 		(property "Value" "~"
 			(at 0 -1.75 0)
 			(layer "B.Fab")
-			(uuid "48b36b7e-8aad-43d2-87e8-928b86c01372")
+			(uuid "89660e49-8cba-4bfa-8f25-bb82e355c974")
 			(effects
 				(font
 					(size 1 1)
@@ -26414,7 +26526,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "6c101aaf-a10d-40a7-995a-ac73fe6a115b")
+			(uuid "3bb3730a-7403-4b02-a389-3d1565ecf373")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26427,7 +26539,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "0a6145de-9939-4eaa-bd37-6954610cecda")
+			(uuid "d43b4f16-5ce1-4373-a5d3-91e9d41baa33")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26440,7 +26552,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "f59052e8-466a-4e75-8902-7cd57d7e3b8c")
+			(uuid "a22725a5-318f-4800-adf1-7420f502e92e")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26457,7 +26569,7 @@
 			(at -0.05 0 0)
 			(unlocked yes)
 			(layer "B.Fab")
-			(uuid "324a9ec3-0117-4606-b940-96593c392426")
+			(uuid "44e0555c-beb1-454c-a421-177925603cdc")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -26472,7 +26584,7 @@
 			(layers "B.Cu")
 			(net 47 "/Touch Sensors/CCW")
 			(pintype "passive")
-			(uuid "ae9ba789-30dc-45e3-a7af-3197b654dad5")
+			(uuid "756e2ae3-90e6-4a28-820f-4274f1fd6bac")
 		)
 	)
 	(footprint "open-ephys:Touch_Center_2mm"
@@ -26485,7 +26597,7 @@
 			(at 0 1.65 0)
 			(layer "B.SilkS")
 			(hide yes)
-			(uuid "d68c216c-fef9-4b96-a35e-0b877b2e3563")
+			(uuid "9ff19aa4-88d5-43d9-9cf3-77267118ac7e")
 			(effects
 				(font
 					(size 1 1)
@@ -26497,7 +26609,7 @@
 		(property "Value" "~"
 			(at 0 -1.75 0)
 			(layer "B.Fab")
-			(uuid "26a4903f-03a9-49f5-ad8c-0ce284e780c6")
+			(uuid "2b3d0ea8-746b-4fbc-9106-7cfb6b5e2549")
 			(effects
 				(font
 					(size 1 1)
@@ -26510,7 +26622,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "eb992eef-63a6-4304-bf18-30dd4d0133b3")
+			(uuid "2802a380-8efd-4d8f-a27d-c4ccbdb91f09")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26523,7 +26635,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "12a9c5e8-1a96-492c-8eb8-5f659142a4a8")
+			(uuid "83d8bf04-c76e-4294-b072-263910744c9a")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26536,7 +26648,7 @@
 			(at 0 0 0)
 			(layer "B.Fab")
 			(hide yes)
-			(uuid "55209c97-858a-431e-9c69-fd37324bb198")
+			(uuid "58333d01-8159-4ac9-a1e2-9b663a3185e6")
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26553,7 +26665,7 @@
 			(at -0.05 0 0)
 			(unlocked yes)
 			(layer "B.Fab")
-			(uuid "0227709f-714f-42ee-9631-d8e25db77362")
+			(uuid "9e0b1a77-28cf-4772-908c-418bdb6d8297")
 			(effects
 				(font
 					(size 0.25 0.25)
@@ -26568,7 +26680,7 @@
 			(layers "B.Cu")
 			(net 48 "/Touch Sensors/MODE")
 			(pintype "passive")
-			(uuid "39d9d576-c8b6-437a-a587-cf0aa2dc383a")
+			(uuid "77333950-7aec-412c-9eca-8a9e72e50037")
 		)
 	)
 	(gr_line
@@ -27728,28 +27840,6 @@
 		(layer "F.SilkS")
 		(uuid "271bc8e5-f16a-4a08-b3c2-929683a5fd3c")
 	)
-	(gr_circle
-		(center 123.5 61.25)
-		(end 125 61.25)
-		(stroke
-			(width 0.2)
-			(type solid)
-		)
-		(fill solid)
-		(layer "B.Mask")
-		(uuid "e8bc4c45-667a-44e1-b51f-c8f807558013")
-	)
-	(gr_circle
-		(center 123.5 61.25)
-		(end 123.5 59.75)
-		(stroke
-			(width 0.2)
-			(type solid)
-		)
-		(fill solid)
-		(layer "F.Mask")
-		(uuid "7099984a-8ffc-4494-9241-eb1aac0409ef")
-	)
 	(gr_line
 		(start 123.5 149)
 		(end 123.5 54)
@@ -27895,7 +27985,7 @@
 			(justify left)
 		)
 	)
-	(gr_text "Commutator\nControl Board\nRev. F\n"
+	(gr_text "Commutator\nControl Board\nRev. G\n"
 		(at 106.4 135.7 90)
 		(layer "F.SilkS")
 		(uuid "b21f8081-f505-4e5c-8cad-2a8c0a6a820e")
@@ -28443,7 +28533,7 @@
 		(uuid "0171bbf8-c252-4e7d-b47e-1a1eedde5775")
 	)
 	(via
-		(at 111.9 62.3)
+		(at 112 62)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -28475,7 +28565,7 @@
 		(uuid "05254f78-ac6b-4fbb-8417-8c734c0543ae")
 	)
 	(via
-		(at 118 65.950003)
+		(at 117 66)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -29043,14 +29133,6 @@
 		(uuid "484eb46d-d425-4a93-b397-870dc928da8f")
 	)
 	(via
-		(at 114.8 62.5)
-		(size 0.5)
-		(drill 0.25)
-		(layers "F.Cu" "B.Cu")
-		(net 1)
-		(uuid "48af28f4-99c0-49e5-88a1-4d4030a20f72")
-	)
-	(via
 		(at 133.4 59.8)
 		(size 0.5)
 		(drill 0.25)
@@ -29331,14 +29413,6 @@
 		(uuid "70efdfe8-4cf9-47d0-b2ed-97c8ad871d49")
 	)
 	(via
-		(at 114.8 63.3)
-		(size 0.5)
-		(drill 0.25)
-		(layers "F.Cu" "B.Cu")
-		(net 1)
-		(uuid "7138a9f7-cad4-419d-9593-a8e75921257f")
-	)
-	(via
 		(at 141.5 110.5)
 		(size 0.5)
 		(drill 0.25)
@@ -29411,7 +29485,7 @@
 		(uuid "7916dccb-1960-424c-8ca6-e92044977a4a")
 	)
 	(via
-		(at 102.9 88)
+		(at 102.75 88)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -29627,14 +29701,6 @@
 		(uuid "953f5fcc-0cc4-44b3-8b87-13c29c3b0466")
 	)
 	(via
-		(at 114.8 61.6)
-		(size 0.5)
-		(drill 0.25)
-		(layers "F.Cu" "B.Cu")
-		(net 1)
-		(uuid "963d2473-0b69-45b1-bcc1-876518f78ed1")
-	)
-	(via
 		(at 112.75 69.75)
 		(size 0.5)
 		(drill 0.25)
@@ -29681,6 +29747,14 @@
 		(layers "F.Cu" "B.Cu")
 		(net 1)
 		(uuid "9c77f5a3-233d-4a5e-b0a3-411a905e3225")
+	)
+	(via
+		(at 114.5 64.5)
+		(size 0.5)
+		(drill 0.25)
+		(layers "F.Cu" "B.Cu")
+		(net 1)
+		(uuid "9cc4f660-251a-4183-81c1-b40ede3d92ec")
 	)
 	(via
 		(at 133.6 82.2)
@@ -29811,14 +29885,6 @@
 		(uuid "a9cf75da-b69b-4edb-89e1-f2d3265b49e1")
 	)
 	(via
-		(at 107.9 64.5)
-		(size 0.5)
-		(drill 0.25)
-		(layers "F.Cu" "B.Cu")
-		(net 1)
-		(uuid "aa0c5c7a-87d6-40d4-babd-8e327edb7c09")
-	)
-	(via
 		(at 136.95 138.2)
 		(size 0.5)
 		(drill 0.25)
@@ -29875,7 +29941,7 @@
 		(uuid "aec4543b-a2c3-4c65-8158-a73e4b30969f")
 	)
 	(via
-		(at 104.7 64.6)
+		(at 105 65)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -30171,7 +30237,7 @@
 		(uuid "d07ef9ce-19fe-4c81-9ff9-cfdd2250ae1f")
 	)
 	(via
-		(at 106.3 63.3)
+		(at 107 63)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -30763,6 +30829,14 @@
 		(uuid "0a3c1ab5-da19-4fd1-bc5e-dbb711669e75")
 	)
 	(segment
+		(start 119.4375 81.2)
+		(end 118.9 81.2)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 3)
+		(uuid "0df66ac7-f007-417f-a944-c7cb923350e2")
+	)
+	(segment
 		(start 134.175 66.725)
 		(end 134.5 66.725)
 		(width 0.5)
@@ -30953,6 +31027,14 @@
 		(layer "F.Cu")
 		(net 3)
 		(uuid "3cdabe0a-2a2f-4c00-a67d-d36e9cfc1ff3")
+	)
+	(segment
+		(start 119.4375 81.2)
+		(end 119.4375 81.6)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 3)
+		(uuid "3d892ad0-f3f2-4624-8d17-ea543f3b561f")
 	)
 	(segment
 		(start 111.9 84.8)
@@ -31377,6 +31459,14 @@
 		(layer "F.Cu")
 		(net 3)
 		(uuid "dfd59314-de64-4f66-9e98-fb9f68788e1f")
+	)
+	(segment
+		(start 118.9 81.2)
+		(end 118.8 81.3)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 3)
+		(uuid "dfd8a62a-2e44-4948-aa2f-a588944b7d06")
 	)
 	(segment
 		(start 120.32 73.685001)
@@ -33931,6 +34021,14 @@
 		(uuid "049f57b3-fb60-4264-ac9f-5aff089679b5")
 	)
 	(segment
+		(start 116.45 61.45)
+		(end 116.45 60.05)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 31)
+		(uuid "0f65525b-4ed1-44c4-a4af-0f8f29945900")
+	)
+	(segment
 		(start 119.4375 76.4)
 		(end 119.834314 76.4)
 		(width 0.2)
@@ -33947,12 +34045,12 @@
 		(uuid "1e3ccc20-33d7-4a1d-8a36-bb998bebd8a0")
 	)
 	(segment
-		(start 117.5 61.112462)
-		(end 117.5 60.05)
+		(start 118.5 65.7)
+		(end 118.5 63.5)
 		(width 0.25)
 		(layer "F.Cu")
 		(net 31)
-		(uuid "218fda54-d85a-4f65-83b6-5fde44bcef15")
+		(uuid "239aee1d-cfa9-438c-85a8-f1e26abdb315")
 	)
 	(segment
 		(start 124.1 71.6)
@@ -33963,28 +34061,12 @@
 		(uuid "31ce530a-c0b8-441a-8d85-f95d5fef86f1")
 	)
 	(segment
-		(start 119 65.6)
-		(end 119 62.612462)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 31)
-		(uuid "334ee54c-85a9-45f6-97b0-cf1fd3d291e6")
-	)
-	(segment
 		(start 122.625 72.175)
 		(end 122.625 72.2)
 		(width 0.25)
 		(layer "F.Cu")
 		(net 31)
 		(uuid "384d41d5-7ac7-483c-b597-128e5d1695c5")
-	)
-	(segment
-		(start 119 62.612462)
-		(end 117.5 61.112462)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 31)
-		(uuid "3b01c5b5-2b5f-4fee-93dd-443796313983")
 	)
 	(segment
 		(start 123.5 71.6)
@@ -33995,12 +34077,28 @@
 		(uuid "4a9e1d52-f193-4504-b734-27bd9ec40b4b")
 	)
 	(segment
-		(start 121.8 66.1)
-		(end 119.5 66.1)
+		(start 107.35 60.05)
+		(end 116.7 60.05)
 		(width 0.25)
 		(layer "F.Cu")
 		(net 31)
-		(uuid "a3f0fba6-5204-4912-8882-110713be6b6e")
+		(uuid "713da95a-7830-4dd4-a826-4f7dc6f02f04")
+	)
+	(segment
+		(start 124 68)
+		(end 122.5 66.5)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 31)
+		(uuid "83a027cf-c40b-4558-b59f-ed1f9833aedf")
+	)
+	(segment
+		(start 122.5 66.5)
+		(end 119.3 66.5)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 31)
+		(uuid "9da1635f-1d67-4b0f-9ac3-0bfcdb3e4b3d")
 	)
 	(segment
 		(start 120.734315 75.5)
@@ -34035,6 +34133,22 @@
 		(uuid "bbafca3e-b205-4301-aff4-5c1d8d431463")
 	)
 	(segment
+		(start 118.5 63.5)
+		(end 116.45 61.45)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 31)
+		(uuid "c1d06215-098b-4cf2-bf8f-b77c968dd9e2")
+	)
+	(segment
+		(start 119.3 66.5)
+		(end 118.5 65.7)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 31)
+		(uuid "d4fee47d-9597-46ff-8eac-364d7ab3119a")
+	)
+	(segment
 		(start 123.2 71.6)
 		(end 122.625 72.175)
 		(width 0.25)
@@ -34042,32 +34156,8 @@
 		(net 31)
 		(uuid "dbb68960-3d19-4388-8277-8bc84d28f90f")
 	)
-	(segment
-		(start 105.5 60.05)
-		(end 116.7 60.05)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 31)
-		(uuid "ea1ca618-d1f4-4ac2-a5cb-b64dd41f1ec1")
-	)
-	(segment
-		(start 119.5 66.1)
-		(end 119 65.6)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 31)
-		(uuid "f14a183f-229b-4660-bcf9-79a9a8e02683")
-	)
-	(segment
-		(start 123.7 68)
-		(end 121.8 66.1)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 31)
-		(uuid "f5607f8d-4a06-4585-b7a7-43bffb5e02d8")
-	)
 	(via
-		(at 123.7 68)
+		(at 124 68)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -34083,28 +34173,20 @@
 		(uuid "3583bd82-f542-4b2f-9d78-59ad00be254e")
 	)
 	(segment
-		(start 123.255 68.445)
-		(end 123.255 71.355)
+		(start 124 68)
+		(end 123.5 68.5)
 		(width 0.2)
 		(layer "In1.Cu")
 		(net 31)
-		(uuid "39546489-2898-443f-8564-05374cbb5cd3")
+		(uuid "5e091876-ef52-4095-937e-8b7792ec381f")
 	)
 	(segment
-		(start 123.255 71.355)
+		(start 123.5 68.5)
 		(end 123.5 71.6)
 		(width 0.2)
 		(layer "In1.Cu")
 		(net 31)
-		(uuid "97b1e89f-dddd-41ed-8713-84867873b10f")
-	)
-	(segment
-		(start 123.7 68)
-		(end 123.255 68.445)
-		(width 0.2)
-		(layer "In1.Cu")
-		(net 31)
-		(uuid "f1573a0a-2425-4230-accf-d2c84e1e0b28")
+		(uuid "eba0153e-e369-48f2-a6fe-40ff0083d2ba")
 	)
 	(segment
 		(start 120.137046 80.4)
@@ -35211,39 +35293,23 @@
 		(uuid "fde45716-95f4-4161-9573-1ad2b913704b")
 	)
 	(segment
-		(start 115.2 64.5)
-		(end 109.6 64.5)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 48)
-		(uuid "66efd4ec-5b80-4c1f-911b-bb688c8de8b4")
-	)
-	(segment
-		(start 108.5325 65.5675)
+		(start 112.4075 62.8)
 		(end 108.5325 66.675)
 		(width 0.25)
 		(layer "F.Cu")
 		(net 48)
-		(uuid "7e82e80b-72be-4ecc-8df3-31607bd2cf8e")
+		(uuid "3150b539-2c74-4dc3-a383-bc400bd14030")
 	)
 	(segment
-		(start 109.6 64.5)
-		(end 108.5325 65.5675)
+		(start 116.4 62.8)
+		(end 112.4075 62.8)
 		(width 0.25)
 		(layer "F.Cu")
 		(net 48)
-		(uuid "826e7b77-0441-4c1d-9983-52d5a6a3bc89")
-	)
-	(segment
-		(start 115.6 64.1)
-		(end 115.2 64.5)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 48)
-		(uuid "ef7a0f06-d7ee-46b0-8dc9-5c358375b6af")
+		(uuid "f7bf4faa-5490-45bb-abbf-7730d228d36c")
 	)
 	(via
-		(at 115.6 64.1)
+		(at 116.4 62.8)
 		(size 0.5)
 		(drill 0.25)
 		(layers "F.Cu" "B.Cu")
@@ -35251,12 +35317,12 @@
 		(uuid "960048d2-c1dc-4b4c-88ab-fdc49f720f2e")
 	)
 	(segment
-		(start 115.6 64.1)
-		(end 116 64.5)
+		(start 116.4 62.9)
+		(end 118 64.5)
 		(width 0.25)
 		(layer "B.Cu")
 		(net 48)
-		(uuid "4cce8666-1d39-4db0-9606-e5f601a1bc29")
+		(uuid "31d67161-f626-4336-8652-22b9b18eebb3")
 	)
 	(segment
 		(start 117.35 64.75)
@@ -35267,12 +35333,44 @@
 		(uuid "8e5f526c-4ccf-4173-a581-310ba19117e7")
 	)
 	(segment
-		(start 116 64.5)
-		(end 118 64.5)
+		(start 116.4 62.8)
+		(end 116.4 62.9)
 		(width 0.25)
 		(layer "B.Cu")
 		(net 48)
-		(uuid "981c369e-e367-4aa2-b957-beee0173a413")
+		(uuid "ed4cf06b-29cc-4d85-a8e0-fc1863e8d4c3")
+	)
+	(segment
+		(start 116.031282 67)
+		(end 115.701282 66.67)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 49)
+		(uuid "2af8fb0c-2adc-420c-8811-04e8f65959e9")
+	)
+	(segment
+		(start 115.701282 66.67)
+		(end 114.958859 66.67)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 49)
+		(uuid "2f1e604c-5f34-490f-876b-d70e26c9d57c")
+	)
+	(segment
+		(start 121.3 67)
+		(end 116.031282 67)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 49)
+		(uuid "5215cf2d-2c95-47a8-aa48-3c0823add65f")
+	)
+	(segment
+		(start 123.2 68.9)
+		(end 121.3 67)
+		(width 0.25)
+		(layer "F.Cu")
+		(net 49)
+		(uuid "cd3c52ee-b8d5-41cc-b357-52d777c89102")
 	)
 	(segment
 		(start 125.7 68.9)
@@ -35280,31 +35378,7 @@
 		(width 0.25)
 		(layer "F.Cu")
 		(net 49)
-		(uuid "2096a57e-acf5-4213-bd85-f8bd50cc42bf")
-	)
-	(segment
-		(start 123.2 68.9)
-		(end 121.43 67.13)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 49)
-		(uuid "5fb840c7-3a80-489c-810a-efb444ccea96")
-	)
-	(segment
-		(start 115.418859 67.13)
-		(end 114.958859 66.67)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 49)
-		(uuid "64d77c3c-9aa2-4afa-b80c-f80a4b383340")
-	)
-	(segment
-		(start 121.43 67.13)
-		(end 115.418859 67.13)
-		(width 0.25)
-		(layer "F.Cu")
-		(net 49)
-		(uuid "d8fcff40-c11e-488a-bec6-7a4218bc6cb0")
+		(uuid "d4f12d81-f3d1-41ea-9392-3c195915e70a")
 	)
 	(via
 		(at 125.7 68.9)
@@ -35357,20 +35431,44 @@
 		(uuid "d5ab616f-fea0-4192-80aa-c36adfdd8037")
 	)
 	(segment
-		(start 103.85 84.95)
-		(end 103.6 84.7)
+		(start 103.7 68.9875)
+		(end 106.155 66.5325)
 		(width 0.2)
 		(layer "F.Cu")
 		(net 50)
-		(uuid "16fc6ee0-26e2-433f-b260-308772d61cf9")
+		(uuid "1830d103-201a-472e-8306-b3593152e2d9")
 	)
 	(segment
-		(start 103.85 116.25)
-		(end 103.85 84.95)
+		(start 106.3 118.7)
+		(end 104 116.4)
 		(width 0.2)
 		(layer "F.Cu")
 		(net 50)
-		(uuid "742c45b8-ddb5-4135-9c72-d4bb4bbae364")
+		(uuid "82461a83-af71-4602-b26e-3484f6d2d251")
+	)
+	(segment
+		(start 104 116.4)
+		(end 104 84)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 50)
+		(uuid "9d0659ee-1c85-4737-8247-780798ce5509")
+	)
+	(segment
+		(start 103.7 83.7)
+		(end 103.7 68.9875)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 50)
+		(uuid "b763fc2e-527c-4dae-879a-1d8ec73d7a4f")
+	)
+	(segment
+		(start 104 84)
+		(end 103.7 83.7)
+		(width 0.2)
+		(layer "F.Cu")
+		(net 50)
+		(uuid "be8c17b4-271a-4533-861c-f5e219b5f652")
 	)
 	(segment
 		(start 109 118.7)
@@ -35378,39 +35476,7 @@
 		(width 0.2)
 		(layer "F.Cu")
 		(net 50)
-		(uuid "7c415d8d-af32-4f41-9e6d-0c46e6c7ef75")
-	)
-	(segment
-		(start 103.6 68.9)
-		(end 105.9675 66.5325)
-		(width 0.2)
-		(layer "F.Cu")
-		(net 50)
-		(uuid "84982a3d-71c6-42fe-8a87-39144b8274a2")
-	)
-	(segment
-		(start 105.9675 66.5325)
-		(end 106.155 66.5325)
-		(width 0.2)
-		(layer "F.Cu")
-		(net 50)
-		(uuid "e06706c8-26c0-4fbb-bffe-53f15cb1c4f4")
-	)
-	(segment
-		(start 103.6 84.7)
-		(end 103.6 68.9)
-		(width 0.2)
-		(layer "F.Cu")
-		(net 50)
-		(uuid "eb08368c-5774-4330-88c2-dd852784ce5b")
-	)
-	(segment
-		(start 106.3 118.7)
-		(end 103.85 116.25)
-		(width 0.2)
-		(layer "F.Cu")
-		(net 50)
-		(uuid "ff436af2-2140-45a4-b450-3b8ca9152e0d")
+		(uuid "c3c0c310-3707-4eae-93f0-824f00a5c85c")
 	)
 	(via
 		(at 109 118.7)
@@ -37954,8 +38020,9 @@
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 120.445945 83.961629) (xy 120.48921 84.004894) (xy 120.5 84.049839) (xy 120.5 84.1) (xy 121.326 84.1)
-				(xy 121.384191 84.118907) (xy 121.420155 84.168407) (xy 121.425 84.199) (xy 121.425 84.874998) (xy 121.425001 84.874999)
+				(xy 120.445945 83.961629) (xy 120.48921 84.004894) (xy 120.5 84.049839) (xy 120.5 84.1) (xy 121.226 84.1)
+				(xy 121.284191 84.118907) (xy 121.320155 84.168407) (xy 121.325 84.199) (xy 121.325 84.2) (xy 121.326 84.2)
+				(xy 121.384191 84.218907) (xy 121.420155 84.268407) (xy 121.425 84.299) (xy 121.425 84.874998) (xy 121.425001 84.874999)
 				(xy 121.583453 84.874999) (xy 121.676968 84.860189) (xy 121.7374 84.869761) (xy 121.780664 84.913026)
 				(xy 121.790235 84.973458) (xy 121.762457 85.027974) (xy 121.7374 85.046179) (xy 121.636956 85.097358)
 				(xy 121.547358 85.186956) (xy 121.489836 85.299848) (xy 121.489835 85.299852) (xy 121.475 85.393515)
@@ -37968,17 +38035,17 @@
 				(xy 120.271324 85.000215) (xy 120.353224 84.918316) (xy 120.403972 84.809487) (xy 120.4105 84.759901)
 				(xy 120.410499 84.483453) (xy 120.675 84.483453) (xy 120.69076 84.582965) (xy 120.690762 84.582969)
 				(xy 120.751881 84.702921) (xy 120.847078 84.798118) (xy 120.96703 84.859237) (xy 120.967029 84.859237)
-				(xy 121.066545 84.874999) (xy 121.225 84.874999) (xy 121.225 84.300001) (xy 121.224999 84.3) (xy 120.675002 84.3)
-				(xy 120.675001 84.300001) (xy 120.675001 84.483453) (xy 120.675 84.483453) (xy 120.410499 84.483453)
-				(xy 120.410499 84.4001) (xy 120.403972 84.350513) (xy 120.403972 84.350511) (xy 120.353225 84.241686)
-				(xy 120.353224 84.241685) (xy 120.353224 84.241684) (xy 120.281187 84.169647) (xy 120.253412 84.115133)
-				(xy 120.262983 84.054701) (xy 120.281189 84.029642) (xy 120.330996 83.979835) (xy 120.385513 83.952058)
+				(xy 121.066545 84.874999) (xy 121.225 84.874999) (xy 121.225 84.3) (xy 120.675002 84.3) (xy 120.675001 84.300001)
+				(xy 120.675001 84.483453) (xy 120.675 84.483453) (xy 120.410499 84.483453) (xy 120.410499 84.4001)
+				(xy 120.403972 84.350513) (xy 120.403972 84.350511) (xy 120.353225 84.241686) (xy 120.353224 84.241685)
+				(xy 120.353224 84.241684) (xy 120.281187 84.169647) (xy 120.253412 84.115133) (xy 120.262983 84.054701)
+				(xy 120.281189 84.029642) (xy 120.330996 83.979835) (xy 120.385513 83.952058)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 115.139191 74.118907) (xy 115.175155 74.168407) (xy 115.18 74.199) (xy 115.18 74.709999) (xy 115.180001 74.71)
+				(xy 115.139191 74.218907) (xy 115.175155 74.268407) (xy 115.18 74.299) (xy 115.18 74.709999) (xy 115.180001 74.71)
 				(xy 115.251 74.71) (xy 115.309191 74.728907) (xy 115.345155 74.778407) (xy 115.35 74.809) (xy 115.35 74.838345)
 				(xy 115.331093 74.896536) (xy 115.281593 74.9325) (xy 115.270316 74.935442) (xy 115.252262 74.939033)
 				(xy 115.243251 74.942766) (xy 115.242481 74.940909) (xy 115.195645 74.95411) (xy 115.157219 74.941621)
@@ -38018,31 +38085,32 @@
 				(xy 118.125327 76.2005) (xy 118.274673 76.2005) (xy 118.274674 76.2005) (xy 118.34774 76.185966)
 				(xy 118.347746 76.185961) (xy 118.356746 76.182235) (xy 118.357516 76.184093) (xy 118.404329 76.170888)
 				(xy 118.442777 76.18338) (xy 118.443447 76.181764) (xy 118.452454 76.185495) (xy 118.499999 76.194951)
-				(xy 118.5 76.194951) (xy 118.5 75.984613) (xy 118.500477 75.974904) (xy 118.5005 75.97467) (xy 118.5005 75.5615)
-				(xy 118.519407 75.503309) (xy 118.568907 75.467345) (xy 118.5995 75.4625) (xy 118.899999 75.4625)
+				(xy 118.5 76.194951) (xy 118.5 75.984613) (xy 118.500477 75.974904) (xy 118.5005 75.97467) (xy 118.5005 75.6615)
+				(xy 118.519407 75.603309) (xy 118.568907 75.567345) (xy 118.5995 75.5625) (xy 118.6 75.5625) (xy 118.6 75.5615)
+				(xy 118.618907 75.503309) (xy 118.668407 75.467345) (xy 118.699 75.4625) (xy 118.899999 75.4625)
 				(xy 118.9 75.462499) (xy 118.9 75.299) (xy 118.918907 75.240809) (xy 118.968407 75.204845) (xy 118.999 75.2)
 				(xy 119.701 75.2) (xy 119.759191 75.218907) (xy 119.795155 75.268407) (xy 119.8 75.299) (xy 119.8 75.968335)
 				(xy 119.781093 76.026526) (xy 119.771004 76.038339) (xy 119.738839 76.070504) (xy 119.684322 76.098281)
 				(xy 119.668835 76.0995) (xy 119.02532 76.0995) (xy 119.014286 76.101695) (xy 118.953525 76.0945)
 				(xy 118.908598 76.052965) (xy 118.896664 75.992955) (xy 118.897881 75.985275) (xy 118.899999 75.974629)
-				(xy 118.9 75.974622) (xy 118.9 75.662501) (xy 118.899999 75.6625) (xy 118.700001 75.6625) (xy 118.7 75.662501)
-				(xy 118.7 76.194951) (xy 118.706647 76.200407) (xy 118.746043 76.205069) (xy 118.790973 76.246601)
-				(xy 118.802911 76.306611) (xy 118.801695 76.31429) (xy 118.7995 76.325323) (xy 118.7995 76.474672)
-				(xy 118.799501 76.474684) (xy 118.812968 76.542383) (xy 118.814034 76.54774) (xy 118.814035 76.547742)
-				(xy 118.817766 76.556749) (xy 118.815751 76.557583) (xy 118.828811 76.603888) (xy 118.816227 76.642613)
-				(xy 118.817766 76.643251) (xy 118.814033 76.652263) (xy 118.799501 76.725315) (xy 118.7995 76.725327)
-				(xy 118.7995 76.874672) (xy 118.799501 76.874684) (xy 118.804305 76.898832) (xy 118.814034 76.94774)
-				(xy 118.814035 76.947742) (xy 118.817766 76.956749) (xy 118.815751 76.957583) (xy 118.828811 77.003888)
-				(xy 118.816227 77.042613) (xy 118.817766 77.043251) (xy 118.814033 77.052263) (xy 118.799501 77.125315)
-				(xy 118.7995 77.125327) (xy 118.7995 77.274672) (xy 118.799501 77.274684) (xy 118.812407 77.339562)
-				(xy 118.814034 77.34774) (xy 118.814035 77.347742) (xy 118.817766 77.356749) (xy 118.815751 77.357583)
-				(xy 118.828811 77.403888) (xy 118.816227 77.442613) (xy 118.817766 77.443251) (xy 118.814033 77.452263)
-				(xy 118.799501 77.525315) (xy 118.7995 77.525327) (xy 118.7995 77.674672) (xy 118.799501 77.674684)
-				(xy 118.814033 77.747736) (xy 118.814034 77.74774) (xy 118.814035 77.747742) (xy 118.817766 77.756749)
-				(xy 118.815751 77.757583) (xy 118.828811 77.803888) (xy 118.816227 77.842613) (xy 118.817766 77.843251)
-				(xy 118.814033 77.852263) (xy 118.799501 77.925315) (xy 118.7995 77.925327) (xy 118.7995 77.971491)
-				(xy 118.780593 78.029682) (xy 118.731093 78.065646) (xy 118.67261 78.066481) (xy 118.614779 78.049501)
-				(xy 118.614775 78.0495) (xy 118.614774 78.0495) (xy 118.48523 78.0495) (xy 118.485227 78.0495) (xy 118.360935 78.085995)
+				(xy 118.9 75.974622) (xy 118.9 75.662501) (xy 118.899999 75.6625) (xy 118.7 75.6625) (xy 118.7 76.194951)
+				(xy 118.706647 76.200407) (xy 118.746043 76.205069) (xy 118.790973 76.246601) (xy 118.802911 76.306611)
+				(xy 118.801695 76.31429) (xy 118.7995 76.325323) (xy 118.7995 76.474672) (xy 118.799501 76.474684)
+				(xy 118.812968 76.542383) (xy 118.814034 76.54774) (xy 118.814035 76.547742) (xy 118.817766 76.556749)
+				(xy 118.815751 76.557583) (xy 118.828811 76.603888) (xy 118.816227 76.642613) (xy 118.817766 76.643251)
+				(xy 118.814033 76.652263) (xy 118.799501 76.725315) (xy 118.7995 76.725327) (xy 118.7995 76.874672)
+				(xy 118.799501 76.874684) (xy 118.804305 76.898832) (xy 118.814034 76.94774) (xy 118.814035 76.947742)
+				(xy 118.817766 76.956749) (xy 118.815751 76.957583) (xy 118.828811 77.003888) (xy 118.816227 77.042613)
+				(xy 118.817766 77.043251) (xy 118.814033 77.052263) (xy 118.799501 77.125315) (xy 118.7995 77.125327)
+				(xy 118.7995 77.274672) (xy 118.799501 77.274684) (xy 118.812407 77.339562) (xy 118.814034 77.34774)
+				(xy 118.814035 77.347742) (xy 118.817766 77.356749) (xy 118.815751 77.357583) (xy 118.828811 77.403888)
+				(xy 118.816227 77.442613) (xy 118.817766 77.443251) (xy 118.814033 77.452263) (xy 118.799501 77.525315)
+				(xy 118.7995 77.525327) (xy 118.7995 77.674672) (xy 118.799501 77.674684) (xy 118.814033 77.747736)
+				(xy 118.814034 77.74774) (xy 118.814035 77.747742) (xy 118.817766 77.756749) (xy 118.815751 77.757583)
+				(xy 118.828811 77.803888) (xy 118.816227 77.842613) (xy 118.817766 77.843251) (xy 118.814033 77.852263)
+				(xy 118.799501 77.925315) (xy 118.7995 77.925327) (xy 118.7995 77.971491) (xy 118.780593 78.029682)
+				(xy 118.731093 78.065646) (xy 118.67261 78.066481) (xy 118.614779 78.049501) (xy 118.614775 78.0495)
+				(xy 118.614774 78.0495) (xy 118.48523 78.0495) (xy 118.485227 78.0495) (xy 118.360935 78.085995)
 				(xy 118.360928 78.085998) (xy 118.251954 78.156031) (xy 118.167119 78.253938) (xy 118.113304 78.371774)
 				(xy 118.094869 78.499997) (xy 118.094869 78.500002) (xy 118.113304 78.628225) (xy 118.15765 78.725327)
 				(xy 118.16712 78.746063) (xy 118.248136 78.839562) (xy 118.251954 78.843968) (xy 118.355479 78.910499)
@@ -38073,40 +38141,42 @@
 				(xy 118.739776 81.218819) (xy 118.788229 81.256182) (xy 118.803604 81.292747) (xy 118.814504 81.347541)
 				(xy 118.818238 81.356557) (xy 118.816291 81.357363) (xy 118.82941 81.403896) (xy 118.816758 81.442835)
 				(xy 118.818236 81.443447) (xy 118.814504 81.452454) (xy 118.805048 81.499999) (xy 118.805049 81.5)
-				(xy 119.337499 81.5) (xy 119.3375 81.499999) (xy 119.3375 81.1995) (xy 119.356407 81.141309) (xy 119.405907 81.105345)
-				(xy 119.4365 81.1005) (xy 119.4385 81.1005) (xy 119.496691 81.119407) (xy 119.532655 81.168907)
-				(xy 119.5375 81.1995) (xy 119.5375 81.899999) (xy 119.537501 81.9) (xy 119.849623 81.9) (xy 119.849634 81.899998)
-				(xy 119.923173 81.88537) (xy 119.983934 81.89256) (xy 120.012492 81.912463) (xy 120.471004 82.370975)
-				(xy 120.498781 82.425492) (xy 120.5 82.440979) (xy 120.5 83.190161) (xy 120.481093 83.248352) (xy 120.431593 83.284316)
-				(xy 120.370407 83.284316) (xy 120.330996 83.260165) (xy 120.268021 83.19719) (xy 120.159361 83.146521)
-				(xy 120.159354 83.146519) (xy 120.109839 83.14) (xy 120.000001 83.14) (xy 120 83.140001) (xy 120 83.621)
-				(xy 119.981093 83.679191) (xy 119.931593 83.715155) (xy 119.901 83.72) (xy 118.899 83.72) (xy 118.840809 83.701093)
-				(xy 118.804845 83.651593) (xy 118.8 83.621) (xy 118.8 83.123993) (xy 118.788851 83.102112) (xy 118.798422 83.04168)
-				(xy 118.824052 83.012841) (xy 118.823345 83.012134) (xy 118.830241 83.005237) (xy 118.885492 82.922548)
-				(xy 118.885493 82.922546) (xy 118.899999 82.849624) (xy 118.9 82.849622) (xy 118.9 82.825737) (xy 118.918907 82.767546)
-				(xy 118.968407 82.731582) (xy 119.029593 82.731582) (xy 119.079093 82.767546) (xy 119.089053 82.784611)
-				(xy 119.117116 82.84606) (xy 119.117117 82.846061) (xy 119.117118 82.846063) (xy 119.18339 82.922546)
-				(xy 119.201952 82.943968) (xy 119.238863 82.967689) (xy 119.277594 83.015055) (xy 119.281088 83.07614)
-				(xy 119.248009 83.127613) (xy 119.190992 83.149812) (xy 119.166922 83.147074) (xy 119.166865 83.147508)
-				(xy 119.109839 83.14) (xy 119.000001 83.14) (xy 119 83.140001) (xy 119 83.519999) (xy 119.000001 83.52)
-				(xy 119.799999 83.52) (xy 119.8 83.519999) (xy 119.8 83.140001) (xy 119.785473 83.125474) (xy 119.771988 83.121093)
-				(xy 119.736024 83.071593) (xy 119.736024 83.010407) (xy 119.771988 82.960907) (xy 119.776655 82.957716)
-				(xy 119.798049 82.943967) (xy 119.882882 82.846063) (xy 119.936697 82.728226) (xy 119.955133 82.6)
-				(xy 119.952834 82.584011) (xy 119.936697 82.471774) (xy 119.910992 82.415489) (xy 119.882882 82.353937)
-				(xy 119.798049 82.256033) (xy 119.798048 82.256032) (xy 119.798047 82.256031) (xy 119.689073 82.185998)
-				(xy 119.68907 82.185996) (xy 119.689069 82.185996) (xy 119.689066 82.185995) (xy 119.564774 82.1495)
-				(xy 119.564772 82.1495) (xy 119.435228 82.1495) (xy 119.435225 82.1495) (xy 119.310933 82.185995)
-				(xy 119.310926 82.185998) (xy 119.201952 82.256031) (xy 119.117117 82.353938) (xy 119.089053 82.415389)
-				(xy 119.087246 82.417356) (xy 119.085486 82.4232) (xy 119.063301 82.471777) (xy 119.062657 82.476256)
-				(xy 119.035656 82.531162) (xy 118.981539 82.55971) (xy 118.920978 82.550998) (xy 118.902119 82.5375)
-				(xy 118.5995 82.5375) (xy 118.541309 82.518593) (xy 118.505345 82.469093) (xy 118.5005 82.4385)
-				(xy 118.5005 82.025326) (xy 118.500476 82.025083) (xy 118.5 82.015384) (xy 118.5 81.805046) (xy 118.7 81.805046)
-				(xy 118.7 82.337499) (xy 118.700001 82.3375) (xy 118.899999 82.3375) (xy 118.9 82.337499) (xy 118.9 82.025377)
+				(xy 119.3385 81.5) (xy 119.396691 81.518907) (xy 119.432655 81.568407) (xy 119.4375 81.599) (xy 119.4375 81.6)
+				(xy 119.4385 81.6) (xy 119.496691 81.618907) (xy 119.532655 81.668407) (xy 119.5375 81.699) (xy 119.5375 81.899999)
+				(xy 119.537501 81.9) (xy 119.849623 81.9) (xy 119.849634 81.899998) (xy 119.923173 81.88537) (xy 119.983934 81.89256)
+				(xy 120.012492 81.912463) (xy 120.471004 82.370975) (xy 120.498781 82.425492) (xy 120.5 82.440979)
+				(xy 120.5 83.190161) (xy 120.481093 83.248352) (xy 120.431593 83.284316) (xy 120.370407 83.284316)
+				(xy 120.330996 83.260165) (xy 120.268021 83.19719) (xy 120.159361 83.146521) (xy 120.159354 83.146519)
+				(xy 120.109839 83.14) (xy 120.000001 83.14) (xy 120 83.140001) (xy 120 83.521) (xy 119.981093 83.579191)
+				(xy 119.931593 83.615155) (xy 119.901 83.62) (xy 119.9 83.62) (xy 119.9 83.621) (xy 119.881093 83.679191)
+				(xy 119.831593 83.715155) (xy 119.801 83.72) (xy 118.999 83.72) (xy 118.940809 83.701093) (xy 118.904845 83.651593)
+				(xy 118.9 83.621) (xy 118.9 83.62) (xy 118.899 83.62) (xy 118.840809 83.601093) (xy 118.804845 83.551593)
+				(xy 118.8 83.521) (xy 118.8 83.123993) (xy 118.788851 83.102112) (xy 118.798422 83.04168) (xy 118.824052 83.012841)
+				(xy 118.823345 83.012134) (xy 118.830241 83.005237) (xy 118.885492 82.922548) (xy 118.885493 82.922546)
+				(xy 118.899999 82.849624) (xy 118.9 82.849622) (xy 118.9 82.825737) (xy 118.918907 82.767546) (xy 118.968407 82.731582)
+				(xy 119.029593 82.731582) (xy 119.079093 82.767546) (xy 119.089053 82.784611) (xy 119.117116 82.84606)
+				(xy 119.117117 82.846061) (xy 119.117118 82.846063) (xy 119.18339 82.922546) (xy 119.201952 82.943968)
+				(xy 119.238863 82.967689) (xy 119.277594 83.015055) (xy 119.281088 83.07614) (xy 119.248009 83.127613)
+				(xy 119.190992 83.149812) (xy 119.166922 83.147074) (xy 119.166865 83.147508) (xy 119.109839 83.14)
+				(xy 119.000001 83.14) (xy 119 83.140001) (xy 119 83.52) (xy 119.8 83.52) (xy 119.8 83.140001) (xy 119.785473 83.125474)
+				(xy 119.771988 83.121093) (xy 119.736024 83.071593) (xy 119.736024 83.010407) (xy 119.771988 82.960907)
+				(xy 119.776655 82.957716) (xy 119.798049 82.943967) (xy 119.882882 82.846063) (xy 119.936697 82.728226)
+				(xy 119.955133 82.6) (xy 119.952834 82.584011) (xy 119.936697 82.471774) (xy 119.910992 82.415489)
+				(xy 119.882882 82.353937) (xy 119.798049 82.256033) (xy 119.798048 82.256032) (xy 119.798047 82.256031)
+				(xy 119.689073 82.185998) (xy 119.68907 82.185996) (xy 119.689069 82.185996) (xy 119.689066 82.185995)
+				(xy 119.564774 82.1495) (xy 119.564772 82.1495) (xy 119.435228 82.1495) (xy 119.435225 82.1495)
+				(xy 119.310933 82.185995) (xy 119.310926 82.185998) (xy 119.201952 82.256031) (xy 119.117117 82.353938)
+				(xy 119.089053 82.415389) (xy 119.087246 82.417356) (xy 119.085486 82.4232) (xy 119.063301 82.471777)
+				(xy 119.062657 82.476256) (xy 119.035656 82.531162) (xy 118.981539 82.55971) (xy 118.920978 82.550998)
+				(xy 118.902119 82.5375) (xy 118.699 82.5375) (xy 118.640809 82.518593) (xy 118.604845 82.469093)
+				(xy 118.6 82.4385) (xy 118.6 82.4375) (xy 118.5995 82.4375) (xy 118.541309 82.418593) (xy 118.505345 82.369093)
+				(xy 118.5005 82.3385) (xy 118.5005 82.025326) (xy 118.500476 82.025083) (xy 118.5 82.015384) (xy 118.5 81.805046)
+				(xy 118.7 81.805046) (xy 118.7 82.3375) (xy 118.899999 82.3375) (xy 118.9 82.337499) (xy 118.9 82.025377)
 				(xy 118.899999 82.025368) (xy 118.897775 82.014188) (xy 118.904965 81.953427) (xy 118.946497 81.908496)
 				(xy 119.006506 81.896558) (xy 119.014188 81.897775) (xy 119.025368 81.899999) (xy 119.025377 81.9)
-				(xy 119.337499 81.9) (xy 119.3375 81.899999) (xy 119.3375 81.700001) (xy 119.337499 81.7) (xy 118.805048 81.7)
-				(xy 118.799788 81.706409) (xy 118.795033 81.746577) (xy 118.753499 81.791505) (xy 118.704665 81.801217)
-				(xy 118.7 81.805046) (xy 118.5 81.805046) (xy 118.452457 81.814504) (xy 118.443445 81.818237) (xy 118.442574 81.816135)
+				(xy 119.337499 81.9) (xy 119.3375 81.899999) (xy 119.3375 81.7) (xy 118.805048 81.7) (xy 118.799788 81.706409)
+				(xy 118.795033 81.746577) (xy 118.753499 81.791505) (xy 118.704665 81.801217) (xy 118.7 81.805046)
+				(xy 118.5 81.805046) (xy 118.452457 81.814504) (xy 118.443445 81.818237) (xy 118.442574 81.816135)
 				(xy 118.396553 81.82911) (xy 118.357333 81.816363) (xy 118.356752 81.817767) (xy 118.347742 81.814035)
 				(xy 118.34774 81.814034) (xy 118.347736 81.814033) (xy 118.274684 81.799501) (xy 118.274674 81.7995)
 				(xy 118.125326 81.7995) (xy 118.125325 81.7995) (xy 118.125315 81.799501) (xy 118.052263 81.814033)
@@ -38152,11 +38222,9 @@
 				(xy 114.7 81.729218) (xy 114.7 80.8995) (xy 114.718907 80.841309) (xy 114.768407 80.805345) (xy 114.799 80.8005)
 				(xy 117.619747 80.8005) (xy 117.619748 80.8005) (xy 117.678231 80.788867) (xy 117.744552 80.744552)
 				(xy 117.788867 80.678231) (xy 117.8005 80.619748) (xy 117.8005 79.499999) (xy 118.805048 79.499999)
-				(xy 118.805049 79.5) (xy 119.337499 79.5) (xy 119.3375 79.499999) (xy 119.3375 79.300001) (xy 119.5375 79.300001)
-				(xy 119.5375 79.499999) (xy 119.537501 79.5) (xy 120.069951 79.5) (xy 120.069951 79.499999) (xy 120.060495 79.452457)
-				(xy 120.056764 79.443449) (xy 120.058712 79.442642) (xy 120.045587 79.396125) (xy 120.058245 79.357164)
-				(xy 120.056764 79.356551) (xy 120.060495 79.347542) (xy 120.069952 79.3) (xy 119.537501 79.3) (xy 119.5375 79.300001)
-				(xy 119.3375 79.300001) (xy 119.337499 79.3) (xy 118.805048 79.3) (xy 118.814504 79.347545) (xy 118.818236 79.356553)
+				(xy 118.805049 79.5) (xy 120.069951 79.5) (xy 120.069951 79.499999) (xy 120.060495 79.452457) (xy 120.056764 79.443449)
+				(xy 120.058712 79.442642) (xy 120.045587 79.396125) (xy 120.058245 79.357164) (xy 120.056764 79.356551)
+				(xy 120.060495 79.347542) (xy 120.069952 79.3) (xy 118.805048 79.3) (xy 118.814504 79.347545) (xy 118.818236 79.356553)
 				(xy 118.81629 79.357358) (xy 118.82941 79.403896) (xy 118.816758 79.442835) (xy 118.818236 79.443447)
 				(xy 118.814504 79.452454) (xy 118.805048 79.499999) (xy 117.8005 79.499999) (xy 117.8005 77.380252)
 				(xy 117.788867 77.321769) (xy 117.744552 77.255448) (xy 117.744548 77.255445) (xy 117.678233 77.211134)
@@ -38213,8 +38281,8 @@
 				(xy 114.899999 76.194951) (xy 114.9 76.194951) (xy 114.9 75.984613) (xy 114.900477 75.974904) (xy 114.9005 75.97467)
 				(xy 114.9005 75.150326) (xy 114.900476 75.150083) (xy 114.9 75.140384) (xy 114.9 74.930046) (xy 114.891727 74.923257)
 				(xy 114.857553 74.919213) (xy 114.812623 74.87768) (xy 114.8 74.829306) (xy 114.8 74.809) (xy 114.818907 74.750809)
-				(xy 114.868407 74.714845) (xy 114.899 74.71) (xy 114.979999 74.71) (xy 114.98 74.709999) (xy 114.98 74.199)
-				(xy 114.998907 74.140809) (xy 115.048407 74.104845) (xy 115.079 74.1) (xy 115.081 74.1)
+				(xy 114.868407 74.714845) (xy 114.899 74.71) (xy 114.979999 74.71) (xy 114.98 74.709999) (xy 114.98 74.299)
+				(xy 114.998907 74.240809) (xy 115.048407 74.204845) (xy 115.079 74.2) (xy 115.081 74.2)
 			)
 		)
 	)
@@ -38341,30 +38409,30 @@
 				(xy 144.185616 95.1995) (xy 143.254384 95.1995) (xy 143.254379 95.1995) (xy 143.228846 95.202462)
 				(xy 143.228844 95.202463) (xy 143.12436 95.248597) (xy 143.064647 95.308309) (xy 143.010133 95.336085)
 				(xy 142.949701 95.326514) (xy 142.924642 95.308308) (xy 142.865351 95.249017) (xy 142.761036 95.202958)
-				(xy 142.735538 95.2) (xy 141.804468 95.2) (xy 141.804467 95.200001) (xy 141.778961 95.202958) (xy 141.674648 95.249017)
-				(xy 141.617544 95.306122) (xy 142.27 95.958578) (xy 142.825496 95.403082) (xy 142.880013 95.375305)
-				(xy 142.940445 95.384876) (xy 142.98371 95.428141) (xy 142.9945 95.473086) (xy 142.9945 95.475913)
-				(xy 142.975593 95.534104) (xy 142.965504 95.545917) (xy 142.411421 96.099999) (xy 142.965504 96.654082)
-				(xy 142.993281 96.708599) (xy 142.9945 96.724086) (xy 142.9945 96.726914) (xy 142.975593 96.785105)
-				(xy 142.926093 96.821069) (xy 142.864907 96.821069) (xy 142.825496 96.796918) (xy 142.27 96.241422)
-				(xy 141.617544 96.893878) (xy 141.674648 96.950982) (xy 141.778963 96.997041) (xy 141.804461 96.999999)
-				(xy 142.735531 96.999999) (xy 142.735532 96.999998) (xy 142.761038 96.997041) (xy 142.865351 96.950982)
-				(xy 142.924642 96.891692) (xy 142.979159 96.863915) (xy 143.039591 96.873486) (xy 143.064646 96.891689)
+				(xy 142.735538 95.2) (xy 141.804468 95.2) (xy 141.804467 95.200001) (xy 141.778961 95.202958) (xy 141.674646 95.249018)
+				(xy 141.617542 95.306121) (xy 142.269999 95.958578) (xy 142.825496 95.403082) (xy 142.880013 95.375305)
+				(xy 142.940445 95.384876) (xy 142.98371 95.428141) (xy 142.9945 95.473086) (xy 142.9945 95.475912)
+				(xy 142.975593 95.534103) (xy 142.965504 95.545916) (xy 142.411421 96.099999) (xy 142.965504 96.654082)
+				(xy 142.993281 96.708599) (xy 142.9945 96.724086) (xy 142.9945 96.726912) (xy 142.975593 96.785103)
+				(xy 142.926093 96.821067) (xy 142.864907 96.821067) (xy 142.825496 96.796916) (xy 142.27 96.24142)
+				(xy 141.617543 96.893877) (xy 141.674648 96.950982) (xy 141.778963 96.997041) (xy 141.804461 96.999999)
+				(xy 142.735531 96.999999) (xy 142.735532 96.999998) (xy 142.761038 96.997041) (xy 142.86535 96.950982)
+				(xy 142.92464 96.891692) (xy 142.979157 96.863914) (xy 143.039589 96.873485) (xy 143.064645 96.891688)
 				(xy 143.12436 96.951403) (xy 143.228844 96.997537) (xy 143.25438 97.000499) (xy 143.254382 97.0005)
 				(xy 143.254384 97.0005) (xy 143.3205 97.0005) (xy 143.378691 97.019407) (xy 143.414655 97.068907)
 				(xy 143.4195 97.0995) (xy 143.4195 98.7005) (xy 143.400593 98.758691) (xy 143.351093 98.794655)
 				(xy 143.3205 98.7995) (xy 143.254379 98.7995) (xy 143.228846 98.802462) (xy 143.228844 98.802463)
 				(xy 143.12436 98.848597) (xy 143.064647 98.908309) (xy 143.010133 98.936085) (xy 142.949701 98.926514)
 				(xy 142.924642 98.908308) (xy 142.865351 98.849017) (xy 142.761036 98.802958) (xy 142.735538 98.8)
-				(xy 141.804468 98.8) (xy 141.804467 98.800001) (xy 141.778961 98.802958) (xy 141.674648 98.849017)
-				(xy 141.617544 98.906122) (xy 142.27 99.558578) (xy 142.825496 99.003082) (xy 142.880013 98.975305)
-				(xy 142.940445 98.984876) (xy 142.98371 99.028141) (xy 142.9945 99.073086) (xy 142.9945 99.075913)
-				(xy 142.975593 99.134104) (xy 142.965504 99.145917) (xy 142.411421 99.699999) (xy 142.965504 100.254082)
-				(xy 142.993281 100.308599) (xy 142.9945 100.324086) (xy 142.9945 100.326914) (xy 142.975593 100.385105)
-				(xy 142.926093 100.421069) (xy 142.864907 100.421069) (xy 142.825496 100.396918) (xy 142.27 99.841422)
-				(xy 141.617544 100.493878) (xy 141.674648 100.550982) (xy 141.778963 100.597041) (xy 141.804461 100.599999)
-				(xy 142.735531 100.599999) (xy 142.735532 100.599998) (xy 142.761038 100.597041) (xy 142.865351 100.550982)
-				(xy 142.924642 100.491692) (xy 142.979159 100.463915) (xy 143.039591 100.473486) (xy 143.064646 100.491689)
+				(xy 141.804468 98.8) (xy 141.804467 98.800001) (xy 141.778961 98.802958) (xy 141.674646 98.849018)
+				(xy 141.617542 98.906121) (xy 142.269999 99.558578) (xy 142.825496 99.003082) (xy 142.880013 98.975305)
+				(xy 142.940445 98.984876) (xy 142.98371 99.028141) (xy 142.9945 99.073086) (xy 142.9945 99.075912)
+				(xy 142.975593 99.134103) (xy 142.965504 99.145916) (xy 142.411421 99.699999) (xy 142.965504 100.254082)
+				(xy 142.993281 100.308599) (xy 142.9945 100.324086) (xy 142.9945 100.326912) (xy 142.975593 100.385103)
+				(xy 142.926093 100.421067) (xy 142.864907 100.421067) (xy 142.825496 100.396916) (xy 142.27 99.84142)
+				(xy 141.617543 100.493877) (xy 141.674648 100.550982) (xy 141.778963 100.597041) (xy 141.804461 100.599999)
+				(xy 142.735531 100.599999) (xy 142.735532 100.599998) (xy 142.761038 100.597041) (xy 142.86535 100.550982)
+				(xy 142.92464 100.491692) (xy 142.979157 100.463914) (xy 143.039589 100.473485) (xy 143.064645 100.491688)
 				(xy 143.12436 100.551403) (xy 143.228844 100.597537) (xy 143.25438 100.600499) (xy 143.254382 100.6005)
 				(xy 143.254384 100.6005) (xy 143.3205 100.6005) (xy 143.378691 100.619407) (xy 143.414655 100.668907)
 				(xy 143.4195 100.6995) (xy 143.4195 139.314521) (xy 143.400593 139.372712) (xy 143.390504 139.384525)
@@ -38493,70 +38561,71 @@
 				(xy 125.075364 143.415582) (xy 124.976239 143.614652) (xy 124.915379 143.828554) (xy 124.894859 144.05)
 				(xy 116.440657 144.05) (xy 116.924114 143.566543) (xy 117.000775 143.451811) (xy 117.05358 143.324328)
 				(xy 117.0805 143.188994) (xy 117.0805 143.133123) (xy 125.324545 143.133123) (xy 126.099999 143.908577)
-				(xy 126.875453 143.133123) (xy 126.82626 143.088277) (xy 126.637176 142.971202) (xy 126.429799 142.890863)
-				(xy 126.211196 142.85) (xy 125.988804 142.85) (xy 125.7702 142.890863) (xy 125.562821 142.971202)
-				(xy 125.562816 142.971205) (xy 125.373742 143.088275) (xy 125.373739 143.088277) (xy 125.324545 143.133123)
-				(xy 117.0805 143.133123) (xy 117.0805 143.051006) (xy 117.0805 138.274662) (xy 117.099407 138.216471)
-				(xy 117.10949 138.204664) (xy 117.160411 138.153744) (xy 117.209221 138.049071) (xy 117.2155 138.001375)
-				(xy 117.215499 134.998626) (xy 117.209221 134.950929) (xy 117.20204 134.93553) (xy 117.160412 134.846258)
-				(xy 117.160411 134.846257) (xy 117.160411 134.846256) (xy 117.078744 134.764589) (xy 117.078742 134.764588)
-				(xy 117.078741 134.764587) (xy 116.974075 134.71578) (xy 116.974063 134.715777) (xy 116.926376 134.7095)
-				(xy 115.833629 134.7095) (xy 115.833618 134.709501) (xy 115.785932 134.715778) (xy 115.785924 134.71578)
-				(xy 115.681258 134.764587) (xy 115.599587 134.846258) (xy 115.55078 134.950924) (xy 115.550777 134.950936)
-				(xy 115.5445 134.998619) (xy 115.5445 138.00137) (xy 115.544501 138.001381) (xy 115.550778 138.049067)
-				(xy 115.55078 138.049075) (xy 115.599587 138.153741) (xy 115.599588 138.153742) (xy 115.599589 138.153744)
-				(xy 115.650505 138.20466) (xy 115.678281 138.259175) (xy 115.6795 138.274662) (xy 115.6795 142.788835)
-				(xy 115.660593 142.847026) (xy 115.650504 142.858839) (xy 114.738839 143.770504) (xy 114.684322 143.798281)
-				(xy 114.668835 143.7995) (xy 112.681165 143.7995) (xy 112.622974 143.780593) (xy 112.611161 143.770504)
-				(xy 112.329496 143.488839) (xy 112.301719 143.434322) (xy 112.3005 143.418835) (xy 112.3005 137.531008)
-				(xy 112.300499 137.531004) (xy 112.27358 137.395672) (xy 112.220775 137.268189) (xy 112.194809 137.229328)
-				(xy 112.144114 137.153457) (xy 108.729496 133.738839) (xy 108.701719 133.684322) (xy 108.7005 133.668835)
-				(xy 108.7005 126.931011) (xy 108.7005 126.931007) (xy 108.695992 126.908346) (xy 108.67358 126.795672)
-				(xy 108.620775 126.668189) (xy 108.544114 126.553457) (xy 106.679496 124.688839) (xy 106.651719 124.634322)
-				(xy 106.6505 124.618835) (xy 106.6505 123.850001) (xy 107.225001 123.850001) (xy 107.225001 124.429203)
-				(xy 107.22785 124.4596) (xy 107.22785 124.459602) (xy 107.272654 124.587647) (xy 107.353207 124.69679)
-				(xy 107.353209 124.696792) (xy 107.462352 124.777345) (xy 107.590398 124.822149) (xy 107.620789 124.824999)
-				(xy 107.887498 124.824999) (xy 107.8875 124.824998) (xy 107.8875 123.850001) (xy 108.0875 123.850001)
-				(xy 108.0875 124.824998) (xy 108.087501 124.824999) (xy 108.354203 124.824999) (xy 108.3846 124.822149)
-				(xy 108.384602 124.822149) (xy 108.512647 124.777345) (xy 108.62179 124.696792) (xy 108.621792 124.69679)
-				(xy 108.702345 124.587647) (xy 108.747149 124.459601) (xy 108.749999 124.429211) (xy 108.75 124.42921)
-				(xy 108.75 123.850001) (xy 108.749999 123.85) (xy 108.087501 123.85) (xy 108.0875 123.850001) (xy 107.8875 123.850001)
-				(xy 107.887499 123.85) (xy 107.225002 123.85) (xy 107.225001 123.850001) (xy 106.6505 123.850001)
-				(xy 106.6505 122.881164) (xy 106.669407 122.822973) (xy 106.679496 122.81116) (xy 106.76116 122.729496)
-				(xy 106.815677 122.701719) (xy 106.831164 122.7005) (xy 107.232901 122.7005) (xy 107.291092 122.719407)
-				(xy 107.327056 122.768907) (xy 107.327056 122.830093) (xy 107.312556 122.858288) (xy 107.272655 122.91235)
-				(xy 107.22785 123.040398) (xy 107.225 123.070788) (xy 107.225 123.649999) (xy 107.225001 123.65)
-				(xy 108.749998 123.65) (xy 108.749999 123.649999) (xy 108.749999 123.070796) (xy 108.747149 123.040399)
-				(xy 108.747149 123.040397) (xy 108.702344 122.91235) (xy 108.662444 122.858288) (xy 108.643102 122.800241)
-				(xy 108.661573 122.74191) (xy 108.710803 122.705577) (xy 108.742099 122.7005) (xy 110.15728 122.7005)
-				(xy 110.215471 122.719407) (xy 110.251435 122.768907) (xy 110.251435 122.830093) (xy 110.236935 122.858288)
-				(xy 110.197207 122.912116) (xy 110.152355 123.040296) (xy 110.152353 123.040305) (xy 110.1495 123.070725)
-				(xy 110.1495 124.429274) (xy 110.152353 124.459694) (xy 110.152355 124.459703) (xy 110.197207 124.587883)
-				(xy 110.277845 124.697144) (xy 110.277847 124.697146) (xy 110.27785 124.69715) (xy 110.291352 124.707115)
-				(xy 110.326945 124.756879) (xy 110.326489 124.818063) (xy 110.302569 124.856774) (xy 109.455883 125.70346)
-				(xy 109.379223 125.818191) (xy 109.32642 125.94567) (xy 109.32642 125.945672) (xy 109.300596 126.075499)
-				(xy 109.300595 126.075504) (xy 109.2995 126.081007) (xy 109.2995 132.068996) (xy 109.32642 132.204327)
-				(xy 109.32642 132.204329) (xy 109.379223 132.331808) (xy 109.4337 132.41334) (xy 109.455886 132.446543)
-				(xy 113.110505 136.101162) (xy 113.138281 136.155677) (xy 113.1395 136.171164) (xy 113.1395 138.925337)
-				(xy 113.120593 138.983528) (xy 113.110504 138.99534) (xy 113.059589 139.046255) (xy 113.059587 139.046258)
-				(xy 113.01078 139.150924) (xy 113.010777 139.150936) (xy 113.0045 139.198619) (xy 113.0045 142.20137)
-				(xy 113.004501 142.201381) (xy 113.010778 142.249067) (xy 113.01078 142.249075) (xy 113.059587 142.353741)
-				(xy 113.059588 142.353742) (xy 113.059589 142.353744) (xy 113.141256 142.435411) (xy 113.141257 142.435411)
-				(xy 113.141258 142.435412) (xy 113.245924 142.484219) (xy 113.245925 142.484219) (xy 113.245929 142.484221)
-				(xy 113.245935 142.484221) (xy 113.245936 142.484222) (xy 113.250526 142.484826) (xy 113.293625 142.4905)
-				(xy 114.386374 142.490499) (xy 114.434071 142.484221) (xy 114.538744 142.435411) (xy 114.620411 142.353744)
-				(xy 114.669221 142.249071) (xy 114.6755 142.201375) (xy 114.675499 139.198626) (xy 114.669221 139.150929)
-				(xy 114.665902 139.143812) (xy 114.620412 139.046258) (xy 114.62041 139.046255) (xy 114.569496 138.99534)
-				(xy 114.541719 138.940823) (xy 114.5405 138.925337) (xy 114.5405 135.771008) (xy 114.540499 135.771004)
-				(xy 114.51358 135.635672) (xy 114.460775 135.508189) (xy 114.384114 135.393457) (xy 110.729496 131.738839)
-				(xy 110.701719 131.684322) (xy 110.7005 131.668835) (xy 110.7005 126.500001) (xy 111.04 126.500001)
-				(xy 111.04 126.609838) (xy 111.046519 126.659354) (xy 111.046521 126.659361) (xy 111.09719 126.768021)
-				(xy 111.181978 126.852809) (xy 111.290638 126.903478) (xy 111.290645 126.90348) (xy 111.340161 126.91)
-				(xy 111.419999 126.91) (xy 111.42 126.909999) (xy 111.42 126.500001) (xy 111.419999 126.5) (xy 111.040001 126.5)
+				(xy 126.875453 143.133123) (xy 126.875453 143.133122) (xy 126.826263 143.088279) (xy 126.637176 142.971202)
+				(xy 126.429799 142.890863) (xy 126.211196 142.85) (xy 125.988804 142.85) (xy 125.7702 142.890863)
+				(xy 125.562821 142.971202) (xy 125.562816 142.971205) (xy 125.373742 143.088275) (xy 125.373739 143.088277)
+				(xy 125.324545 143.133123) (xy 117.0805 143.133123) (xy 117.0805 143.051006) (xy 117.0805 138.274662)
+				(xy 117.099407 138.216471) (xy 117.10949 138.204664) (xy 117.160411 138.153744) (xy 117.209221 138.049071)
+				(xy 117.2155 138.001375) (xy 117.215499 134.998626) (xy 117.209221 134.950929) (xy 117.20204 134.93553)
+				(xy 117.160412 134.846258) (xy 117.160411 134.846257) (xy 117.160411 134.846256) (xy 117.078744 134.764589)
+				(xy 117.078742 134.764588) (xy 117.078741 134.764587) (xy 116.974075 134.71578) (xy 116.974063 134.715777)
+				(xy 116.926376 134.7095) (xy 115.833629 134.7095) (xy 115.833618 134.709501) (xy 115.785932 134.715778)
+				(xy 115.785924 134.71578) (xy 115.681258 134.764587) (xy 115.599587 134.846258) (xy 115.55078 134.950924)
+				(xy 115.550777 134.950936) (xy 115.5445 134.998619) (xy 115.5445 138.00137) (xy 115.544501 138.001381)
+				(xy 115.550778 138.049067) (xy 115.55078 138.049075) (xy 115.599587 138.153741) (xy 115.599588 138.153742)
+				(xy 115.599589 138.153744) (xy 115.650505 138.20466) (xy 115.678281 138.259175) (xy 115.6795 138.274662)
+				(xy 115.6795 142.788835) (xy 115.660593 142.847026) (xy 115.650504 142.858839) (xy 114.738839 143.770504)
+				(xy 114.684322 143.798281) (xy 114.668835 143.7995) (xy 112.681165 143.7995) (xy 112.622974 143.780593)
+				(xy 112.611161 143.770504) (xy 112.329496 143.488839) (xy 112.301719 143.434322) (xy 112.3005 143.418835)
+				(xy 112.3005 137.531008) (xy 112.300499 137.531004) (xy 112.27358 137.395672) (xy 112.220775 137.268189)
+				(xy 112.194809 137.229328) (xy 112.144114 137.153457) (xy 108.729496 133.738839) (xy 108.701719 133.684322)
+				(xy 108.7005 133.668835) (xy 108.7005 126.931011) (xy 108.7005 126.931007) (xy 108.695992 126.908346)
+				(xy 108.67358 126.795672) (xy 108.620775 126.668189) (xy 108.544114 126.553457) (xy 106.679496 124.688839)
+				(xy 106.651719 124.634322) (xy 106.6505 124.618835) (xy 106.6505 123.850001) (xy 107.225001 123.850001)
+				(xy 107.225001 124.429203) (xy 107.22785 124.4596) (xy 107.22785 124.459602) (xy 107.272654 124.587647)
+				(xy 107.353207 124.69679) (xy 107.353209 124.696792) (xy 107.462352 124.777345) (xy 107.590398 124.822149)
+				(xy 107.620789 124.824999) (xy 107.887498 124.824999) (xy 107.8875 124.824998) (xy 107.8875 123.850001)
+				(xy 108.0875 123.850001) (xy 108.0875 124.824998) (xy 108.087501 124.824999) (xy 108.354203 124.824999)
+				(xy 108.3846 124.822149) (xy 108.384602 124.822149) (xy 108.512647 124.777345) (xy 108.62179 124.696792)
+				(xy 108.621792 124.69679) (xy 108.702345 124.587647) (xy 108.747149 124.459601) (xy 108.749999 124.429211)
+				(xy 108.75 124.42921) (xy 108.75 123.850001) (xy 108.749999 123.85) (xy 108.087501 123.85) (xy 108.0875 123.850001)
+				(xy 107.8875 123.850001) (xy 107.887499 123.85) (xy 107.225002 123.85) (xy 107.225001 123.850001)
+				(xy 106.6505 123.850001) (xy 106.6505 122.881164) (xy 106.669407 122.822973) (xy 106.679496 122.81116)
+				(xy 106.76116 122.729496) (xy 106.815677 122.701719) (xy 106.831164 122.7005) (xy 107.232901 122.7005)
+				(xy 107.291092 122.719407) (xy 107.327056 122.768907) (xy 107.327056 122.830093) (xy 107.312556 122.858288)
+				(xy 107.272655 122.91235) (xy 107.22785 123.040398) (xy 107.225 123.070788) (xy 107.225 123.649999)
+				(xy 107.225001 123.65) (xy 108.749998 123.65) (xy 108.749999 123.649999) (xy 108.749999 123.070796)
+				(xy 108.747149 123.040399) (xy 108.747149 123.040397) (xy 108.702344 122.91235) (xy 108.662444 122.858288)
+				(xy 108.643102 122.800241) (xy 108.661573 122.74191) (xy 108.710803 122.705577) (xy 108.742099 122.7005)
+				(xy 110.15728 122.7005) (xy 110.215471 122.719407) (xy 110.251435 122.768907) (xy 110.251435 122.830093)
+				(xy 110.236935 122.858288) (xy 110.197207 122.912116) (xy 110.152355 123.040296) (xy 110.152353 123.040305)
+				(xy 110.1495 123.070725) (xy 110.1495 124.429274) (xy 110.152353 124.459694) (xy 110.152355 124.459703)
+				(xy 110.197207 124.587883) (xy 110.277845 124.697144) (xy 110.277847 124.697146) (xy 110.27785 124.69715)
+				(xy 110.291352 124.707115) (xy 110.326945 124.756879) (xy 110.326489 124.818063) (xy 110.302569 124.856774)
+				(xy 109.455883 125.70346) (xy 109.379223 125.818191) (xy 109.32642 125.94567) (xy 109.32642 125.945672)
+				(xy 109.300596 126.075499) (xy 109.300595 126.075504) (xy 109.2995 126.081007) (xy 109.2995 132.068996)
+				(xy 109.32642 132.204327) (xy 109.32642 132.204329) (xy 109.379223 132.331808) (xy 109.4337 132.41334)
+				(xy 109.455886 132.446543) (xy 113.110505 136.101162) (xy 113.138281 136.155677) (xy 113.1395 136.171164)
+				(xy 113.1395 138.925337) (xy 113.120593 138.983528) (xy 113.110504 138.99534) (xy 113.059589 139.046255)
+				(xy 113.059587 139.046258) (xy 113.01078 139.150924) (xy 113.010777 139.150936) (xy 113.0045 139.198619)
+				(xy 113.0045 142.20137) (xy 113.004501 142.201381) (xy 113.010778 142.249067) (xy 113.01078 142.249075)
+				(xy 113.059587 142.353741) (xy 113.059588 142.353742) (xy 113.059589 142.353744) (xy 113.141256 142.435411)
+				(xy 113.141257 142.435411) (xy 113.141258 142.435412) (xy 113.245924 142.484219) (xy 113.245925 142.484219)
+				(xy 113.245929 142.484221) (xy 113.245935 142.484221) (xy 113.245936 142.484222) (xy 113.250526 142.484826)
+				(xy 113.293625 142.4905) (xy 114.386374 142.490499) (xy 114.434071 142.484221) (xy 114.538744 142.435411)
+				(xy 114.620411 142.353744) (xy 114.669221 142.249071) (xy 114.6755 142.201375) (xy 114.675499 139.198626)
+				(xy 114.669221 139.150929) (xy 114.665902 139.143812) (xy 114.620412 139.046258) (xy 114.62041 139.046255)
+				(xy 114.569496 138.99534) (xy 114.541719 138.940823) (xy 114.5405 138.925337) (xy 114.5405 135.771008)
+				(xy 114.540499 135.771004) (xy 114.51358 135.635672) (xy 114.460775 135.508189) (xy 114.384114 135.393457)
+				(xy 110.729496 131.738839) (xy 110.701719 131.684322) (xy 110.7005 131.668835) (xy 110.7005 126.500001)
+				(xy 111.04 126.500001) (xy 111.04 126.609838) (xy 111.046519 126.659354) (xy 111.046521 126.659361)
+				(xy 111.09719 126.768021) (xy 111.181978 126.852809) (xy 111.290638 126.903478) (xy 111.290645 126.90348)
+				(xy 111.340161 126.91) (xy 111.419999 126.91) (xy 111.42 126.909999) (xy 111.42 126.5) (xy 111.040001 126.5)
 				(xy 111.04 126.500001) (xy 110.7005 126.500001) (xy 110.7005 126.481165) (xy 110.719407 126.422974)
 				(xy 110.729496 126.411161) (xy 110.870996 126.269661) (xy 110.925513 126.241884) (xy 110.985945 126.251455)
-				(xy 111.008248 126.273758) (xy 111.011004 126.271003) (xy 111.040001 126.3) (xy 111.521 126.3) (xy 111.579191 126.318907)
-				(xy 111.615155 126.368407) (xy 111.62 126.399) (xy 111.62 126.909999) (xy 111.637039 126.927038)
+				(xy 111.008248 126.273758) (xy 111.011004 126.271003) (xy 111.040001 126.3) (xy 111.421 126.3) (xy 111.479191 126.318907)
+				(xy 111.515155 126.368407) (xy 111.52 126.399) (xy 111.52 126.4) (xy 111.521 126.4) (xy 111.579191 126.418907)
+				(xy 111.615155 126.468407) (xy 111.62 126.499) (xy 111.62 126.909999) (xy 111.637039 126.927038)
 				(xy 111.642791 126.928907) (xy 111.678755 126.978407) (xy 111.678755 127.039593) (xy 111.654605 127.079001)
 				(xy 111.591731 127.141876) (xy 111.529517 127.20409) (xy 111.529516 127.204091) (xy 111.476795 127.295406)
 				(xy 111.476791 127.295415) (xy 111.46752 127.33002) (xy 111.466309 127.334539) (xy 111.4495 127.397273)
@@ -38685,7 +38754,7 @@
 				(xy 141.152793 137.562882) (xy 141.197646 137.434699) (xy 141.200499 137.404273) (xy 141.2005 137.404273)
 				(xy 141.2005 136.645727) (xy 141.200499 136.645725) (xy 141.197646 136.615305) (xy 141.197646 136.615301)
 				(xy 141.152793 136.487118) (xy 141.129844 136.456022) (xy 141.110503 136.397973) (xy 141.1105 136.397235)
-				(xy 141.1105 131.804242) (xy 141.129407 131.746051) (xy 141.152716 131.723146) (xy 141.171715 131.709843)
+				(xy 141.1105 131.804242) (xy 141.129407 131.746051) (xy 141.152716 131.723146) (xy 141.198898 131.690809)
 				(xy 141.236233 131.664667) (xy 141.394667 131.506233) (xy 141.523181 131.322696) (xy 141.617872 131.11963)
 				(xy 141.675863 130.903206) (xy 141.681963 130.833489) (xy 141.695391 130.680003) (xy 141.695391 130.679996)
 				(xy 141.675864 130.456801) (xy 141.675863 130.456798) (xy 141.675863 130.456794) (xy 141.617872 130.24037)
@@ -38782,8 +38851,9 @@
 				(xy 121.731253 121.3495) (xy 121.595922 121.37642) (xy 121.59592 121.37642) (xy 121.468441 121.429223)
 				(xy 121.35371 121.505883) (xy 120.456128 122.403465) (xy 120.453048 122.407219) (xy 120.452157 122.406487)
 				(xy 120.408222 122.441108) (xy 120.347083 122.443496) (xy 120.296217 122.409492) (xy 120.275588 122.353538)
-				(xy 120.272685 122.35) (xy 119.750001 122.35) (xy 119.75 122.350001) (xy 119.75 122.751) (xy 119.731093 122.809191)
-				(xy 119.681593 122.845155) (xy 119.651 122.85) (xy 119.027316 122.85) (xy 119.040231 122.914924)
+				(xy 120.272685 122.35) (xy 119.750001 122.35) (xy 119.75 122.350001) (xy 119.75 122.651) (xy 119.731093 122.709191)
+				(xy 119.681593 122.745155) (xy 119.651 122.75) (xy 119.65 122.75) (xy 119.65 122.751) (xy 119.631093 122.809191)
+				(xy 119.581593 122.845155) (xy 119.551 122.85) (xy 119.027316 122.85) (xy 119.040231 122.914924)
 				(xy 119.040231 122.914925) (xy 119.060025 122.944548) (xy 119.076634 123.003436) (xy 119.060027 123.05455)
 				(xy 119.039761 123.08488) (xy 119.039759 123.084886) (xy 119.024501 123.161589) (xy 119.0245 123.161599)
 				(xy 119.0245 123.338397) (xy 119.024501 123.338404) (xy 119.039759 123.415115) (xy 119.039759 123.415116)
@@ -38833,114 +38903,116 @@
 				(xy 115.03841 125.824501) (xy 115.038402 125.8245) (xy 115.038401 125.8245) (xy 115.0384 125.8245)
 				(xy 114.861602 125.8245) (xy 114.861595 125.824501) (xy 114.784884 125.839759) (xy 114.784882 125.83976)
 				(xy 114.754549 125.860027) (xy 114.69566 125.876634) (xy 114.644548 125.860025) (xy 114.614924 125.840231)
-				(xy 114.55 125.827316) (xy 114.55 126.451) (xy 114.531093 126.509191) (xy 114.481593 126.545155)
-				(xy 114.451 126.55) (xy 114.449 126.55) (xy 114.390809 126.531093) (xy 114.354845 126.481593) (xy 114.35 126.451)
-				(xy 114.35 125.850001) (xy 114.349999 125.85) (xy 113.850001 125.85) (xy 113.85 125.850001) (xy 113.85 126.074999)
-				(xy 113.850001 126.075) (xy 114.026 126.075) (xy 114.084191 126.093907) (xy 114.120155 126.143407)
-				(xy 114.125 126.174) (xy 114.125 126.269547) (xy 114.106093 126.327738) (xy 114.056593 126.363702)
-				(xy 113.99811 126.364537) (xy 113.939778 126.34741) (xy 113.939774 126.347409) (xy 113.939773 126.347409)
-				(xy 113.810229 126.347409) (xy 113.810226 126.347409) (xy 113.685934 126.383904) (xy 113.685927 126.383907)
-				(xy 113.576953 126.45394) (xy 113.492118 126.551847) (xy 113.438303 126.669683) (xy 113.419868 126.797906)
-				(xy 113.419868 126.797911) (xy 113.438303 126.926134) (xy 113.479338 127.015986) (xy 113.492119 127.043972)
-				(xy 113.575743 127.140481) (xy 113.576953 127.141877) (xy 113.580741 127.145159) (xy 113.612339 127.197554)
-				(xy 113.607104 127.258515) (xy 113.567038 127.304757) (xy 113.565414 127.305716) (xy 113.532886 127.324495)
-				(xy 113.532886 127.324496) (xy 113.515491 127.334538) (xy 113.515489 127.334539) (xy 113.104523 127.745504)
-				(xy 113.050007 127.773281) (xy 113.03452 127.7745) (xy 112.593479 127.7745) (xy 112.593476 127.774501)
-				(xy 112.4997 127.789352) (xy 112.499695 127.789354) (xy 112.394446 127.842982) (xy 112.334014 127.852554)
-				(xy 112.279497 127.824777) (xy 112.251719 127.770261) (xy 112.2505 127.754773) (xy 112.2505 127.656898)
-				(xy 112.269407 127.598707) (xy 112.27949 127.586901) (xy 112.72591 127.140481) (xy 112.725913 127.14048)
-				(xy 112.80048 127.065913) (xy 112.853207 126.974587) (xy 112.862592 126.939562) (xy 112.880501 126.872727)
-				(xy 112.880501 126.831982) (xy 112.898405 126.775197) (xy 112.903219 126.76832) (xy 112.903224 126.768316)
-				(xy 112.953972 126.659487) (xy 112.9605 126.609901) (xy 112.960499 126.1901) (xy 112.957941 126.17067)
-				(xy 112.953972 126.140513) (xy 112.953972 126.140511) (xy 112.903225 126.031684) (xy 112.902064 126.030027)
-				(xy 112.901325 126.02761) (xy 112.899564 126.023834) (xy 112.900094 126.023586) (xy 112.884173 125.971516)
-				(xy 112.904091 125.913664) (xy 112.913147 125.903244) (xy 112.969651 125.84674) (xy 113.024166 125.818965)
-				(xy 113.084598 125.828536) (xy 113.127863 125.871801) (xy 113.13675 125.89743) (xy 113.140229 125.914919)
-				(xy 113.14023 125.914923) (xy 113.198246 126.001749) (xy 113.19825 126.001753) (xy 113.285076 126.059768)
-				(xy 113.361643 126.074999) (xy 113.361645 126.075) (xy 113.649999 126.075) (xy 113.65 126.074999)
-				(xy 113.65 125.749) (xy 113.668907 125.690809) (xy 113.718407 125.654845) (xy 113.749 125.65) (xy 114.372683 125.65)
-				(xy 114.359769 125.585077) (xy 114.339973 125.555451) (xy 114.323364 125.496563) (xy 114.339971 125.44545)
-				(xy 114.36024 125.415117) (xy 114.3755 125.338401) (xy 114.375499 125.1616) (xy 114.36024 125.084883)
-				(xy 114.340273 125.055001) (xy 114.323665 124.996114) (xy 114.340274 124.944998) (xy 114.360238 124.91512)
-				(xy 114.360238 124.915119) (xy 114.36024 124.915117) (xy 114.3755 124.838401) (xy 114.375499 124.6616)
-				(xy 114.36024 124.584883) (xy 114.340273 124.555001) (xy 114.323665 124.496114) (xy 114.340274 124.444998)
-				(xy 114.360238 124.41512) (xy 114.360238 124.415119) (xy 114.36024 124.415117) (xy 114.3755 124.338401)
-				(xy 114.375499 124.1616) (xy 114.36024 124.084883) (xy 114.340273 124.055001) (xy 114.323665 123.996114)
-				(xy 114.340274 123.944998) (xy 114.360238 123.91512) (xy 114.360238 123.915119) (xy 114.36024 123.915117)
-				(xy 114.3755 123.838401) (xy 114.375499 123.6616) (xy 114.36024 123.584883) (xy 114.340273 123.555001)
-				(xy 114.323665 123.496114) (xy 114.340274 123.444998) (xy 114.360238 123.41512) (xy 114.360238 123.415119)
-				(xy 114.36024 123.415117) (xy 114.3755 123.338401) (xy 114.375499 123.1616) (xy 114.36024 123.084883)
-				(xy 114.339973 123.054551) (xy 114.323365 122.995663) (xy 114.339975 122.944547) (xy 114.359768 122.914924)
-				(xy 114.372684 122.85) (xy 113.749 122.85) (xy 113.690809 122.831093) (xy 113.654845 122.781593)
-				(xy 113.65 122.751) (xy 113.65 121.925001) (xy 113.649999 121.925) (xy 113.361643 121.925) (xy 113.285076 121.940231)
-				(xy 113.19825 121.998246) (xy 113.198246 121.99825) (xy 113.14023 122.085076) (xy 113.140229 122.08508)
-				(xy 113.13248 122.124035) (xy 113.102583 122.177418) (xy 113.047017 122.203033) (xy 112.987008 122.191095)
-				(xy 112.965379 122.174723) (xy 112.616656 121.826) (xy 112.246543 121.455886) (xy 112.244985 121.454845)
-				(xy 112.131808 121.379223) (xy 112.004328 121.32642) (xy 111.868996 121.2995) (xy 111.868994 121.2995)
-				(xy 111.868993 121.2995) (xy 111.364479 121.2995) (xy 111.306288 121.280593) (xy 111.270324 121.231093)
-				(xy 111.270324 121.169907) (xy 111.294475 121.130496) (xy 112.22497 120.200001) (xy 113.74 120.200001)
-				(xy 113.74 120.309838) (xy 113.746519 120.359354) (xy 113.746521 120.359361) (xy 113.79719 120.468021)
-				(xy 113.881978 120.552809) (xy 113.990638 120.603478) (xy 113.990645 120.60348) (xy 114.040161 120.61)
-				(xy 114.119999 120.61) (xy 114.12 120.609999) (xy 114.12 120.200001) (xy 114.119999 120.2) (xy 113.740001 120.2)
-				(xy 113.74 120.200001) (xy 112.22497 120.200001) (xy 112.53481 119.890161) (xy 113.74 119.890161)
-				(xy 113.74 119.999999) (xy 113.740001 120) (xy 114.119999 120) (xy 114.12 119.999999) (xy 114.12 119.590001)
-				(xy 114.119999 119.59) (xy 114.040161 119.59) (xy 113.990645 119.596519) (xy 113.990638 119.596521)
-				(xy 113.881978 119.64719) (xy 113.79719 119.731978) (xy 113.746521 119.840638) (xy 113.746519 119.840645)
-				(xy 113.74 119.890161) (xy 112.53481 119.890161) (xy 113.095475 119.329496) (xy 113.149992 119.301719)
-				(xy 113.165479 119.3005) (xy 114.119075 119.3005) (xy 114.177266 119.319407) (xy 114.193895 119.33467)
-				(xy 114.20195 119.343966) (xy 114.201951 119.343967) (xy 114.316887 119.417832) (xy 114.315729 119.419633)
-				(xy 114.353351 119.454161) (xy 114.365503 119.514127) (xy 114.340087 119.569784) (xy 114.337152 119.572847)
-				(xy 114.32 119.589999) (xy 114.32 120.609999) (xy 114.320001 120.61) (xy 114.399838 120.61) (xy 114.449354 120.60348)
-				(xy 114.449361 120.603478) (xy 114.558021 120.552809) (xy 114.629642 120.481189) (xy 114.684159 120.453412)
-				(xy 114.744591 120.462983) (xy 114.769646 120.481186) (xy 114.841684 120.553224) (xy 114.950513 120.603972)
-				(xy 115.000099 120.6105) (xy 115.025499 120.610499) (xy 115.083688 120.629404) (xy 115.119654 120.678903)
-				(xy 115.1245 120.709499) (xy 115.1245 120.8255) (xy 115.105593 120.883691) (xy 115.056093 120.919655)
-				(xy 115.025501 120.9245) (xy 114.861602 120.9245) (xy 114.861595 120.924501) (xy 114.784884 120.939759)
-				(xy 114.755 120.959727) (xy 114.696111 120.976334) (xy 114.644999 120.959726) (xy 114.615119 120.939761)
-				(xy 114.615117 120.93976) (xy 114.615114 120.939759) (xy 114.615113 120.939759) (xy 114.53841 120.924501)
-				(xy 114.538402 120.9245) (xy 114.538401 120.9245) (xy 114.5384 120.9245) (xy 114.361602 120.9245)
-				(xy 114.361595 120.924501) (xy 114.284883 120.939759) (xy 114.284881 120.93976) (xy 114.19789 120.997886)
-				(xy 114.197886 120.99789) (xy 114.139762 121.084879) (xy 114.139759 121.084886) (xy 114.124501 121.161588)
-				(xy 114.1245 121.161598) (xy 114.1245 121.161599) (xy 114.1245 121.549) (xy 114.124501 121.826)
-				(xy 114.105594 121.884191) (xy 114.056094 121.920155) (xy 114.025501 121.925) (xy 113.850001 121.925)
-				(xy 113.85 121.925001) (xy 113.85 122.149999) (xy 113.850001 122.15) (xy 114.24047 122.15) (xy 114.278359 122.157537)
-				(xy 114.283187 122.159537) (xy 114.329711 122.199275) (xy 114.343993 122.258771) (xy 114.320576 122.315298)
-				(xy 114.268406 122.347265) (xy 114.245298 122.35) (xy 113.850001 122.35) (xy 113.85 122.350001)
-				(xy 113.85 122.649999) (xy 113.850001 122.65) (xy 114.372683 122.65) (xy 119.027316 122.65) (xy 119.549999 122.65)
-				(xy 119.55 122.649999) (xy 119.55 122.350001) (xy 119.549999 122.35) (xy 119.027316 122.35) (xy 119.040231 122.414924)
-				(xy 119.040231 122.414925) (xy 119.060326 122.444999) (xy 119.076934 122.503887) (xy 119.060326 122.555001)
-				(xy 119.040231 122.585074) (xy 119.040231 122.585075) (xy 119.027316 122.65) (xy 114.372683 122.65)
-				(xy 114.359768 122.585075) (xy 114.339674 122.555002) (xy 114.323065 122.496114) (xy 114.339674 122.444998)
-				(xy 114.359768 122.414924) (xy 114.372683 122.349999) (xy 114.362265 122.337304) (xy 114.339965 122.280327)
-				(xy 114.355413 122.221125) (xy 114.40271 122.182309) (xy 114.43879 122.175499) (xy 114.5384 122.175499)
-				(xy 114.615117 122.16024) (xy 114.644998 122.140273) (xy 114.703886 122.123665) (xy 114.755002 122.140274)
-				(xy 114.784879 122.160238) (xy 114.78488 122.160238) (xy 114.784883 122.16024) (xy 114.861599 122.1755)
-				(xy 115.0384 122.175499) (xy 115.115117 122.16024) (xy 115.144998 122.140273) (xy 115.203886 122.123665)
-				(xy 115.255002 122.140274) (xy 115.284879 122.160238) (xy 115.28488 122.160238) (xy 115.284883 122.16024)
-				(xy 115.361599 122.1755) (xy 115.5384 122.175499) (xy 115.615117 122.16024) (xy 115.644998 122.140273)
-				(xy 115.703886 122.123665) (xy 115.755002 122.140274) (xy 115.784879 122.160238) (xy 115.78488 122.160238)
-				(xy 115.784883 122.16024) (xy 115.861599 122.1755) (xy 116.0384 122.175499) (xy 116.115117 122.16024)
-				(xy 116.144998 122.140273) (xy 116.203886 122.123665) (xy 116.255002 122.140274) (xy 116.284879 122.160238)
-				(xy 116.28488 122.160238) (xy 116.284883 122.16024) (xy 116.361599 122.1755) (xy 116.5384 122.175499)
-				(xy 116.615117 122.16024) (xy 116.644998 122.140273) (xy 116.703886 122.123665) (xy 116.755002 122.140274)
-				(xy 116.784879 122.160238) (xy 116.78488 122.160238) (xy 116.784883 122.16024) (xy 116.861599 122.1755)
-				(xy 117.0384 122.175499) (xy 117.115117 122.16024) (xy 117.144998 122.140273) (xy 117.203886 122.123665)
-				(xy 117.255002 122.140274) (xy 117.284879 122.160238) (xy 117.28488 122.160238) (xy 117.284883 122.16024)
-				(xy 117.361599 122.1755) (xy 117.5384 122.175499) (xy 117.615117 122.16024) (xy 117.644998 122.140273)
-				(xy 117.703886 122.123665) (xy 117.755002 122.140274) (xy 117.784879 122.160238) (xy 117.78488 122.160238)
-				(xy 117.784883 122.16024) (xy 117.861599 122.1755) (xy 118.0384 122.175499) (xy 118.115117 122.16024)
-				(xy 118.144998 122.140273) (xy 118.203886 122.123665) (xy 118.255002 122.140274) (xy 118.284879 122.160238)
-				(xy 118.28488 122.160238) (xy 118.284883 122.16024) (xy 118.361599 122.1755) (xy 118.5384 122.175499)
-				(xy 118.615117 122.16024) (xy 118.645446 122.139974) (xy 118.704333 122.123365) (xy 118.755449 122.139973)
-				(xy 118.785075 122.159768) (xy 118.78508 122.159771) (xy 118.849999 122.172683) (xy 118.85 122.172682)
-				(xy 118.85 121.650001) (xy 119.05 121.650001) (xy 119.05 122.149999) (xy 119.050001 122.15) (xy 119.549999 122.15)
+				(xy 114.55 125.827316) (xy 114.55 126.351) (xy 114.531093 126.409191) (xy 114.481593 126.445155)
+				(xy 114.451 126.45) (xy 114.449 126.45) (xy 114.390809 126.431093) (xy 114.354845 126.381593) (xy 114.35 126.351)
+				(xy 114.35 125.850001) (xy 114.349999 125.85) (xy 113.85 125.85) (xy 113.85 126.074999) (xy 113.850001 126.075)
+				(xy 114.026 126.075) (xy 114.084191 126.093907) (xy 114.120155 126.143407) (xy 114.125 126.174)
+				(xy 114.125 126.269547) (xy 114.106093 126.327738) (xy 114.056593 126.363702) (xy 113.99811 126.364537)
+				(xy 113.939778 126.34741) (xy 113.939774 126.347409) (xy 113.939773 126.347409) (xy 113.810229 126.347409)
+				(xy 113.810226 126.347409) (xy 113.685934 126.383904) (xy 113.685927 126.383907) (xy 113.576953 126.45394)
+				(xy 113.492118 126.551847) (xy 113.438303 126.669683) (xy 113.419868 126.797906) (xy 113.419868 126.797911)
+				(xy 113.438303 126.926134) (xy 113.479338 127.015986) (xy 113.492119 127.043972) (xy 113.575743 127.140481)
+				(xy 113.576953 127.141877) (xy 113.580741 127.145159) (xy 113.612339 127.197554) (xy 113.607104 127.258515)
+				(xy 113.567038 127.304757) (xy 113.565414 127.305716) (xy 113.532886 127.324495) (xy 113.532886 127.324496)
+				(xy 113.515491 127.334538) (xy 113.515489 127.334539) (xy 113.104523 127.745504) (xy 113.050007 127.773281)
+				(xy 113.03452 127.7745) (xy 112.593479 127.7745) (xy 112.593476 127.774501) (xy 112.4997 127.789352)
+				(xy 112.499695 127.789354) (xy 112.394446 127.842982) (xy 112.334014 127.852554) (xy 112.279497 127.824777)
+				(xy 112.251719 127.770261) (xy 112.2505 127.754773) (xy 112.2505 127.656898) (xy 112.269407 127.598707)
+				(xy 112.27949 127.586901) (xy 112.72591 127.140481) (xy 112.725913 127.14048) (xy 112.80048 127.065913)
+				(xy 112.853207 126.974587) (xy 112.862592 126.939562) (xy 112.880501 126.872727) (xy 112.880501 126.831982)
+				(xy 112.898405 126.775197) (xy 112.903219 126.76832) (xy 112.903224 126.768316) (xy 112.953972 126.659487)
+				(xy 112.9605 126.609901) (xy 112.960499 126.1901) (xy 112.957941 126.17067) (xy 112.953972 126.140513)
+				(xy 112.953972 126.140511) (xy 112.903225 126.031684) (xy 112.902064 126.030027) (xy 112.901325 126.02761)
+				(xy 112.899564 126.023834) (xy 112.900094 126.023586) (xy 112.884173 125.971516) (xy 112.904091 125.913664)
+				(xy 112.913147 125.903244) (xy 112.969651 125.84674) (xy 113.024166 125.818965) (xy 113.084598 125.828536)
+				(xy 113.127863 125.871801) (xy 113.13675 125.89743) (xy 113.140229 125.914919) (xy 113.14023 125.914923)
+				(xy 113.198246 126.001749) (xy 113.19825 126.001753) (xy 113.285076 126.059768) (xy 113.361643 126.074999)
+				(xy 113.361645 126.075) (xy 113.649999 126.075) (xy 113.65 126.074999) (xy 113.65 125.849) (xy 113.668907 125.790809)
+				(xy 113.718407 125.754845) (xy 113.749 125.75) (xy 113.75 125.75) (xy 113.75 125.749) (xy 113.768907 125.690809)
+				(xy 113.818407 125.654845) (xy 113.849 125.65) (xy 114.372683 125.65) (xy 114.359769 125.585077)
+				(xy 114.339973 125.555451) (xy 114.323364 125.496563) (xy 114.339971 125.44545) (xy 114.36024 125.415117)
+				(xy 114.3755 125.338401) (xy 114.375499 125.1616) (xy 114.36024 125.084883) (xy 114.340273 125.055001)
+				(xy 114.323665 124.996114) (xy 114.340274 124.944998) (xy 114.360238 124.91512) (xy 114.360238 124.915119)
+				(xy 114.36024 124.915117) (xy 114.3755 124.838401) (xy 114.375499 124.6616) (xy 114.36024 124.584883)
+				(xy 114.340273 124.555001) (xy 114.323665 124.496114) (xy 114.340274 124.444998) (xy 114.360238 124.41512)
+				(xy 114.360238 124.415119) (xy 114.36024 124.415117) (xy 114.3755 124.338401) (xy 114.375499 124.1616)
+				(xy 114.36024 124.084883) (xy 114.340273 124.055001) (xy 114.323665 123.996114) (xy 114.340274 123.944998)
+				(xy 114.360238 123.91512) (xy 114.360238 123.915119) (xy 114.36024 123.915117) (xy 114.3755 123.838401)
+				(xy 114.375499 123.6616) (xy 114.36024 123.584883) (xy 114.340273 123.555001) (xy 114.323665 123.496114)
+				(xy 114.340274 123.444998) (xy 114.360238 123.41512) (xy 114.360238 123.415119) (xy 114.36024 123.415117)
+				(xy 114.3755 123.338401) (xy 114.375499 123.1616) (xy 114.36024 123.084883) (xy 114.339973 123.054551)
+				(xy 114.323365 122.995663) (xy 114.339975 122.944547) (xy 114.359768 122.914924) (xy 114.372684 122.85)
+				(xy 113.849 122.85) (xy 113.790809 122.831093) (xy 113.754845 122.781593) (xy 113.75 122.751) (xy 113.75 122.75)
+				(xy 113.749 122.75) (xy 113.690809 122.731093) (xy 113.654845 122.681593) (xy 113.65 122.651) (xy 113.65 121.925001)
+				(xy 113.649999 121.925) (xy 113.361643 121.925) (xy 113.285076 121.940231) (xy 113.19825 121.998246)
+				(xy 113.198246 121.99825) (xy 113.14023 122.085076) (xy 113.140229 122.08508) (xy 113.13248 122.124035)
+				(xy 113.102583 122.177418) (xy 113.047017 122.203033) (xy 112.987008 122.191095) (xy 112.965379 122.174723)
+				(xy 112.616656 121.826) (xy 112.246543 121.455886) (xy 112.244985 121.454845) (xy 112.131808 121.379223)
+				(xy 112.004328 121.32642) (xy 111.868996 121.2995) (xy 111.868994 121.2995) (xy 111.868993 121.2995)
+				(xy 111.364479 121.2995) (xy 111.306288 121.280593) (xy 111.270324 121.231093) (xy 111.270324 121.169907)
+				(xy 111.294475 121.130496) (xy 112.22497 120.200001) (xy 113.74 120.200001) (xy 113.74 120.309838)
+				(xy 113.746519 120.359354) (xy 113.746521 120.359361) (xy 113.79719 120.468021) (xy 113.881978 120.552809)
+				(xy 113.990638 120.603478) (xy 113.990645 120.60348) (xy 114.040161 120.61) (xy 114.119999 120.61)
+				(xy 114.12 120.609999) (xy 114.12 120.200001) (xy 114.119999 120.2) (xy 113.740001 120.2) (xy 113.74 120.200001)
+				(xy 112.22497 120.200001) (xy 112.53481 119.890161) (xy 113.74 119.890161) (xy 113.74 119.999999)
+				(xy 113.740001 120) (xy 114.119999 120) (xy 114.12 119.999999) (xy 114.12 119.590001) (xy 114.119999 119.59)
+				(xy 114.040161 119.59) (xy 113.990645 119.596519) (xy 113.990638 119.596521) (xy 113.881978 119.64719)
+				(xy 113.79719 119.731978) (xy 113.746521 119.840638) (xy 113.746519 119.840645) (xy 113.74 119.890161)
+				(xy 112.53481 119.890161) (xy 113.095475 119.329496) (xy 113.149992 119.301719) (xy 113.165479 119.3005)
+				(xy 114.119075 119.3005) (xy 114.177266 119.319407) (xy 114.193895 119.33467) (xy 114.20195 119.343966)
+				(xy 114.201951 119.343967) (xy 114.316887 119.417832) (xy 114.315729 119.419633) (xy 114.353351 119.454161)
+				(xy 114.365503 119.514127) (xy 114.340087 119.569784) (xy 114.337152 119.572847) (xy 114.32 119.589999)
+				(xy 114.32 120.609999) (xy 114.320001 120.61) (xy 114.399838 120.61) (xy 114.449354 120.60348) (xy 114.449361 120.603478)
+				(xy 114.558021 120.552809) (xy 114.629642 120.481189) (xy 114.684159 120.453412) (xy 114.744591 120.462983)
+				(xy 114.769646 120.481186) (xy 114.841684 120.553224) (xy 114.950513 120.603972) (xy 115.000099 120.6105)
+				(xy 115.025499 120.610499) (xy 115.083688 120.629404) (xy 115.119654 120.678903) (xy 115.1245 120.709499)
+				(xy 115.1245 120.8255) (xy 115.105593 120.883691) (xy 115.056093 120.919655) (xy 115.025501 120.9245)
+				(xy 114.861602 120.9245) (xy 114.861595 120.924501) (xy 114.784884 120.939759) (xy 114.755 120.959727)
+				(xy 114.696111 120.976334) (xy 114.644999 120.959726) (xy 114.615119 120.939761) (xy 114.615117 120.93976)
+				(xy 114.615114 120.939759) (xy 114.615113 120.939759) (xy 114.53841 120.924501) (xy 114.538402 120.9245)
+				(xy 114.538401 120.9245) (xy 114.5384 120.9245) (xy 114.361602 120.9245) (xy 114.361595 120.924501)
+				(xy 114.284883 120.939759) (xy 114.284881 120.93976) (xy 114.19789 120.997886) (xy 114.197886 120.99789)
+				(xy 114.139762 121.084879) (xy 114.139759 121.084886) (xy 114.124501 121.161588) (xy 114.1245 121.161598)
+				(xy 114.1245 121.161599) (xy 114.1245 121.549) (xy 114.124501 121.826) (xy 114.105594 121.884191)
+				(xy 114.056094 121.920155) (xy 114.025501 121.925) (xy 113.850001 121.925) (xy 113.85 121.925001)
+				(xy 113.85 122.149999) (xy 113.850001 122.15) (xy 114.24047 122.15) (xy 114.278359 122.157537) (xy 114.283187 122.159537)
+				(xy 114.329711 122.199275) (xy 114.343993 122.258771) (xy 114.320576 122.315298) (xy 114.268406 122.347265)
+				(xy 114.245298 122.35) (xy 113.850001 122.35) (xy 113.85 122.350001) (xy 113.85 122.65) (xy 114.372683 122.65)
+				(xy 119.027316 122.65) (xy 119.55 122.65) (xy 119.55 122.350001) (xy 119.549999 122.35) (xy 119.027316 122.35)
+				(xy 119.040231 122.414924) (xy 119.040231 122.414925) (xy 119.060326 122.444999) (xy 119.076934 122.503887)
+				(xy 119.060326 122.555001) (xy 119.040231 122.585074) (xy 119.040231 122.585075) (xy 119.027316 122.65)
+				(xy 114.372683 122.65) (xy 114.359768 122.585075) (xy 114.339674 122.555002) (xy 114.323065 122.496114)
+				(xy 114.339674 122.444998) (xy 114.359768 122.414924) (xy 114.372683 122.349999) (xy 114.362265 122.337304)
+				(xy 114.339965 122.280327) (xy 114.355413 122.221125) (xy 114.40271 122.182309) (xy 114.43879 122.175499)
+				(xy 114.5384 122.175499) (xy 114.615117 122.16024) (xy 114.644998 122.140273) (xy 114.703886 122.123665)
+				(xy 114.755002 122.140274) (xy 114.784879 122.160238) (xy 114.78488 122.160238) (xy 114.784883 122.16024)
+				(xy 114.861599 122.1755) (xy 115.0384 122.175499) (xy 115.115117 122.16024) (xy 115.144998 122.140273)
+				(xy 115.203886 122.123665) (xy 115.255002 122.140274) (xy 115.284879 122.160238) (xy 115.28488 122.160238)
+				(xy 115.284883 122.16024) (xy 115.361599 122.1755) (xy 115.5384 122.175499) (xy 115.615117 122.16024)
+				(xy 115.644998 122.140273) (xy 115.703886 122.123665) (xy 115.755002 122.140274) (xy 115.784879 122.160238)
+				(xy 115.78488 122.160238) (xy 115.784883 122.16024) (xy 115.861599 122.1755) (xy 116.0384 122.175499)
+				(xy 116.115117 122.16024) (xy 116.144998 122.140273) (xy 116.203886 122.123665) (xy 116.255002 122.140274)
+				(xy 116.284879 122.160238) (xy 116.28488 122.160238) (xy 116.284883 122.16024) (xy 116.361599 122.1755)
+				(xy 116.5384 122.175499) (xy 116.615117 122.16024) (xy 116.644998 122.140273) (xy 116.703886 122.123665)
+				(xy 116.755002 122.140274) (xy 116.784879 122.160238) (xy 116.78488 122.160238) (xy 116.784883 122.16024)
+				(xy 116.861599 122.1755) (xy 117.0384 122.175499) (xy 117.115117 122.16024) (xy 117.144998 122.140273)
+				(xy 117.203886 122.123665) (xy 117.255002 122.140274) (xy 117.284879 122.160238) (xy 117.28488 122.160238)
+				(xy 117.284883 122.16024) (xy 117.361599 122.1755) (xy 117.5384 122.175499) (xy 117.615117 122.16024)
+				(xy 117.644998 122.140273) (xy 117.703886 122.123665) (xy 117.755002 122.140274) (xy 117.784879 122.160238)
+				(xy 117.78488 122.160238) (xy 117.784883 122.16024) (xy 117.861599 122.1755) (xy 118.0384 122.175499)
+				(xy 118.115117 122.16024) (xy 118.144998 122.140273) (xy 118.203886 122.123665) (xy 118.255002 122.140274)
+				(xy 118.284879 122.160238) (xy 118.28488 122.160238) (xy 118.284883 122.16024) (xy 118.361599 122.1755)
+				(xy 118.5384 122.175499) (xy 118.615117 122.16024) (xy 118.645446 122.139974) (xy 118.704333 122.123365)
+				(xy 118.755449 122.139973) (xy 118.785075 122.159768) (xy 118.78508 122.159771) (xy 118.849999 122.172683)
+				(xy 118.85 122.172682) (xy 118.85 122.149999) (xy 119.05 122.149999) (xy 119.050001 122.15) (xy 119.549999 122.15)
 				(xy 119.55 122.149999) (xy 119.55 121.925001) (xy 119.75 121.925001) (xy 119.75 122.149999) (xy 119.750001 122.15)
 				(xy 120.272683 122.15) (xy 120.259768 122.085076) (xy 120.201753 121.99825) (xy 120.201749 121.998246)
 				(xy 120.114923 121.940231) (xy 120.038356 121.925) (xy 119.750001 121.925) (xy 119.75 121.925001)
 				(xy 119.55 121.925001) (xy 119.549999 121.925) (xy 119.374 121.925) (xy 119.315809 121.906093) (xy 119.279845 121.856593)
-				(xy 119.275 121.826) (xy 119.275 121.650001) (xy 119.274999 121.65) (xy 119.050001 121.65) (xy 119.05 121.650001)
-				(xy 118.85 121.650001) (xy 118.85 121.549) (xy 118.868907 121.490809) (xy 118.918407 121.454845)
-				(xy 118.949 121.45) (xy 119.274999 121.45) (xy 119.275 121.449999) (xy 119.275 121.161645) (xy 119.274999 121.161641)
+				(xy 119.275 121.826) (xy 119.275 121.650001) (xy 119.274999 121.65) (xy 119.05 121.65) (xy 119.05 122.149999)
+				(xy 118.85 122.149999) (xy 118.85 121.649) (xy 118.868907 121.590809) (xy 118.918407 121.554845)
+				(xy 118.949 121.55) (xy 118.95 121.55) (xy 118.95 121.549) (xy 118.968907 121.490809) (xy 119.018407 121.454845)
+				(xy 119.049 121.45) (xy 119.274999 121.45) (xy 119.275 121.449999) (xy 119.275 121.161645) (xy 119.274999 121.161641)
 				(xy 119.265925 121.11602) (xy 119.273117 121.055259) (xy 119.314649 121.010329) (xy 119.337399 121.00108)
 				(xy 119.385074 120.988304) (xy 119.415989 120.980021) (xy 119.484511 120.94046) (xy 119.54046 120.884511)
 				(xy 122.64046 117.784511) (xy 122.665264 117.741547) (xy 122.710733 117.700608) (xy 122.771583 117.694212)
@@ -38973,23 +39045,23 @@
 				(xy 134.712696 112.733181) (xy 134.896233 112.604667) (xy 134.905093 112.595807) (xy 139.575615 112.595807)
 				(xy 139.584093 112.604285) (xy 139.767556 112.732747) (xy 139.970542 112.8274) (xy 140.186888 112.88537)
 				(xy 140.409997 112.904889) (xy 140.410003 112.904889) (xy 140.633111 112.88537) (xy 140.849457 112.8274)
-				(xy 141.052443 112.732747) (xy 141.235906 112.604285) (xy 141.244385 112.595807) (xy 140.41 111.761422)
+				(xy 141.052443 112.732747) (xy 141.235909 112.604283) (xy 141.244384 112.595807) (xy 140.409999 111.761422)
 				(xy 139.575615 112.595807) (xy 134.905093 112.595807) (xy 135.054667 112.446233) (xy 135.183181 112.262696)
 				(xy 135.277872 112.05963) (xy 135.335863 111.843206) (xy 135.335872 111.843111) (xy 135.355391 111.620003)
 				(xy 135.355391 111.619996) (xy 139.125111 111.619996) (xy 139.125111 111.620003) (xy 139.144629 111.843111)
-				(xy 139.202599 112.059457) (xy 139.297252 112.262443) (xy 139.425714 112.445906) (xy 139.434193 112.454385)
-				(xy 140.268578 111.62) (xy 140.551422 111.62) (xy 141.385807 112.454385) (xy 141.394285 112.445906)
+				(xy 139.202599 112.059457) (xy 139.297252 112.262443) (xy 139.425714 112.445906) (xy 139.434192 112.454384)
+				(xy 140.268576 111.619999) (xy 140.551422 111.619999) (xy 141.385807 112.454384) (xy 141.394283 112.445909)
 				(xy 141.522747 112.262443) (xy 141.6174 112.059457) (xy 141.67537 111.843111) (xy 141.694889 111.620003)
 				(xy 141.694889 111.619996) (xy 141.67537 111.396888) (xy 141.6174 111.180543) (xy 141.522747 110.977557)
-				(xy 141.394285 110.794093) (xy 141.385807 110.785615) (xy 140.551422 111.62) (xy 140.268578 111.62)
-				(xy 139.434193 110.785615) (xy 139.425714 110.794093) (xy 139.297252 110.977557) (xy 139.202599 111.180543)
+				(xy 141.394285 110.794093) (xy 141.385807 110.785615) (xy 140.551422 111.619999) (xy 140.268576 111.619999)
+				(xy 139.434191 110.785614) (xy 139.425716 110.79409) (xy 139.297252 110.977557) (xy 139.202599 111.180543)
 				(xy 139.144629 111.396888) (xy 139.125111 111.619996) (xy 135.355391 111.619996) (xy 135.335864 111.396801)
 				(xy 135.335863 111.396798) (xy 135.335863 111.396794) (xy 135.277872 111.18037) (xy 135.265463 111.15376)
-				(xy 135.258005 111.093034) (xy 135.285182 111.041919) (xy 135.68291 110.644193) (xy 139.575615 110.644193)
-				(xy 140.41 111.478578) (xy 141.244385 110.644193) (xy 141.235906 110.635714) (xy 141.052443 110.507252)
+				(xy 135.258005 111.093034) (xy 135.285182 111.041919) (xy 135.682912 110.644191) (xy 139.575614 110.644191)
+				(xy 140.409999 111.478576) (xy 141.244384 110.644192) (xy 141.235906 110.635714) (xy 141.052443 110.507252)
 				(xy 140.849457 110.412599) (xy 140.633111 110.354629) (xy 140.410003 110.335111) (xy 140.409997 110.335111)
-				(xy 140.186888 110.354629) (xy 139.970543 110.412599) (xy 139.767557 110.507252) (xy 139.584093 110.635714)
-				(xy 139.575615 110.644193) (xy 135.68291 110.644193) (xy 136.03549 110.291614) (xy 136.094799 110.188887)
+				(xy 140.186888 110.354629) (xy 139.970543 110.412599) (xy 139.767557 110.507252) (xy 139.58409 110.635716)
+				(xy 139.575614 110.644191) (xy 135.682912 110.644191) (xy 136.03549 110.291614) (xy 136.094799 110.188887)
 				(xy 136.099884 110.169907) (xy 136.101287 110.164672) (xy 136.101287 110.164669) (xy 136.1255 110.074309)
 				(xy 136.1255 108.331899) (xy 136.144407 108.273708) (xy 136.15449 108.261901) (xy 136.20305 108.213342)
 				(xy 136.260646 108.100304) (xy 136.2755 108.006519) (xy 136.275499 107.393482) (xy 136.265466 107.330128)
@@ -39120,11 +39192,11 @@
 				(xy 139.807138 103.493789) (xy 139.729554 103.454257) (xy 139.68629 103.410992) (xy 139.6755 103.366048)
 				(xy 139.6755 101.585159) (xy 139.683935 101.545171) (xy 139.687204 101.537766) (xy 139.687206 101.537765)
 				(xy 139.732585 101.434991) (xy 139.7355 101.409865) (xy 139.735499 100.805477) (xy 139.754406 100.747287)
-				(xy 139.764496 100.735474) (xy 139.912854 100.587116) (xy 140.14046 100.359511) (xy 140.15928 100.326914)
-				(xy 140.18002 100.290992) (xy 140.18002 100.29099) (xy 140.180022 100.290988) (xy 140.182008 100.283577)
-				(xy 141.545 100.283577) (xy 142.128577 99.699999) (xy 141.545 99.116422) (xy 141.545 100.283577)
-				(xy 140.182008 100.283577) (xy 140.2005 100.214562) (xy 140.2005 100.135438) (xy 140.2005 96.683577)
-				(xy 141.545 96.683577) (xy 142.128577 96.099999) (xy 141.545 95.516422) (xy 141.545 96.683577) (xy 140.2005 96.683577)
+				(xy 139.764496 100.735474) (xy 139.912854 100.587116) (xy 140.14046 100.359511) (xy 140.159281 100.326912)
+				(xy 140.18002 100.290992) (xy 140.18002 100.29099) (xy 140.180022 100.290988) (xy 140.182007 100.283578)
+				(xy 141.545 100.283578) (xy 142.128578 99.699999) (xy 141.545 99.116421) (xy 141.545 100.283578)
+				(xy 140.182007 100.283578) (xy 140.2005 100.214562) (xy 140.2005 100.135438) (xy 140.2005 96.683578)
+				(xy 141.545 96.683578) (xy 142.128578 96.099999) (xy 141.545 95.516421) (xy 141.545 96.683578) (xy 140.2005 96.683578)
 				(xy 140.2005 95.178126) (xy 140.219407 95.119935) (xy 140.22949 95.108128) (xy 140.64046 94.697159)
 				(xy 140.663051 94.65803) (xy 140.68002 94.62864) (xy 140.68002 94.628638) (xy 140.680022 94.628636)
 				(xy 140.7005 94.55221) (xy 140.7005 94.473086) (xy 140.7005 91.960438) (xy 140.691686 91.927543)
@@ -39156,14 +39228,15 @@
 				(xy 119.707288 86.680593) (xy 119.695475 86.670504) (xy 118.529496 85.504525) (xy 118.501719 85.450008)
 				(xy 118.5005 85.434521) (xy 118.5005 85.143529) (xy 118.519407 85.085338) (xy 118.568907 85.049374)
 				(xy 118.630093 85.049374) (xy 118.640153 85.053337) (xy 118.640645 85.05348) (xy 118.690161 85.06)
-				(xy 118.799999 85.06) (xy 118.8 85.059999) (xy 118.8 84.680001) (xy 119 84.680001) (xy 119 85.059999)
-				(xy 119.000001 85.06) (xy 119.109838 85.06) (xy 119.159354 85.05348) (xy 119.159361 85.053478) (xy 119.268021 85.002809)
-				(xy 119.329996 84.940835) (xy 119.384513 84.913058) (xy 119.444945 84.922629) (xy 119.470004 84.940835)
-				(xy 119.531978 85.002809) (xy 119.640638 85.053478) (xy 119.640645 85.05348) (xy 119.690161 85.06)
-				(xy 119.799999 85.06) (xy 119.8 85.059999) (xy 119.8 84.680001) (xy 119.799999 84.68) (xy 119.000001 84.68)
-				(xy 119 84.680001) (xy 118.8 84.680001) (xy 118.8 84.579) (xy 118.818907 84.520809) (xy 118.868407 84.484845)
-				(xy 118.899 84.48) (xy 119.901 84.48) (xy 119.959191 84.498907) (xy 119.995155 84.548407) (xy 120 84.579)
-				(xy 120 85.059999) (xy 120.02161 85.081609) (xy 120.049086 85.134331) (xy 120.053403 85.158682)
+				(xy 118.799999 85.06) (xy 118.8 85.059999) (xy 119 85.059999) (xy 119.000001 85.06) (xy 119.109838 85.06)
+				(xy 119.159354 85.05348) (xy 119.159361 85.053478) (xy 119.268021 85.002809) (xy 119.329996 84.940835)
+				(xy 119.384513 84.913058) (xy 119.444945 84.922629) (xy 119.470004 84.940835) (xy 119.531978 85.002809)
+				(xy 119.640638 85.053478) (xy 119.640645 85.05348) (xy 119.690161 85.06) (xy 119.799999 85.06) (xy 119.8 85.059999)
+				(xy 119.8 84.68) (xy 119 84.68) (xy 119 85.059999) (xy 118.8 85.059999) (xy 118.8 84.679) (xy 118.818907 84.620809)
+				(xy 118.868407 84.584845) (xy 118.899 84.58) (xy 118.9 84.58) (xy 118.9 84.579) (xy 118.918907 84.520809)
+				(xy 118.968407 84.484845) (xy 118.999 84.48) (xy 119.801 84.48) (xy 119.859191 84.498907) (xy 119.895155 84.548407)
+				(xy 119.9 84.579) (xy 119.9 84.58) (xy 119.901 84.58) (xy 119.959191 84.598907) (xy 119.995155 84.648407)
+				(xy 120 84.679) (xy 120 85.059999) (xy 120.02161 85.081609) (xy 120.049086 85.134331) (xy 120.053403 85.158682)
 				(xy 120.053403 85.158683) (xy 120.077218 85.215037) (xy 120.077219 85.215038) (xy 120.102554 85.255725)
 				(xy 120.108567 85.266927) (xy 120.131581 85.31732) (xy 120.139519 85.344354) (xy 120.145494 85.385909)
 				(xy 120.145494 85.414091) (xy 120.139519 85.455643) (xy 120.131581 85.482677) (xy 120.114141 85.520866)
@@ -39205,78 +39278,84 @@
 				(xy 122.225 82.983453) (xy 122.24076 83.082965) (xy 122.240762 83.082969) (xy 122.301881 83.202921)
 				(xy 122.397078 83.298118) (xy 122.52204 83.361791) (xy 122.565304 83.405056) (xy 122.574875 83.465488)
 				(xy 122.547097 83.520004) (xy 122.52204 83.538209) (xy 122.397078 83.601881) (xy 122.301881 83.697078)
-				(xy 122.240762 83.81703) (xy 122.225 83.916546) (xy 122.225 84.099999) (xy 122.225001 84.1) (xy 123.524998 84.1)
-				(xy 123.524999 84.099999) (xy 123.524999 83.916546) (xy 123.509239 83.817034) (xy 123.509237 83.81703)
-				(xy 123.449607 83.7) (xy 128.094859 83.7) (xy 128.115379 83.921445) (xy 128.176239 84.135347) (xy 128.275366 84.334421)
-				(xy 128.275375 84.334436) (xy 128.382407 84.476168) (xy 129.158577 83.699999) (xy 129.441421 83.699999)
-				(xy 130.217591 84.476169) (xy 130.324624 84.334436) (xy 130.324633 84.334421) (xy 130.42376 84.135347)
-				(xy 130.48462 83.921445) (xy 130.50514 83.7) (xy 130.48462 83.478554) (xy 130.42376 83.264652) (xy 130.324633 83.065578)
-				(xy 130.324624 83.065563) (xy 130.21759 82.923829) (xy 129.441421 83.699999) (xy 129.158577 83.699999)
-				(xy 128.382409 82.923831) (xy 128.275369 83.065573) (xy 128.275364 83.065582) (xy 128.176239 83.264652)
-				(xy 128.115379 83.478554) (xy 128.094859 83.7) (xy 123.449607 83.7) (xy 123.448118 83.697078) (xy 123.352921 83.601881)
-				(xy 123.227959 83.538209) (xy 123.184695 83.494945) (xy 123.175124 83.434512) (xy 123.202902 83.379996)
-				(xy 123.227959 83.361791) (xy 123.352921 83.298118) (xy 123.448118 83.202921) (xy 123.509237 83.082969)
-				(xy 123.525 82.983453) (xy 123.525 82.800001) (xy 123.524999 82.8) (xy 122.225002 82.8) (xy 122.225001 82.800001)
+				(xy 122.240762 83.81703) (xy 122.225 83.916546) (xy 122.225 84.099999) (xy 122.225001 84.1) (xy 122.774999 84.1)
+				(xy 122.775 84.099999) (xy 122.775 83.525001) (xy 122.770002 83.520003) (xy 122.742225 83.465486)
+				(xy 122.751796 83.405054) (xy 122.770003 83.379994) (xy 122.775 83.374997) (xy 122.775 82.800001)
+				(xy 122.975 82.800001) (xy 122.975 83.374998) (xy 122.979997 83.379995) (xy 123.007774 83.434512)
+				(xy 122.998203 83.494944) (xy 122.979998 83.520002) (xy 122.975 83.525) (xy 122.975 84.099999) (xy 122.975001 84.1)
+				(xy 123.524998 84.1) (xy 123.524999 84.099999) (xy 123.524999 83.916546) (xy 123.509239 83.817034)
+				(xy 123.509237 83.81703) (xy 123.449607 83.7) (xy 128.094859 83.7) (xy 128.115379 83.921445) (xy 128.176239 84.135347)
+				(xy 128.275366 84.334421) (xy 128.275375 84.334436) (xy 128.382407 84.476168) (xy 129.158577 83.699999)
+				(xy 129.441421 83.699999) (xy 130.217591 84.476169) (xy 130.324624 84.334436) (xy 130.324633 84.334421)
+				(xy 130.42376 84.135347) (xy 130.48462 83.921445) (xy 130.50514 83.7) (xy 130.48462 83.478554) (xy 130.42376 83.264652)
+				(xy 130.324633 83.065578) (xy 130.324624 83.065563) (xy 130.21759 82.923829) (xy 129.441421 83.699999)
+				(xy 129.158577 83.699999) (xy 128.382409 82.923831) (xy 128.275369 83.065573) (xy 128.275364 83.065582)
+				(xy 128.176239 83.264652) (xy 128.115379 83.478554) (xy 128.094859 83.7) (xy 123.449607 83.7) (xy 123.448118 83.697078)
+				(xy 123.352921 83.601881) (xy 123.227959 83.538209) (xy 123.184695 83.494945) (xy 123.175124 83.434512)
+				(xy 123.202902 83.379996) (xy 123.227959 83.361791) (xy 123.352921 83.298118) (xy 123.448118 83.202921)
+				(xy 123.509237 83.082969) (xy 123.525 82.983453) (xy 123.525 82.800001) (xy 123.524999 82.8) (xy 122.975001 82.8)
+				(xy 122.975 82.800001) (xy 122.775 82.800001) (xy 122.774999 82.8) (xy 122.225002 82.8) (xy 122.225001 82.800001)
 				(xy 122.225001 82.983453) (xy 122.225 82.983453) (xy 121.9755 82.983453) (xy 121.9755 82.783123)
-				(xy 128.524545 82.783123) (xy 129.299999 83.558577) (xy 130.075453 82.783123) (xy 130.02626 82.738277)
-				(xy 129.837176 82.621202) (xy 129.629799 82.540863) (xy 129.411196 82.5) (xy 129.188804 82.5) (xy 128.9702 82.540863)
-				(xy 128.762821 82.621202) (xy 128.762816 82.621205) (xy 128.573742 82.738275) (xy 128.573739 82.738277)
-				(xy 128.524545 82.783123) (xy 121.9755 82.783123) (xy 121.9755 82.416546) (xy 122.225 82.416546)
-				(xy 122.225 82.599999) (xy 122.225001 82.6) (xy 122.774999 82.6) (xy 122.775 82.599999) (xy 122.775 82.025001)
-				(xy 122.975 82.025001) (xy 122.975 82.599999) (xy 122.975001 82.6) (xy 123.524998 82.6) (xy 123.524999 82.599999)
-				(xy 123.524999 82.416546) (xy 123.509239 82.317034) (xy 123.509237 82.31703) (xy 123.50056 82.300001)
-				(xy 134.04 82.300001) (xy 134.04 82.409838) (xy 134.046519 82.459354) (xy 134.046521 82.459361)
-				(xy 134.09719 82.568021) (xy 134.181978 82.652809) (xy 134.290638 82.703478) (xy 134.290645 82.70348)
-				(xy 134.340161 82.71) (xy 134.419999 82.71) (xy 134.42 82.709999) (xy 134.42 82.300001) (xy 134.419999 82.3)
-				(xy 134.040001 82.3) (xy 134.04 82.300001) (xy 123.50056 82.300001) (xy 123.448118 82.197078) (xy 123.352921 82.101881)
-				(xy 123.232969 82.040762) (xy 123.23297 82.040762) (xy 123.133454 82.025) (xy 122.975001 82.025)
-				(xy 122.975 82.025001) (xy 122.775 82.025001) (xy 122.774999 82.025) (xy 122.616547 82.025) (xy 122.616546 82.025001)
-				(xy 122.517034 82.04076) (xy 122.51703 82.040762) (xy 122.397078 82.101881) (xy 122.301881 82.197078)
-				(xy 122.240762 82.31703) (xy 122.225 82.416546) (xy 121.9755 82.416546) (xy 121.9755 82.416512)
-				(xy 121.974933 82.412934) (xy 121.968901 82.374847) (xy 121.959719 82.316874) (xy 121.959716 82.316869)
-				(xy 121.959716 82.316867) (xy 121.898529 82.196782) (xy 121.898528 82.19678) (xy 121.80322 82.101472)
-				(xy 121.803217 82.10147) (xy 121.683132 82.040283) (xy 121.683127 82.040281) (xy 121.683126 82.040281)
-				(xy 121.649913 82.03502) (xy 121.58349 82.0245) (xy 121.583488 82.0245) (xy 121.066512 82.0245)
-				(xy 121.066509 82.0245) (xy 121.036877 82.029193) (xy 120.976445 82.019621) (xy 120.951387 82.001416)
-				(xy 120.504496 81.554525) (xy 120.476719 81.500008) (xy 120.4755 81.484521) (xy 120.4755 81.402433)
-				(xy 120.494407 81.344242) (xy 120.543907 81.308278) (xy 120.605093 81.308278) (xy 120.644504 81.332429)
-				(xy 120.996586 81.684511) (xy 120.996585 81.684511) (xy 121.052535 81.74046) (xy 121.121053 81.780019)
-				(xy 121.121057 81.780021) (xy 121.197481 81.800499) (xy 121.197483 81.8005) (xy 121.197484 81.8005)
-				(xy 123.375605 81.8005) (xy 123.433796 81.819407) (xy 123.465329 81.85766) (xy 123.475933 81.880401)
-				(xy 123.475934 81.880402) (xy 123.475935 81.880404) (xy 123.559596 81.964065) (xy 123.559597 81.964065)
-				(xy 123.559598 81.964066) (xy 123.666824 82.014067) (xy 123.666825 82.014067) (xy 123.666827 82.014068)
-				(xy 123.715684 82.0205) (xy 123.715685 82.0205) (xy 124.064314 82.0205) (xy 124.064316 82.0205)
-				(xy 124.113173 82.014068) (xy 124.220404 81.964065) (xy 124.304065 81.880404) (xy 124.310275 81.867085)
-				(xy 124.352003 81.822337) (xy 124.412064 81.810662) (xy 124.467517 81.836519) (xy 124.489724 81.867084)
-				(xy 124.495935 81.880404) (xy 124.579596 81.964065) (xy 124.579597 81.964065) (xy 124.579598 81.964066)
-				(xy 124.686824 82.014067) (xy 124.686825 82.014067) (xy 124.686827 82.014068) (xy 124.735684 82.0205)
-				(xy 124.735685 82.0205) (xy 125.084314 82.0205) (xy 125.084316 82.0205) (xy 125.133173 82.014068)
-				(xy 125.184441 81.990161) (xy 134.04 81.990161) (xy 134.04 82.099999) (xy 134.040001 82.1) (xy 134.419999 82.1)
-				(xy 134.42 82.099999) (xy 134.42 81.690001) (xy 134.419999 81.69) (xy 134.340161 81.69) (xy 134.290645 81.696519)
-				(xy 134.290638 81.696521) (xy 134.181978 81.74719) (xy 134.09719 81.831978) (xy 134.046521 81.940638)
-				(xy 134.046519 81.940645) (xy 134.04 81.990161) (xy 125.184441 81.990161) (xy 125.240404 81.964065)
-				(xy 125.324065 81.880404) (xy 125.324067 81.8804) (xy 125.329033 81.873309) (xy 125.330666 81.874453)
-				(xy 125.36474 81.837913) (xy 125.412737 81.8255) (xy 125.442851 81.8255) (xy 125.442853 81.8255)
-				(xy 125.525639 81.803318) (xy 125.525641 81.803316) (xy 125.525643 81.803316) (xy 125.599857 81.760468)
-				(xy 125.599857 81.760467) (xy 125.599862 81.760465) (xy 126.860324 80.500001) (xy 134.020001 80.500001)
-				(xy 134.020001 80.62426) (xy 134.026422 80.673041) (xy 134.076349 80.780109) (xy 134.15989 80.86365)
-				(xy 134.266952 80.913574) (xy 134.266959 80.913576) (xy 134.315745 80.919999) (xy 134.389999 80.919998)
-				(xy 134.39 80.919998) (xy 134.39 80.500001) (xy 134.389999 80.5) (xy 134.020002 80.5) (xy 134.020001 80.500001)
-				(xy 126.860324 80.500001) (xy 127.25583 80.104495) (xy 127.310347 80.076719) (xy 127.325834 80.0755)
-				(xy 133.921 80.0755) (xy 133.979191 80.094407) (xy 134.015155 80.143907) (xy 134.02 80.1745) (xy 134.02 80.299999)
-				(xy 134.020001 80.3) (xy 134.491 80.3) (xy 134.549191 80.318907) (xy 134.585155 80.368407) (xy 134.59 80.399)
-				(xy 134.59 80.919998) (xy 134.590001 80.919999) (xy 134.664251 80.919999) (xy 134.66426 80.919998)
-				(xy 134.713041 80.913577) (xy 134.820109 80.86365) (xy 134.903649 80.78011) (xy 134.909997 80.766497)
-				(xy 134.951723 80.721747) (xy 135.011784 80.710069) (xy 135.067238 80.735925) (xy 135.089446 80.76649)
-				(xy 135.095933 80.780401) (xy 135.095934 80.780402) (xy 135.095935 80.780404) (xy 135.179596 80.864065)
-				(xy 135.179597 80.864065) (xy 135.179598 80.864066) (xy 135.286824 80.914067) (xy 135.286825 80.914067)
-				(xy 135.286827 80.914068) (xy 135.335684 80.9205) (xy 135.335685 80.9205) (xy 135.684314 80.9205)
-				(xy 135.684316 80.9205) (xy 135.733173 80.914068) (xy 135.840404 80.864065) (xy 135.924065 80.780404)
-				(xy 135.974068 80.673173) (xy 135.978886 80.636577) (xy 136.005228 80.581352) (xy 136.058999 80.552158)
-				(xy 136.077039 80.5505) (xy 136.7705 80.5505) (xy 136.828691 80.569407) (xy 136.864655 80.618907)
-				(xy 136.8695 80.6495) (xy 136.869501 80.8505) (xy 136.850594 80.90869) (xy 136.801094 80.944654)
-				(xy 136.770501 80.9495) (xy 136.515691 80.9495) (xy 136.488626 80.956752) (xy 136.425325 80.973713)
-				(xy 136.425324 80.973712) (xy 136.401115 80.9802) (xy 136.401113 80.9802) (xy 136.401113 80.980201)
+				(xy 128.524545 82.783123) (xy 129.299999 83.558577) (xy 130.075453 82.783123) (xy 130.075453 82.783122)
+				(xy 130.026263 82.738279) (xy 129.837176 82.621202) (xy 129.629799 82.540863) (xy 129.411196 82.5)
+				(xy 129.188804 82.5) (xy 128.9702 82.540863) (xy 128.762821 82.621202) (xy 128.762816 82.621205)
+				(xy 128.573742 82.738275) (xy 128.573739 82.738277) (xy 128.524545 82.783123) (xy 121.9755 82.783123)
+				(xy 121.9755 82.416546) (xy 122.225 82.416546) (xy 122.225 82.599999) (xy 122.225001 82.6) (xy 122.774999 82.6)
+				(xy 122.775 82.599999) (xy 122.775 82.025001) (xy 122.975 82.025001) (xy 122.975 82.599999) (xy 122.975001 82.6)
+				(xy 123.524998 82.6) (xy 123.524999 82.599999) (xy 123.524999 82.416546) (xy 123.509239 82.317034)
+				(xy 123.509237 82.31703) (xy 123.50056 82.300001) (xy 134.04 82.300001) (xy 134.04 82.409838) (xy 134.046519 82.459354)
+				(xy 134.046521 82.459361) (xy 134.09719 82.568021) (xy 134.181978 82.652809) (xy 134.290638 82.703478)
+				(xy 134.290645 82.70348) (xy 134.340161 82.71) (xy 134.419999 82.71) (xy 134.42 82.709999) (xy 134.42 82.300001)
+				(xy 134.419999 82.3) (xy 134.040001 82.3) (xy 134.04 82.300001) (xy 123.50056 82.300001) (xy 123.448118 82.197078)
+				(xy 123.352921 82.101881) (xy 123.232969 82.040762) (xy 123.23297 82.040762) (xy 123.133454 82.025)
+				(xy 122.975001 82.025) (xy 122.975 82.025001) (xy 122.775 82.025001) (xy 122.774999 82.025) (xy 122.616547 82.025)
+				(xy 122.616546 82.025001) (xy 122.517034 82.04076) (xy 122.51703 82.040762) (xy 122.397078 82.101881)
+				(xy 122.301881 82.197078) (xy 122.240762 82.31703) (xy 122.225 82.416546) (xy 121.9755 82.416546)
+				(xy 121.9755 82.416512) (xy 121.974933 82.412934) (xy 121.968901 82.374847) (xy 121.959719 82.316874)
+				(xy 121.959716 82.316869) (xy 121.959716 82.316867) (xy 121.898529 82.196782) (xy 121.898528 82.19678)
+				(xy 121.80322 82.101472) (xy 121.803217 82.10147) (xy 121.683132 82.040283) (xy 121.683127 82.040281)
+				(xy 121.683126 82.040281) (xy 121.649913 82.03502) (xy 121.58349 82.0245) (xy 121.583488 82.0245)
+				(xy 121.066512 82.0245) (xy 121.066509 82.0245) (xy 121.036877 82.029193) (xy 120.976445 82.019621)
+				(xy 120.951387 82.001416) (xy 120.504496 81.554525) (xy 120.476719 81.500008) (xy 120.4755 81.484521)
+				(xy 120.4755 81.402433) (xy 120.494407 81.344242) (xy 120.543907 81.308278) (xy 120.605093 81.308278)
+				(xy 120.644504 81.332429) (xy 120.996586 81.684511) (xy 120.996585 81.684511) (xy 121.052535 81.74046)
+				(xy 121.121053 81.780019) (xy 121.121057 81.780021) (xy 121.197481 81.800499) (xy 121.197483 81.8005)
+				(xy 121.197484 81.8005) (xy 123.375605 81.8005) (xy 123.433796 81.819407) (xy 123.465329 81.85766)
+				(xy 123.475933 81.880401) (xy 123.475934 81.880402) (xy 123.475935 81.880404) (xy 123.559596 81.964065)
+				(xy 123.559597 81.964065) (xy 123.559598 81.964066) (xy 123.666824 82.014067) (xy 123.666825 82.014067)
+				(xy 123.666827 82.014068) (xy 123.715684 82.0205) (xy 123.715685 82.0205) (xy 124.064314 82.0205)
+				(xy 124.064316 82.0205) (xy 124.113173 82.014068) (xy 124.220404 81.964065) (xy 124.304065 81.880404)
+				(xy 124.310275 81.867085) (xy 124.352003 81.822337) (xy 124.412064 81.810662) (xy 124.467517 81.836519)
+				(xy 124.489724 81.867084) (xy 124.495935 81.880404) (xy 124.579596 81.964065) (xy 124.579597 81.964065)
+				(xy 124.579598 81.964066) (xy 124.686824 82.014067) (xy 124.686825 82.014067) (xy 124.686827 82.014068)
+				(xy 124.735684 82.0205) (xy 124.735685 82.0205) (xy 125.084314 82.0205) (xy 125.084316 82.0205)
+				(xy 125.133173 82.014068) (xy 125.184441 81.990161) (xy 134.04 81.990161) (xy 134.04 82.099999)
+				(xy 134.040001 82.1) (xy 134.419999 82.1) (xy 134.42 82.099999) (xy 134.42 81.690001) (xy 134.419999 81.69)
+				(xy 134.340161 81.69) (xy 134.290645 81.696519) (xy 134.290638 81.696521) (xy 134.181978 81.74719)
+				(xy 134.09719 81.831978) (xy 134.046521 81.940638) (xy 134.046519 81.940645) (xy 134.04 81.990161)
+				(xy 125.184441 81.990161) (xy 125.240404 81.964065) (xy 125.324065 81.880404) (xy 125.324067 81.8804)
+				(xy 125.329033 81.873309) (xy 125.330666 81.874453) (xy 125.36474 81.837913) (xy 125.412737 81.8255)
+				(xy 125.442851 81.8255) (xy 125.442853 81.8255) (xy 125.525639 81.803318) (xy 125.525641 81.803316)
+				(xy 125.525643 81.803316) (xy 125.599857 81.760468) (xy 125.599857 81.760467) (xy 125.599862 81.760465)
+				(xy 126.860324 80.500001) (xy 134.020001 80.500001) (xy 134.020001 80.62426) (xy 134.026422 80.673041)
+				(xy 134.076349 80.780109) (xy 134.15989 80.86365) (xy 134.266952 80.913574) (xy 134.266959 80.913576)
+				(xy 134.315745 80.919999) (xy 134.389999 80.919998) (xy 134.39 80.919998) (xy 134.39 80.5) (xy 134.020002 80.5)
+				(xy 134.020001 80.500001) (xy 126.860324 80.500001) (xy 127.25583 80.104495) (xy 127.310347 80.076719)
+				(xy 127.325834 80.0755) (xy 133.921 80.0755) (xy 133.979191 80.094407) (xy 134.015155 80.143907)
+				(xy 134.02 80.1745) (xy 134.02 80.299999) (xy 134.020001 80.3) (xy 134.391 80.3) (xy 134.449191 80.318907)
+				(xy 134.485155 80.368407) (xy 134.49 80.399) (xy 134.49 80.4) (xy 134.491 80.4) (xy 134.549191 80.418907)
+				(xy 134.585155 80.468407) (xy 134.59 80.499) (xy 134.59 80.919998) (xy 134.590001 80.919999) (xy 134.664251 80.919999)
+				(xy 134.66426 80.919998) (xy 134.713041 80.913577) (xy 134.820109 80.86365) (xy 134.903649 80.78011)
+				(xy 134.909997 80.766497) (xy 134.951723 80.721747) (xy 135.011784 80.710069) (xy 135.067238 80.735925)
+				(xy 135.089446 80.76649) (xy 135.095933 80.780401) (xy 135.095934 80.780402) (xy 135.095935 80.780404)
+				(xy 135.179596 80.864065) (xy 135.179597 80.864065) (xy 135.179598 80.864066) (xy 135.286824 80.914067)
+				(xy 135.286825 80.914067) (xy 135.286827 80.914068) (xy 135.335684 80.9205) (xy 135.335685 80.9205)
+				(xy 135.684314 80.9205) (xy 135.684316 80.9205) (xy 135.733173 80.914068) (xy 135.840404 80.864065)
+				(xy 135.924065 80.780404) (xy 135.974068 80.673173) (xy 135.978886 80.636577) (xy 136.005228 80.581352)
+				(xy 136.058999 80.552158) (xy 136.077039 80.5505) (xy 136.7705 80.5505) (xy 136.828691 80.569407)
+				(xy 136.864655 80.618907) (xy 136.8695 80.6495) (xy 136.869501 80.8505) (xy 136.850594 80.90869)
+				(xy 136.801094 80.944654) (xy 136.770501 80.9495) (xy 136.515691 80.9495) (xy 136.440935 80.969531)
+				(xy 136.440934 80.96953) (xy 136.401115 80.9802) (xy 136.401113 80.9802) (xy 136.401113 80.980201)
 				(xy 136.304579 81.035935) (xy 136.298383 81.039512) (xy 135.67739 81.660504) (xy 135.622874 81.688281)
 				(xy 135.607387 81.6895) (xy 135.300104 81.6895) (xy 135.300092 81.689501) (xy 135.250513 81.696027)
 				(xy 135.250511 81.696027) (xy 135.141686 81.746774) (xy 135.141684 81.746775) (xy 135.141684 81.746776)
@@ -39289,7 +39368,7 @@
 				(xy 135.010593 83.35058) (xy 135.000504 83.362392) (xy 134.739511 83.623385) (xy 134.739507 83.62339)
 				(xy 134.680202 83.726109) (xy 134.680201 83.72611) (xy 134.674708 83.746609) (xy 134.674709 83.74661)
 				(xy 134.661311 83.796614) (xy 134.6495 83.840692) (xy 134.6495 84.51927) (xy 134.630593 84.577461)
-				(xy 134.586266 84.611584) (xy 134.577803 84.614863) (xy 134.562599 84.620753) (xy 134.46691 84.680001)
+				(xy 134.586266 84.611584) (xy 134.5769 84.615212) (xy 134.562599 84.620753) (xy 134.429893 84.702921)
 				(xy 134.373438 84.737876) (xy 134.20902 84.887763) (xy 134.074943 85.065309) (xy 134.074938 85.065318)
 				(xy 133.977433 85.261134) (xy 133.975771 85.264472) (xy 133.914885 85.478464) (xy 133.894357 85.7)
 				(xy 133.914885 85.921536) (xy 133.975771 86.135528) (xy 134.074942 86.334689) (xy 134.209019 86.512236)
@@ -39303,43 +39382,40 @@
 				(xy 135.801719 86.784322) (xy 135.8005 86.768835) (xy 135.8005 86.729595) (xy 135.819407 86.671404)
 				(xy 135.8328 86.656436) (xy 135.990981 86.512236) (xy 136.125058 86.334689) (xy 136.224229 86.135528)
 				(xy 136.285115 85.921536) (xy 136.305643 85.7) (xy 136.285115 85.478464) (xy 136.232524 85.293626)
-				(xy 137.177794 85.293626) (xy 137.257352 85.352345) (xy 137.385398 85.397149) (xy 137.415789 85.399999)
-				(xy 139.024203 85.399999) (xy 139.0546 85.397149) (xy 139.054602 85.397149) (xy 139.182646 85.352345)
-				(xy 139.262205 85.293627) (xy 139.262204 85.293626) (xy 141.107794 85.293626) (xy 141.187352 85.352345)
-				(xy 141.315398 85.397149) (xy 141.345789 85.399999) (xy 142.954203 85.399999) (xy 142.9846 85.397149)
-				(xy 142.984602 85.397149) (xy 143.112646 85.352345) (xy 143.192205 85.293627) (xy 142.149999 84.251421)
-				(xy 141.107794 85.293626) (xy 139.262204 85.293626) (xy 138.219999 84.251421) (xy 137.177794 85.293626)
-				(xy 136.232524 85.293626) (xy 136.224229 85.264472) (xy 136.125058 85.065311) (xy 135.990981 84.887764)
-				(xy 135.826562 84.737876) (xy 135.637401 84.620753) (xy 135.619571 84.613845) (xy 135.613734 84.611584)
-				(xy 135.566304 84.57293) (xy 135.5505 84.51927) (xy 135.5505 84.12761) (xy 135.569407 84.069419)
-				(xy 135.57949 84.057612) (xy 135.840489 83.796614) (xy 135.840492 83.796609) (xy 135.899797 83.693891)
-				(xy 135.899797 83.693889) (xy 135.899799 83.693887) (xy 135.913029 83.644511) (xy 135.9305 83.579309)
-				(xy 135.9305 83.215788) (xy 137.02 83.215788) (xy 137.02 85.004203) (xy 137.02285 85.0346) (xy 137.056838 85.131737)
+				(xy 137.177793 85.293626) (xy 137.257355 85.352345) (xy 137.385398 85.397149) (xy 137.415789 85.399999)
+				(xy 139.024203 85.399999) (xy 139.0546 85.397149) (xy 139.054602 85.397149) (xy 139.182644 85.352345)
+				(xy 139.262206 85.293626) (xy 141.107793 85.293626) (xy 141.187355 85.352345) (xy 141.315398 85.397149)
+				(xy 141.345789 85.399999) (xy 142.954203 85.399999) (xy 142.9846 85.397149) (xy 142.984602 85.397149)
+				(xy 143.112644 85.352345) (xy 143.192206 85.293626) (xy 142.15 84.25142) (xy 141.107793 85.293626)
+				(xy 139.262206 85.293626) (xy 138.22 84.25142) (xy 137.177793 85.293626) (xy 136.232524 85.293626)
+				(xy 136.224229 85.264472) (xy 136.125058 85.065311) (xy 135.990981 84.887764) (xy 135.826562 84.737876)
+				(xy 135.637401 84.620753) (xy 135.619571 84.613845) (xy 135.613734 84.611584) (xy 135.566304 84.57293)
+				(xy 135.5505 84.51927) (xy 135.5505 84.12761) (xy 135.569407 84.069419) (xy 135.57949 84.057612)
+				(xy 135.840489 83.796614) (xy 135.840492 83.796609) (xy 135.899797 83.693891) (xy 135.899797 83.693889)
+				(xy 135.899799 83.693887) (xy 135.913516 83.642693) (xy 135.9305 83.579309) (xy 135.9305 83.215788)
+				(xy 137.02 83.215788) (xy 137.02 85.004203) (xy 137.02285 85.034604) (xy 137.056838 85.131739) (xy 138.078578 84.11)
 				(xy 138.078577 84.109999) (xy 138.361421 84.109999) (xy 139.38316 85.131738) (xy 139.417147 85.034609)
 				(xy 139.417149 85.0346) (xy 139.419999 85.004211) (xy 139.419999 83.215796) (xy 139.419998 83.215788)
-				(xy 140.95 83.215788) (xy 140.95 85.004203) (xy 140.95285 85.0346) (xy 140.986838 85.131737) (xy 142.008577 84.109999)
-				(xy 142.291421 84.109999) (xy 143.31316 85.131738) (xy 143.347147 85.034609) (xy 143.347149 85.0346)
-				(xy 143.349999 85.004211) (xy 143.349999 83.215796) (xy 143.347149 83.185399) (xy 143.347149 83.185398)
-				(xy 143.313159 83.088261) (xy 142.291421 84.109999) (xy 142.008577 84.109999) (xy 140.986838 83.08826)
-				(xy 140.95285 83.185398) (xy 140.95 83.215788) (xy 139.419998 83.215788) (xy 139.417149 83.185399)
-				(xy 139.417149 83.185398) (xy 139.383159 83.088261) (xy 138.361421 84.109999) (xy 138.078577 84.109999)
-				(xy 137.056838 83.08826) (xy 137.02285 83.185398) (xy 137.02 83.215788) (xy 135.9305 83.215788)
-				(xy 135.9305 82.687572) (xy 135.949407 82.629381) (xy 135.979997 82.601837) (xy 136.051614 82.560489)
-				(xy 136.705858 81.906245) (xy 136.760372 81.87847) (xy 136.820804 81.888041) (xy 136.864069 81.931306)
-				(xy 136.873825 81.990521) (xy 136.87 82.016776) (xy 136.87 82.383213) (xy 136.870001 82.383216)
-				(xy 136.879912 82.45125) (xy 136.931214 82.556189) (xy 136.931215 82.55619) (xy 137.013809 82.638785)
-				(xy 137.048052 82.655524) (xy 137.503577 82.199999) (xy 137.373082 82.069504) (xy 137.345305 82.014987)
-				(xy 137.354876 81.954555) (xy 137.398141 81.91129) (xy 137.443086 81.9005) (xy 137.445914 81.9005)
-				(xy 137.504105 81.919407) (xy 137.515917 81.929496) (xy 137.645 82.058578) (xy 137.774083 81.929496)
-				(xy 137.828599 81.901719) (xy 137.844086 81.9005) (xy 137.846913 81.9005) (xy 137.905104 81.919407)
-				(xy 137.941068 81.968907) (xy 137.941068 82.030093) (xy 137.916917 82.069504) (xy 137.645 82.341421)
-				(xy 137.644999 82.34142) (xy 137.286421 82.699999) (xy 137.303674 82.741651) (xy 137.308474 82.802648)
-				(xy 137.276505 82.854817) (xy 137.25848 82.867058) (xy 137.257362 82.867648) (xy 137.177794 82.926372)
-				(xy 138.219999 83.968577) (xy 139.262204 82.926372) (xy 141.107794 82.926372) (xy 142.149999 83.968577)
-				(xy 143.192205 82.926371) (xy 143.112649 82.867655) (xy 142.984601 82.82285) (xy 142.95421 82.82)
-				(xy 141.345796 82.82) (xy 141.315399 82.82285) (xy 141.315397 82.82285) (xy 141.187355 82.867654)
-				(xy 141.107794 82.926372) (xy 139.262204 82.926372) (xy 139.262205 82.926371) (xy 139.182649 82.867655)
-				(xy 139.054601 82.82285) (xy 139.024211 82.82) (xy 138.331413 82.82) (xy 138.273222 82.801093) (xy 138.237258 82.751593)
+				(xy 140.95 83.215788) (xy 140.95 85.004203) (xy 140.95285 85.034604) (xy 140.986838 85.131739) (xy 142.008578 84.11)
+				(xy 142.008577 84.109999) (xy 142.291421 84.109999) (xy 143.31316 85.131738) (xy 143.347147 85.034609)
+				(xy 143.347149 85.0346) (xy 143.349999 85.004211) (xy 143.349999 83.215796) (xy 143.347149 83.185399)
+				(xy 143.347149 83.185398) (xy 143.313159 83.08826) (xy 142.291421 84.109999) (xy 142.008577 84.109999)
+				(xy 140.986838 83.08826) (xy 140.95285 83.185398) (xy 140.95 83.215788) (xy 139.419998 83.215788)
+				(xy 139.417149 83.185399) (xy 139.417149 83.185398) (xy 139.383159 83.08826) (xy 138.361421 84.109999)
+				(xy 138.078577 84.109999) (xy 137.056838 83.08826) (xy 137.02285 83.185398) (xy 137.02 83.215788)
+				(xy 135.9305 83.215788) (xy 135.9305 82.687572) (xy 135.949407 82.629381) (xy 135.979997 82.601837)
+				(xy 136.051614 82.560489) (xy 136.705858 81.906245) (xy 136.760372 81.87847) (xy 136.820804 81.888041)
+				(xy 136.864069 81.931306) (xy 136.873825 81.990521) (xy 136.87 82.016776) (xy 136.87 82.383213)
+				(xy 136.870001 82.383216) (xy 136.879912 82.45125) (xy 136.931214 82.556188) (xy 137.013812 82.638786)
+				(xy 137.048053 82.655525) (xy 137.048054 82.655525) (xy 137.504285 82.199294) (xy 137.558802 82.171516)
+				(xy 137.619234 82.181087) (xy 137.644293 82.199293) (xy 137.645706 82.200706) (xy 137.673483 82.255223)
+				(xy 137.663912 82.315655) (xy 137.645706 82.340714) (xy 137.28642 82.699999) (xy 137.303673 82.741652)
+				(xy 137.308472 82.802649) (xy 137.276502 82.854818) (xy 137.258474 82.867061) (xy 137.257355 82.867652)
+				(xy 137.177792 82.926372) (xy 138.219999 83.968579) (xy 139.262205 82.926372) (xy 141.107792 82.926372)
+				(xy 142.149999 83.968579) (xy 143.192205 82.926372) (xy 143.112646 82.867654) (xy 142.984601 82.82285)
+				(xy 142.95421 82.82) (xy 141.345796 82.82) (xy 141.315399 82.82285) (xy 141.315397 82.82285) (xy 141.18735 82.867655)
+				(xy 141.107792 82.926372) (xy 139.262205 82.926372) (xy 139.182646 82.867654) (xy 139.054601 82.82285)
+				(xy 139.024211 82.82) (xy 138.331413 82.82) (xy 138.273222 82.801093) (xy 138.237258 82.751593)
 				(xy 138.237258 82.690407) (xy 138.270481 82.644679) (xy 138.270388 82.644586) (xy 138.270976 82.643997)
 				(xy 138.273222 82.640907) (xy 138.273892 82.640425) (xy 138.276188 82.638785) (xy 138.358786 82.556187)
 				(xy 138.395237 82.481625) (xy 138.43778 82.437651) (xy 138.498045 82.427081) (xy 138.509782 82.429474)
@@ -39364,39 +39440,36 @@
 				(xy 138.885347 75.558503) (xy 138.795766 75.5345) (xy 138.644234 75.5345) (xy 138.5098 75.57052)
 				(xy 138.448699 75.567318) (xy 138.401149 75.528813) (xy 138.395237 75.518374) (xy 138.358786 75.443812)
 				(xy 138.276186 75.361212) (xy 138.273886 75.35957) (xy 138.27202 75.357046) (xy 138.270388 75.355414)
-				(xy 138.270632 75.355169) (xy 138.250405 75.327807) (xy 138.237417 75.349003) (xy 137.715003 75.871417)
-				(xy 137.660486 75.899194) (xy 137.600054 75.889623) (xy 137.574995 75.871417) (xy 137.048052 75.344474)
-				(xy 137.013811 75.361214) (xy 136.931213 75.443812) (xy 136.879912 75.548751) (xy 136.87 75.616784)
-				(xy 136.87 75.983213) (xy 136.87026 75.986786) (xy 136.868444 75.986917) (xy 136.859186 76.040628)
-				(xy 136.815336 76.083299) (xy 136.754779 76.092046) (xy 136.701593 76.064489) (xy 136.279496 75.642392)
-				(xy 136.251719 75.587875) (xy 136.2505 75.572388) (xy 136.2505 75.073626) (xy 137.177794 75.073626)
-				(xy 137.257356 75.132347) (xy 137.258466 75.132934) (xy 137.259261 75.133753) (xy 137.263324 75.136752)
-				(xy 137.262826 75.137426) (xy 137.301081 75.176839) (xy 137.309749 75.237407) (xy 137.303674 75.258348)
-				(xy 137.286422 75.299999) (xy 137.645 75.658577) (xy 138.008827 75.294749) (xy 138.005769 75.255889)
-				(xy 138.037738 75.203719) (xy 138.094266 75.180304) (xy 138.102034 75.179999) (xy 138.167413 75.179999)
-				(xy 138.225604 75.198906) (xy 138.249462 75.231743) (xy 138.272563 75.19939) (xy 138.330595 75.180002)
-				(xy 138.331413 75.179999) (xy 139.024203 75.179999) (xy 139.0546 75.177149) (xy 139.054602 75.177149)
-				(xy 139.182646 75.132345) (xy 139.262205 75.073627) (xy 139.262204 75.073626) (xy 141.107794 75.073626)
-				(xy 141.187352 75.132345) (xy 141.315398 75.177149) (xy 141.345789 75.179999) (xy 142.954203 75.179999)
-				(xy 142.9846 75.177149) (xy 142.984602 75.177149) (xy 143.112646 75.132345) (xy 143.192205 75.073627)
-				(xy 142.149999 74.031421) (xy 141.107794 75.073626) (xy 139.262204 75.073626) (xy 138.219999 74.031421)
-				(xy 137.177794 75.073626) (xy 136.2505 75.073626) (xy 136.2505 72.995788) (xy 137.02 72.995788)
-				(xy 137.02 74.784203) (xy 137.02285 74.8146) (xy 137.056838 74.911737) (xy 138.078577 73.889999)
-				(xy 138.361421 73.889999) (xy 139.38316 74.911738) (xy 139.417147 74.814609) (xy 139.417149 74.8146)
-				(xy 139.419999 74.784211) (xy 139.419999 72.995796) (xy 139.419998 72.995788) (xy 140.95 72.995788)
-				(xy 140.95 74.784203) (xy 140.95285 74.8146) (xy 140.986838 74.911737) (xy 142.008577 73.889999)
-				(xy 142.291421 73.889999) (xy 143.31316 74.911738) (xy 143.347147 74.814609) (xy 143.347149 74.8146)
-				(xy 143.349999 74.784211) (xy 143.349999 72.995796) (xy 143.347149 72.965399) (xy 143.347149 72.965398)
-				(xy 143.313159 72.868261) (xy 142.291421 73.889999) (xy 142.008577 73.889999) (xy 140.986838 72.86826)
-				(xy 140.95285 72.965398) (xy 140.95 72.995788) (xy 139.419998 72.995788) (xy 139.417149 72.965399)
-				(xy 139.417149 72.965398) (xy 139.383159 72.868261) (xy 138.361421 73.889999) (xy 138.078577 73.889999)
-				(xy 137.056838 72.86826) (xy 137.02285 72.965398) (xy 137.02 72.995788) (xy 136.2505 72.995788)
-				(xy 136.2505 72.706372) (xy 137.177794 72.706372) (xy 138.219999 73.748577) (xy 139.262204 72.706372)
-				(xy 141.107794 72.706372) (xy 142.149999 73.748577) (xy 143.192205 72.706371) (xy 143.112649 72.647655)
-				(xy 142.984601 72.60285) (xy 142.95421 72.6) (xy 141.345796 72.6) (xy 141.315399 72.60285) (xy 141.315397 72.60285)
-				(xy 141.187355 72.647654) (xy 141.107794 72.706372) (xy 139.262204 72.706372) (xy 139.262205 72.706371)
-				(xy 139.182649 72.647655) (xy 139.054601 72.60285) (xy 139.02421 72.6) (xy 137.415796 72.6) (xy 137.385399 72.60285)
-				(xy 137.385397 72.60285) (xy 137.257355 72.647654) (xy 137.177794 72.706372) (xy 136.2505 72.706372)
+				(xy 138.270632 75.355169) (xy 138.237514 75.310368) (xy 138.237009 75.249185) (xy 138.272563 75.19939)
+				(xy 138.330595 75.180002) (xy 138.331413 75.179999) (xy 139.024203 75.179999) (xy 139.0546 75.177149)
+				(xy 139.054602 75.177149) (xy 139.182644 75.132345) (xy 139.262206 75.073626) (xy 141.107793 75.073626)
+				(xy 141.187355 75.132345) (xy 141.315398 75.177149) (xy 141.345789 75.179999) (xy 142.954203 75.179999)
+				(xy 142.9846 75.177149) (xy 142.984602 75.177149) (xy 143.112644 75.132345) (xy 143.192206 75.073626)
+				(xy 142.15 74.03142) (xy 141.107793 75.073626) (xy 139.262206 75.073626) (xy 138.22 74.03142) (xy 137.177793 75.073626)
+				(xy 137.257353 75.132344) (xy 137.258465 75.132932) (xy 137.259261 75.133752) (xy 137.263324 75.136751)
+				(xy 137.262826 75.137425) (xy 137.301079 75.176838) (xy 137.309747 75.237406) (xy 137.303673 75.258345)
+				(xy 137.286419 75.299999) (xy 137.645706 75.659287) (xy 137.673483 75.713803) (xy 137.663912 75.774235)
+				(xy 137.645681 75.799318) (xy 137.644268 75.80073) (xy 137.589741 75.828489) (xy 137.529313 75.818896)
+				(xy 137.504285 75.800706) (xy 137.048052 75.344473) (xy 137.013812 75.361213) (xy 136.931213 75.443812)
+				(xy 136.879912 75.548751) (xy 136.87 75.616784) (xy 136.87 75.983213) (xy 136.87026 75.986786) (xy 136.868444 75.986917)
+				(xy 136.859186 76.040628) (xy 136.815336 76.083299) (xy 136.754779 76.092046) (xy 136.701593 76.064489)
+				(xy 136.279496 75.642392) (xy 136.251719 75.587875) (xy 136.2505 75.572388) (xy 136.2505 72.995788)
+				(xy 137.02 72.995788) (xy 137.02 74.784203) (xy 137.02285 74.814604) (xy 137.056838 74.911739) (xy 138.078578 73.89)
+				(xy 138.078577 73.889999) (xy 138.361421 73.889999) (xy 139.38316 74.911738) (xy 139.417147 74.814609)
+				(xy 139.417149 74.8146) (xy 139.419999 74.784211) (xy 139.419999 72.995796) (xy 139.419998 72.995788)
+				(xy 140.95 72.995788) (xy 140.95 74.784203) (xy 140.95285 74.814604) (xy 140.986838 74.911739) (xy 142.008578 73.89)
+				(xy 142.008577 73.889999) (xy 142.291421 73.889999) (xy 143.31316 74.911738) (xy 143.347147 74.814609)
+				(xy 143.347149 74.8146) (xy 143.349999 74.784211) (xy 143.349999 72.995796) (xy 143.347149 72.965399)
+				(xy 143.347149 72.965398) (xy 143.313159 72.86826) (xy 142.291421 73.889999) (xy 142.008577 73.889999)
+				(xy 140.986838 72.86826) (xy 140.95285 72.965398) (xy 140.95 72.995788) (xy 139.419998 72.995788)
+				(xy 139.417149 72.965399) (xy 139.417149 72.965398) (xy 139.383159 72.86826) (xy 138.361421 73.889999)
+				(xy 138.078577 73.889999) (xy 137.056838 72.86826) (xy 137.02285 72.965398) (xy 137.02 72.995788)
+				(xy 136.2505 72.995788) (xy 136.2505 72.706372) (xy 137.177792 72.706372) (xy 138.219999 73.748579)
+				(xy 139.262205 72.706372) (xy 141.107792 72.706372) (xy 142.149999 73.748579) (xy 143.192205 72.706372)
+				(xy 143.112646 72.647654) (xy 142.984601 72.60285) (xy 142.95421 72.6) (xy 141.345796 72.6) (xy 141.315399 72.60285)
+				(xy 141.315397 72.60285) (xy 141.18735 72.647655) (xy 141.107792 72.706372) (xy 139.262205 72.706372)
+				(xy 139.182646 72.647654) (xy 139.054601 72.60285) (xy 139.02421 72.6) (xy 137.415796 72.6) (xy 137.385399 72.60285)
+				(xy 137.385397 72.60285) (xy 137.25735 72.647655) (xy 137.177792 72.706372) (xy 136.2505 72.706372)
 				(xy 136.2505 72.51756) (xy 136.269407 72.459369) (xy 136.279497 72.447556) (xy 136.475337 72.251716)
 				(xy 136.73549 71.991564) (xy 136.794799 71.888837) (xy 136.80218 71.86129) (xy 136.80265 71.859538)
 				(xy 136.816766 71.806855) (xy 136.8255 71.774259) (xy 136.8255 71.2495) (xy 136.844407 71.191309)
@@ -39466,137 +39539,138 @@
 				(xy 123.666824 79.985932) (xy 123.559598 80.035933) (xy 123.475933 80.119598) (xy 123.425932 80.226824)
 				(xy 123.425932 80.226825) (xy 123.4195 80.275685) (xy 123.4195 80.504521) (xy 123.400593 80.562712)
 				(xy 123.390504 80.574525) (xy 123.329004 80.636025) (xy 123.274487 80.663802) (xy 123.214055 80.654231)
-				(xy 123.17079 80.610966) (xy 123.16 80.566021) (xy 123.16 80.500001) (xy 123.159999 80.5) (xy 122.679 80.5)
-				(xy 122.620809 80.481093) (xy 122.584845 80.431593) (xy 122.58 80.401) (xy 122.58 79.500001) (xy 122.78 79.500001)
-				(xy 122.78 80.299999) (xy 122.780001 80.3) (xy 123.159999 80.3) (xy 123.16 80.299999) (xy 123.16 80.190161)
-				(xy 123.15348 80.140645) (xy 123.153478 80.140638) (xy 123.102809 80.031978) (xy 123.040835 79.970004)
-				(xy 123.013058 79.915487) (xy 123.022629 79.855055) (xy 123.040835 79.829996) (xy 123.102809 79.768021)
-				(xy 123.153478 79.659361) (xy 123.15348 79.659354) (xy 123.16 79.609838) (xy 123.16 79.500001) (xy 123.159999 79.5)
-				(xy 122.780001 79.5) (xy 122.78 79.500001) (xy 122.58 79.500001) (xy 122.58 78.500001) (xy 122.78 78.500001)
-				(xy 122.78 79.299999) (xy 122.780001 79.3) (xy 123.159999 79.3) (xy 123.16 79.299999) (xy 123.16 79.190161)
-				(xy 123.15348 79.140645) (xy 123.153478 79.140638) (xy 123.102809 79.031978) (xy 123.040835 78.970004)
-				(xy 123.013058 78.915487) (xy 123.022629 78.855055) (xy 123.040835 78.829996) (xy 123.102809 78.768021)
-				(xy 123.153478 78.659361) (xy 123.15348 78.659354) (xy 123.16 78.609838) (xy 123.16 78.500001) (xy 123.159999 78.5)
-				(xy 122.780001 78.5) (xy 122.78 78.500001) (xy 122.58 78.500001) (xy 122.58 78.399) (xy 122.598907 78.340809)
-				(xy 122.648407 78.304845) (xy 122.679 78.3) (xy 123.159999 78.3) (xy 123.16 78.299999) (xy 123.16 78.1895)
-				(xy 123.178907 78.131309) (xy 123.228407 78.095345) (xy 123.259 78.0905) (xy 123.66343 78.0905)
-				(xy 123.721621 78.109407) (xy 123.733434 78.119496) (xy 123.898449 78.284511) (xy 123.898448 78.284511)
-				(xy 123.954398 78.34046) (xy 124.022916 78.380019) (xy 124.02292 78.380021) (xy 124.099344 78.400499)
-				(xy 124.099346 78.4005) (xy 124.099347 78.4005) (xy 132.489563 78.4005) (xy 132.489563 78.400499)
-				(xy 132.565989 78.380021) (xy 132.634511 78.34046) (xy 132.69046 78.284511) (xy 133.57497 77.400001)
-				(xy 134.270001 77.400001) (xy 134.270001 77.52426) (xy 134.276422 77.573041) (xy 134.326349 77.680109)
-				(xy 134.40989 77.76365) (xy 134.516952 77.813574) (xy 134.516959 77.813576) (xy 134.565745 77.819999)
-				(xy 134.639999 77.819998) (xy 134.64 77.819998) (xy 134.64 77.400001) (xy 134.639999 77.4) (xy 134.270002 77.4)
-				(xy 134.270001 77.400001) (xy 133.57497 77.400001) (xy 133.899225 77.075746) (xy 134.27 77.075746)
-				(xy 134.27 77.199999) (xy 134.270001 77.2) (xy 134.639999 77.2) (xy 134.64 77.199999) (xy 134.64 76.779999)
-				(xy 134.565749 76.78) (xy 134.565738 76.780001) (xy 134.516959 76.786422) (xy 134.40989 76.836349)
-				(xy 134.326349 76.91989) (xy 134.276425 77.026952) (xy 134.276423 77.026959) (xy 134.27 77.075746)
-				(xy 133.899225 77.075746) (xy 134.14046 76.834511) (xy 134.168224 76.786423) (xy 134.18002 76.765992)
-				(xy 134.18002 76.76599) (xy 134.180022 76.765988) (xy 134.2005 76.689562) (xy 134.2005 76.610438)
-				(xy 134.2005 74.760438) (xy 134.195147 74.74046) (xy 134.180022 74.684012) (xy 134.180019 74.684006)
-				(xy 134.140463 74.615493) (xy 134.140461 74.615491) (xy 134.14046 74.615489) (xy 132.849511 73.32454)
-				(xy 132.849504 73.324536) (xy 132.821415 73.308319) (xy 132.795784 73.293521) (xy 132.780988 73.284978)
-				(xy 132.704564 73.2645) (xy 132.704562 73.2645) (xy 132.628365 73.2645) (xy 132.570174 73.245593)
-				(xy 132.544389 73.214891) (xy 132.543965 73.215194) (xy 132.540115 73.209802) (xy 132.539423 73.208978)
-				(xy 132.539198 73.208518) (xy 132.539198 73.208517) (xy 132.456483 73.125802) (xy 132.456481 73.125801)
-				(xy 132.351395 73.074427) (xy 132.324139 73.070456) (xy 132.28326 73.0645) (xy 130.91674 73.0645)
-				(xy 130.882673 73.069463) (xy 130.848604 73.074427) (xy 130.743518 73.125801) (xy 130.660801 73.208518)
-				(xy 130.609427 73.313604) (xy 130.607834 73.324538) (xy 130.5995 73.38174) (xy 130.5995 73.74826)
-				(xy 130.600055 73.752066) (xy 130.609427 73.816395) (xy 130.660801 73.921481) (xy 130.660802 73.921483)
-				(xy 130.743517 74.004198) (xy 130.760209 74.012358) (xy 130.848604 74.055572) (xy 130.848605 74.055572)
-				(xy 130.848607 74.055573) (xy 130.91674 74.0655) (xy 130.916743 74.0655) (xy 132.283257 74.0655)
-				(xy 132.28326 74.0655) (xy 132.351393 74.055573) (xy 132.456483 74.004198) (xy 132.497852 73.962828)
-				(xy 132.552366 73.935052) (xy 132.612798 73.944623) (xy 132.637858 73.962829) (xy 133.570504 74.895475)
-				(xy 133.598281 74.949992) (xy 133.5995 74.965479) (xy 133.5995 76.484521) (xy 133.580593 76.542712)
-				(xy 133.570504 76.554525) (xy 132.354525 77.770504) (xy 132.300008 77.798281) (xy 132.284521 77.7995)
-				(xy 124.304388 77.7995) (xy 124.246197 77.780593) (xy 124.234384 77.770504) (xy 124.233384 77.769504)
-				(xy 124.205607 77.714987) (xy 124.215178 77.654555) (xy 124.258443 77.61129) (xy 124.303388 77.6005)
-				(xy 132.139563 77.6005) (xy 132.139563 77.600499) (xy 132.215989 77.580021) (xy 132.284511 77.54046)
-				(xy 132.34046 77.484511) (xy 133.24046 76.584511) (xy 133.243052 76.580021) (xy 133.280021 76.515989)
-				(xy 133.3005 76.439562) (xy 133.3005 75.160438) (xy 133.280021 75.084011) (xy 133.279565 75.083222)
-				(xy 133.24046 75.015489) (xy 133.184512 74.95954) (xy 132.81951 74.594539) (xy 132.819508 74.594538)
-				(xy 132.800576 74.583608) (xy 132.800576 74.583607) (xy 132.800572 74.583606) (xy 132.769136 74.565456)
-				(xy 132.750988 74.554978) (xy 132.674564 74.5345) (xy 132.674562 74.5345) (xy 132.628365 74.5345)
-				(xy 132.570174 74.515593) (xy 132.544389 74.484891) (xy 132.543965 74.485194) (xy 132.540115 74.479802)
-				(xy 132.539423 74.478978) (xy 132.539198 74.478518) (xy 132.539198 74.478517) (xy 132.456483 74.395802)
-				(xy 132.454333 74.394751) (xy 132.351395 74.344427) (xy 132.324139 74.340456) (xy 132.28326 74.3345)
-				(xy 130.91674 74.3345) (xy 130.882673 74.339463) (xy 130.848604 74.344427) (xy 130.743518 74.395801)
-				(xy 130.660801 74.478518) (xy 130.609427 74.583604) (xy 130.605977 74.607288) (xy 130.5995 74.65174)
-				(xy 130.5995 75.01826) (xy 130.606118 75.063682) (xy 130.609427 75.086395) (xy 130.655188 75.179999)
-				(xy 130.660802 75.191483) (xy 130.743517 75.274198) (xy 130.785555 75.294749) (xy 130.848604 75.325572)
-				(xy 130.848605 75.325572) (xy 130.848607 75.325573) (xy 130.91674 75.3355) (xy 130.916743 75.3355)
-				(xy 132.283257 75.3355) (xy 132.28326 75.3355) (xy 132.351393 75.325573) (xy 132.456483 75.274198)
-				(xy 132.482851 75.247829) (xy 132.537365 75.220052) (xy 132.597798 75.229623) (xy 132.622858 75.247829)
-				(xy 132.670504 75.295475) (xy 132.698281 75.349992) (xy 132.6995 75.365479) (xy 132.6995 75.669812)
-				(xy 132.680593 75.728003) (xy 132.631093 75.763967) (xy 132.569907 75.763967) (xy 132.530498 75.739817)
-				(xy 132.456483 75.665802) (xy 132.441704 75.658577) (xy 132.351395 75.614427) (xy 132.324139 75.610456)
-				(xy 132.28326 75.6045) (xy 130.91674 75.6045) (xy 130.882673 75.609463) (xy 130.848604 75.614427)
-				(xy 130.743518 75.665801) (xy 130.660801 75.748518) (xy 130.660577 75.748978) (xy 130.66018 75.749387)
-				(xy 130.656035 75.755194) (xy 130.655164 75.754572) (xy 130.618035 75.792953) (xy 130.571635 75.8045)
-				(xy 127.795874 75.8045) (xy 127.737683 75.785593) (xy 127.701719 75.736093) (xy 127.701719 75.674907)
-				(xy 127.725868 75.635498) (xy 127.740477 75.62089) (xy 127.830456 75.47769) (xy 127.886313 75.318059)
-				(xy 127.886314 75.318053) (xy 127.905249 75.150004) (xy 127.905249 75.149995) (xy 127.886314 74.981946)
-				(xy 127.886311 74.981934) (xy 127.838224 74.844511) (xy 127.830456 74.82231) (xy 127.825611 74.8146)
-				(xy 127.740479 74.679113) (xy 127.740478 74.679112) (xy 127.740477 74.67911) (xy 127.62089 74.559523)
-				(xy 127.620887 74.559521) (xy 127.620886 74.55952) (xy 127.477691 74.469544) (xy 127.318065 74.413688)
-				(xy 127.318053 74.413685) (xy 127.150004 74.394751) (xy 127.149996 74.394751) (xy 126.981946 74.413685)
-				(xy 126.981934 74.413688) (xy 126.822309 74.469544) (xy 126.822308 74.469544) (xy 126.679113 74.55952)
-				(xy 126.55952 74.679113) (xy 126.469544 74.822308) (xy 126.469544 74.822309) (xy 126.413688 74.981934)
-				(xy 126.413685 74.981946) (xy 126.394751 75.149995) (xy 126.394751 75.150004) (xy 126.413685 75.318053)
-				(xy 126.413688 75.318065) (xy 126.469544 75.47769) (xy 126.469544 75.477691) (xy 126.55952 75.620886)
-				(xy 126.559523 75.62089) (xy 126.67911 75.740477) (xy 126.679112 75.740478) (xy 126.679115 75.740481)
-				(xy 126.74449 75.781559) (xy 126.783702 75.828527) (xy 126.787817 75.889574) (xy 126.761822 75.935388)
-				(xy 126.243864 76.453347) (xy 126.189347 76.481124) (xy 126.17386 76.482343) (xy 125.485334 76.482343)
-				(xy 125.427143 76.463436) (xy 125.391179 76.413936) (xy 125.390821 76.364125) (xy 125.388979 76.363857)
-				(xy 125.4 76.288215) (xy 125.4 76.205001) (xy 125.399999 76.205) (xy 123.400002 76.205) (xy 123.400001 76.205001)
-				(xy 123.400001 76.288216) (xy 123.411021 76.363858) (xy 123.409107 76.364136) (xy 123.408369 76.415291)
-				(xy 123.371695 76.464267) (xy 123.314666 76.482343) (xy 122.181636 76.482343) (xy 122.123445 76.463436)
-				(xy 122.087481 76.413936) (xy 122.087481 76.35275) (xy 122.111632 76.313339) (xy 122.503187 75.921784)
-				(xy 123.4 75.921784) (xy 123.4 76.004999) (xy 123.400001 76.005) (xy 124.299999 76.005) (xy 124.3 76.004999)
-				(xy 124.3 75.605001) (xy 124.5 75.605001) (xy 124.5 76.004999) (xy 124.500001 76.005) (xy 125.399998 76.005)
-				(xy 125.399999 76.004999) (xy 125.399999 75.921786) (xy 125.399998 75.921783) (xy 125.390087 75.853749)
-				(xy 125.338785 75.748811) (xy 125.256187 75.666213) (xy 125.151248 75.614912) (xy 125.083216 75.605)
-				(xy 124.500001 75.605) (xy 124.5 75.605001) (xy 124.3 75.605001) (xy 124.299999 75.605) (xy 123.716786 75.605)
-				(xy 123.716783 75.605001) (xy 123.648749 75.614912) (xy 123.543811 75.666214) (xy 123.461213 75.748812)
-				(xy 123.409912 75.853751) (xy 123.4 75.921784) (xy 122.503187 75.921784) (xy 123.260475 75.164496)
-				(xy 123.314992 75.136719) (xy 123.330479 75.1355) (xy 123.371635 75.1355) (xy 123.429826 75.154407)
-				(xy 123.45561 75.185108) (xy 123.456035 75.184806) (xy 123.459884 75.190197) (xy 123.460576 75.19102)
-				(xy 123.460802 75.191483) (xy 123.543517 75.274198) (xy 123.585555 75.294749) (xy 123.648604 75.325572)
-				(xy 123.648605 75.325572) (xy 123.648607 75.325573) (xy 123.71674 75.3355) (xy 123.716743 75.3355)
-				(xy 125.083257 75.3355) (xy 125.08326 75.3355) (xy 125.151393 75.325573) (xy 125.256483 75.274198)
-				(xy 125.339198 75.191483) (xy 125.390573 75.086393) (xy 125.4005 75.01826) (xy 125.4005 74.65174)
-				(xy 125.390573 74.583607) (xy 125.389007 74.580404) (xy 125.354589 74.51) (xy 125.339198 74.478517)
-				(xy 125.256483 74.395802) (xy 125.254333 74.394751) (xy 125.151395 74.344427) (xy 125.124139 74.340456)
-				(xy 125.08326 74.3345) (xy 123.71674 74.3345) (xy 123.682673 74.339463) (xy 123.648604 74.344427)
-				(xy 123.543518 74.395801) (xy 123.460801 74.478518) (xy 123.460577 74.478978) (xy 123.46018 74.479387)
-				(xy 123.456035 74.485194) (xy 123.455164 74.484572) (xy 123.418035 74.522953) (xy 123.371635 74.5345)
-				(xy 123.129479 74.5345) (xy 123.071288 74.515593) (xy 123.035324 74.466093) (xy 123.035324 74.404907)
-				(xy 123.059475 74.365497) (xy 123.412613 74.012358) (xy 123.46713 73.98458) (xy 123.527562 73.994151)
-				(xy 123.540141 74.001788) (xy 123.543515 74.004197) (xy 123.648604 74.055572) (xy 123.648605 74.055572)
-				(xy 123.648607 74.055573) (xy 123.71674 74.0655) (xy 123.716743 74.0655) (xy 125.083257 74.0655)
-				(xy 125.08326 74.0655) (xy 125.151393 74.055573) (xy 125.256483 74.004198) (xy 125.339198 73.921483)
-				(xy 125.390573 73.816393) (xy 125.4005 73.74826) (xy 125.4005 73.38174) (xy 125.390573 73.313607)
-				(xy 125.387987 73.308318) (xy 125.342314 73.214891) (xy 125.339198 73.208517) (xy 125.256483 73.125802)
-				(xy 125.256481 73.125801) (xy 125.151395 73.074427) (xy 125.124139 73.070456) (xy 125.08326 73.0645)
-				(xy 123.71674 73.0645) (xy 123.682673 73.069463) (xy 123.648604 73.074427) (xy 123.543518 73.125801)
-				(xy 123.460801 73.208518) (xy 123.45895 73.212305) (xy 123.416404 73.256277) (xy 123.395635 73.264446)
-				(xy 123.319012 73.284977) (xy 123.319008 73.284979) (xy 123.250493 73.324536) (xy 123.250488 73.32454)
-				(xy 123.094503 73.480525) (xy 123.039987 73.508302) (xy 122.979555 73.498731) (xy 122.93629 73.455466)
-				(xy 122.9255 73.410521) (xy 122.9255 72.933951) (xy 122.944407 72.87576) (xy 122.979552 72.845742)
-				(xy 123.063342 72.80305) (xy 123.15305 72.713342) (xy 123.210646 72.600304) (xy 123.217025 72.560026)
-				(xy 123.244802 72.50551) (xy 123.299318 72.477732) (xy 123.35975 72.487303) (xy 123.403015 72.530567)
-				(xy 123.409393 72.546285) (xy 123.409425 72.546391) (xy 123.445895 72.620991) (xy 123.460802 72.651483)
-				(xy 123.543517 72.734198) (xy 123.59278 72.758281) (xy 123.648604 72.785572) (xy 123.648605 72.785572)
-				(xy 123.648607 72.785573) (xy 123.71674 72.7955) (xy 123.716743 72.7955) (xy 125.083257 72.7955)
-				(xy 125.08326 72.7955) (xy 125.151393 72.785573) (xy 125.256483 72.734198) (xy 125.339198 72.651483)
-				(xy 125.390573 72.546393) (xy 125.4005 72.47826) (xy 125.4005 72.11174) (xy 125.390573 72.043607)
-				(xy 125.390281 72.04301) (xy 125.352603 71.965938) (xy 125.339198 71.938517) (xy 125.256483 71.855802)
-				(xy 125.245237 71.850304) (xy 125.151395 71.804427) (xy 125.124139 71.800456) (xy 125.08326 71.7945)
-				(xy 125.083257 71.7945) (xy 124.774216 71.7945) (xy 124.716025 71.775593) (xy 124.68848 71.745001)
-				(xy 124.665465 71.705138) (xy 124.429828 71.469501) (xy 124.402053 71.414987) (xy 124.411624 71.354555)
-				(xy 124.454889 71.31129) (xy 124.499834 71.3005) (xy 127.839563 71.3005) (xy 127.839563 71.300499)
-				(xy 127.915989 71.280021) (xy 127.984511 71.24046) (xy 128.04046 71.184511) (xy 128.08481 71.140161)
-				(xy 132.6 71.140161) (xy 132.6 71.219999) (xy 132.600001 71.22) (xy 133.009999 71.22) (xy 133.01 71.219999)
+				(xy 123.17079 80.610966) (xy 123.16 80.566021) (xy 123.16 80.500001) (xy 123.159999 80.5) (xy 122.779 80.5)
+				(xy 122.720809 80.481093) (xy 122.684845 80.431593) (xy 122.68 80.401) (xy 122.68 80.4) (xy 122.679 80.4)
+				(xy 122.620809 80.381093) (xy 122.584845 80.331593) (xy 122.58 80.301) (xy 122.58 79.500001) (xy 122.78 79.500001)
+				(xy 122.78 80.3) (xy 123.159999 80.3) (xy 123.16 80.299999) (xy 123.16 80.190161) (xy 123.15348 80.140645)
+				(xy 123.153478 80.140638) (xy 123.102809 80.031978) (xy 123.040835 79.970004) (xy 123.013058 79.915487)
+				(xy 123.022629 79.855055) (xy 123.040835 79.829996) (xy 123.102809 79.768021) (xy 123.153478 79.659361)
+				(xy 123.15348 79.659354) (xy 123.16 79.609838) (xy 123.16 79.500001) (xy 123.159999 79.5) (xy 122.780001 79.5)
+				(xy 122.78 79.500001) (xy 122.58 79.500001) (xy 122.58 79.299999) (xy 122.78 79.299999) (xy 122.780001 79.3)
+				(xy 123.159999 79.3) (xy 123.16 79.299999) (xy 123.16 79.190161) (xy 123.15348 79.140645) (xy 123.153478 79.140638)
+				(xy 123.102809 79.031978) (xy 123.040835 78.970004) (xy 123.013058 78.915487) (xy 123.022629 78.855055)
+				(xy 123.040835 78.829996) (xy 123.102809 78.768021) (xy 123.153478 78.659361) (xy 123.15348 78.659354)
+				(xy 123.16 78.609838) (xy 123.16 78.500001) (xy 123.159999 78.5) (xy 122.78 78.5) (xy 122.78 79.299999)
+				(xy 122.58 79.299999) (xy 122.58 78.499) (xy 122.598907 78.440809) (xy 122.648407 78.404845) (xy 122.679 78.4)
+				(xy 122.68 78.4) (xy 122.68 78.399) (xy 122.698907 78.340809) (xy 122.748407 78.304845) (xy 122.779 78.3)
+				(xy 123.159999 78.3) (xy 123.16 78.299999) (xy 123.16 78.1895) (xy 123.178907 78.131309) (xy 123.228407 78.095345)
+				(xy 123.259 78.0905) (xy 123.66343 78.0905) (xy 123.721621 78.109407) (xy 123.733434 78.119496)
+				(xy 123.898449 78.284511) (xy 123.898448 78.284511) (xy 123.954398 78.34046) (xy 124.022916 78.380019)
+				(xy 124.02292 78.380021) (xy 124.099344 78.400499) (xy 124.099346 78.4005) (xy 124.099347 78.4005)
+				(xy 132.489563 78.4005) (xy 132.489563 78.400499) (xy 132.565989 78.380021) (xy 132.634511 78.34046)
+				(xy 132.69046 78.284511) (xy 133.57497 77.400001) (xy 134.270001 77.400001) (xy 134.270001 77.52426)
+				(xy 134.276422 77.573041) (xy 134.326349 77.680109) (xy 134.40989 77.76365) (xy 134.516952 77.813574)
+				(xy 134.516959 77.813576) (xy 134.565745 77.819999) (xy 134.639999 77.819998) (xy 134.64 77.819998)
+				(xy 134.64 77.400001) (xy 134.639999 77.4) (xy 134.270002 77.4) (xy 134.270001 77.400001) (xy 133.57497 77.400001)
+				(xy 133.899225 77.075746) (xy 134.27 77.075746) (xy 134.27 77.199999) (xy 134.270001 77.2) (xy 134.639999 77.2)
+				(xy 134.64 77.199999) (xy 134.64 76.779999) (xy 134.565749 76.78) (xy 134.565738 76.780001) (xy 134.516959 76.786422)
+				(xy 134.40989 76.836349) (xy 134.326349 76.91989) (xy 134.276425 77.026952) (xy 134.276423 77.026959)
+				(xy 134.27 77.075746) (xy 133.899225 77.075746) (xy 134.14046 76.834511) (xy 134.168224 76.786423)
+				(xy 134.18002 76.765992) (xy 134.18002 76.76599) (xy 134.180022 76.765988) (xy 134.2005 76.689562)
+				(xy 134.2005 76.610438) (xy 134.2005 74.760438) (xy 134.195147 74.74046) (xy 134.180022 74.684012)
+				(xy 134.180019 74.684006) (xy 134.140463 74.615493) (xy 134.140461 74.615491) (xy 134.14046 74.615489)
+				(xy 132.849511 73.32454) (xy 132.849504 73.324536) (xy 132.821415 73.308319) (xy 132.795784 73.293521)
+				(xy 132.780988 73.284978) (xy 132.704564 73.2645) (xy 132.704562 73.2645) (xy 132.628365 73.2645)
+				(xy 132.570174 73.245593) (xy 132.544389 73.214891) (xy 132.543965 73.215194) (xy 132.540115 73.209802)
+				(xy 132.539423 73.208978) (xy 132.539198 73.208518) (xy 132.539198 73.208517) (xy 132.456483 73.125802)
+				(xy 132.456481 73.125801) (xy 132.351395 73.074427) (xy 132.324139 73.070456) (xy 132.28326 73.0645)
+				(xy 130.91674 73.0645) (xy 130.882673 73.069463) (xy 130.848604 73.074427) (xy 130.743518 73.125801)
+				(xy 130.660801 73.208518) (xy 130.609427 73.313604) (xy 130.607834 73.324538) (xy 130.5995 73.38174)
+				(xy 130.5995 73.74826) (xy 130.600055 73.752066) (xy 130.609427 73.816395) (xy 130.660801 73.921481)
+				(xy 130.660802 73.921483) (xy 130.743517 74.004198) (xy 130.760209 74.012358) (xy 130.848604 74.055572)
+				(xy 130.848605 74.055572) (xy 130.848607 74.055573) (xy 130.91674 74.0655) (xy 130.916743 74.0655)
+				(xy 132.283257 74.0655) (xy 132.28326 74.0655) (xy 132.351393 74.055573) (xy 132.456483 74.004198)
+				(xy 132.497852 73.962828) (xy 132.552366 73.935052) (xy 132.612798 73.944623) (xy 132.637858 73.962829)
+				(xy 133.570504 74.895475) (xy 133.598281 74.949992) (xy 133.5995 74.965479) (xy 133.5995 76.484521)
+				(xy 133.580593 76.542712) (xy 133.570504 76.554525) (xy 132.354525 77.770504) (xy 132.300008 77.798281)
+				(xy 132.284521 77.7995) (xy 124.304388 77.7995) (xy 124.246197 77.780593) (xy 124.234384 77.770504)
+				(xy 124.233384 77.769504) (xy 124.205607 77.714987) (xy 124.215178 77.654555) (xy 124.258443 77.61129)
+				(xy 124.303388 77.6005) (xy 132.139563 77.6005) (xy 132.139563 77.600499) (xy 132.215989 77.580021)
+				(xy 132.284511 77.54046) (xy 132.34046 77.484511) (xy 133.24046 76.584511) (xy 133.243052 76.580021)
+				(xy 133.280021 76.515989) (xy 133.3005 76.439562) (xy 133.3005 75.160438) (xy 133.280021 75.084011)
+				(xy 133.279565 75.083222) (xy 133.24046 75.015489) (xy 133.184512 74.95954) (xy 132.81951 74.594539)
+				(xy 132.819508 74.594538) (xy 132.800576 74.583608) (xy 132.800576 74.583607) (xy 132.800572 74.583606)
+				(xy 132.769136 74.565456) (xy 132.750988 74.554978) (xy 132.674564 74.5345) (xy 132.674562 74.5345)
+				(xy 132.628365 74.5345) (xy 132.570174 74.515593) (xy 132.544389 74.484891) (xy 132.543965 74.485194)
+				(xy 132.540115 74.479802) (xy 132.539423 74.478978) (xy 132.539198 74.478518) (xy 132.539198 74.478517)
+				(xy 132.456483 74.395802) (xy 132.454333 74.394751) (xy 132.351395 74.344427) (xy 132.324139 74.340456)
+				(xy 132.28326 74.3345) (xy 130.91674 74.3345) (xy 130.882673 74.339463) (xy 130.848604 74.344427)
+				(xy 130.743518 74.395801) (xy 130.660801 74.478518) (xy 130.609427 74.583604) (xy 130.605977 74.607288)
+				(xy 130.5995 74.65174) (xy 130.5995 75.01826) (xy 130.606118 75.063682) (xy 130.609427 75.086395)
+				(xy 130.655188 75.179999) (xy 130.660802 75.191483) (xy 130.743517 75.274198) (xy 130.78704 75.295475)
+				(xy 130.848604 75.325572) (xy 130.848605 75.325572) (xy 130.848607 75.325573) (xy 130.91674 75.3355)
+				(xy 130.916743 75.3355) (xy 132.283257 75.3355) (xy 132.28326 75.3355) (xy 132.351393 75.325573)
+				(xy 132.456483 75.274198) (xy 132.482851 75.247829) (xy 132.537365 75.220052) (xy 132.597798 75.229623)
+				(xy 132.622858 75.247829) (xy 132.670504 75.295475) (xy 132.698281 75.349992) (xy 132.6995 75.365479)
+				(xy 132.6995 75.669812) (xy 132.680593 75.728003) (xy 132.631093 75.763967) (xy 132.569907 75.763967)
+				(xy 132.530498 75.739817) (xy 132.456483 75.665802) (xy 132.456481 75.665801) (xy 132.351395 75.614427)
+				(xy 132.324139 75.610456) (xy 132.28326 75.6045) (xy 130.91674 75.6045) (xy 130.882673 75.609463)
+				(xy 130.848604 75.614427) (xy 130.743518 75.665801) (xy 130.660801 75.748518) (xy 130.660577 75.748978)
+				(xy 130.66018 75.749387) (xy 130.656035 75.755194) (xy 130.655164 75.754572) (xy 130.618035 75.792953)
+				(xy 130.571635 75.8045) (xy 127.795874 75.8045) (xy 127.737683 75.785593) (xy 127.701719 75.736093)
+				(xy 127.701719 75.674907) (xy 127.725868 75.635498) (xy 127.740477 75.62089) (xy 127.830456 75.47769)
+				(xy 127.886313 75.318059) (xy 127.88718 75.310368) (xy 127.905249 75.150004) (xy 127.905249 75.149995)
+				(xy 127.886314 74.981946) (xy 127.886311 74.981934) (xy 127.838224 74.844511) (xy 127.830456 74.82231)
+				(xy 127.825611 74.8146) (xy 127.740479 74.679113) (xy 127.740478 74.679112) (xy 127.740477 74.67911)
+				(xy 127.62089 74.559523) (xy 127.620887 74.559521) (xy 127.620886 74.55952) (xy 127.477691 74.469544)
+				(xy 127.318065 74.413688) (xy 127.318053 74.413685) (xy 127.150004 74.394751) (xy 127.149996 74.394751)
+				(xy 126.981946 74.413685) (xy 126.981934 74.413688) (xy 126.822309 74.469544) (xy 126.822308 74.469544)
+				(xy 126.679113 74.55952) (xy 126.55952 74.679113) (xy 126.469544 74.822308) (xy 126.469544 74.822309)
+				(xy 126.413688 74.981934) (xy 126.413685 74.981946) (xy 126.394751 75.149995) (xy 126.394751 75.150004)
+				(xy 126.413685 75.318053) (xy 126.413688 75.318065) (xy 126.469544 75.47769) (xy 126.469544 75.477691)
+				(xy 126.55952 75.620886) (xy 126.559523 75.62089) (xy 126.67911 75.740477) (xy 126.679112 75.740478)
+				(xy 126.679115 75.740481) (xy 126.74449 75.781559) (xy 126.783702 75.828527) (xy 126.787817 75.889574)
+				(xy 126.761822 75.935388) (xy 126.243864 76.453347) (xy 126.189347 76.481124) (xy 126.17386 76.482343)
+				(xy 125.485334 76.482343) (xy 125.427143 76.463436) (xy 125.391179 76.413936) (xy 125.390821 76.364125)
+				(xy 125.388979 76.363857) (xy 125.4 76.288215) (xy 125.4 76.205001) (xy 125.399999 76.205) (xy 123.400002 76.205)
+				(xy 123.400001 76.205001) (xy 123.400001 76.288216) (xy 123.411021 76.363858) (xy 123.409107 76.364136)
+				(xy 123.408369 76.415291) (xy 123.371695 76.464267) (xy 123.314666 76.482343) (xy 122.181636 76.482343)
+				(xy 122.123445 76.463436) (xy 122.087481 76.413936) (xy 122.087481 76.35275) (xy 122.111632 76.313339)
+				(xy 122.503187 75.921784) (xy 123.4 75.921784) (xy 123.4 76.004999) (xy 123.400001 76.005) (xy 124.299999 76.005)
+				(xy 124.3 76.004999) (xy 124.3 75.605001) (xy 124.5 75.605001) (xy 124.5 76.004999) (xy 124.500001 76.005)
+				(xy 125.399998 76.005) (xy 125.399999 76.004999) (xy 125.399999 75.921786) (xy 125.399998 75.921783)
+				(xy 125.390087 75.853749) (xy 125.338785 75.748811) (xy 125.256187 75.666213) (xy 125.151248 75.614912)
+				(xy 125.083216 75.605) (xy 124.500001 75.605) (xy 124.5 75.605001) (xy 124.3 75.605001) (xy 124.299999 75.605)
+				(xy 123.716786 75.605) (xy 123.716783 75.605001) (xy 123.648749 75.614912) (xy 123.543811 75.666214)
+				(xy 123.461213 75.748812) (xy 123.409912 75.853751) (xy 123.4 75.921784) (xy 122.503187 75.921784)
+				(xy 123.260475 75.164496) (xy 123.314992 75.136719) (xy 123.330479 75.1355) (xy 123.371635 75.1355)
+				(xy 123.429826 75.154407) (xy 123.45561 75.185108) (xy 123.456035 75.184806) (xy 123.459884 75.190197)
+				(xy 123.460576 75.19102) (xy 123.460802 75.191483) (xy 123.543517 75.274198) (xy 123.58704 75.295475)
+				(xy 123.648604 75.325572) (xy 123.648605 75.325572) (xy 123.648607 75.325573) (xy 123.71674 75.3355)
+				(xy 123.716743 75.3355) (xy 125.083257 75.3355) (xy 125.08326 75.3355) (xy 125.151393 75.325573)
+				(xy 125.256483 75.274198) (xy 125.339198 75.191483) (xy 125.390573 75.086393) (xy 125.4005 75.01826)
+				(xy 125.4005 74.65174) (xy 125.390573 74.583607) (xy 125.389007 74.580404) (xy 125.354589 74.51)
+				(xy 125.339198 74.478517) (xy 125.256483 74.395802) (xy 125.254333 74.394751) (xy 125.151395 74.344427)
+				(xy 125.124139 74.340456) (xy 125.08326 74.3345) (xy 123.71674 74.3345) (xy 123.682673 74.339463)
+				(xy 123.648604 74.344427) (xy 123.543518 74.395801) (xy 123.460801 74.478518) (xy 123.460577 74.478978)
+				(xy 123.46018 74.479387) (xy 123.456035 74.485194) (xy 123.455164 74.484572) (xy 123.418035 74.522953)
+				(xy 123.371635 74.5345) (xy 123.129479 74.5345) (xy 123.071288 74.515593) (xy 123.035324 74.466093)
+				(xy 123.035324 74.404907) (xy 123.059475 74.365497) (xy 123.412613 74.012358) (xy 123.46713 73.98458)
+				(xy 123.527562 73.994151) (xy 123.540141 74.001788) (xy 123.543515 74.004197) (xy 123.648604 74.055572)
+				(xy 123.648605 74.055572) (xy 123.648607 74.055573) (xy 123.71674 74.0655) (xy 123.716743 74.0655)
+				(xy 125.083257 74.0655) (xy 125.08326 74.0655) (xy 125.151393 74.055573) (xy 125.256483 74.004198)
+				(xy 125.339198 73.921483) (xy 125.390573 73.816393) (xy 125.4005 73.74826) (xy 125.4005 73.38174)
+				(xy 125.390573 73.313607) (xy 125.387987 73.308318) (xy 125.342314 73.214891) (xy 125.339198 73.208517)
+				(xy 125.256483 73.125802) (xy 125.256481 73.125801) (xy 125.151395 73.074427) (xy 125.124139 73.070456)
+				(xy 125.08326 73.0645) (xy 123.71674 73.0645) (xy 123.682673 73.069463) (xy 123.648604 73.074427)
+				(xy 123.543518 73.125801) (xy 123.460801 73.208518) (xy 123.45895 73.212305) (xy 123.416404 73.256277)
+				(xy 123.395635 73.264446) (xy 123.319012 73.284977) (xy 123.319008 73.284979) (xy 123.250493 73.324536)
+				(xy 123.250488 73.32454) (xy 123.094503 73.480525) (xy 123.039987 73.508302) (xy 122.979555 73.498731)
+				(xy 122.93629 73.455466) (xy 122.9255 73.410521) (xy 122.9255 72.933951) (xy 122.944407 72.87576)
+				(xy 122.979552 72.845742) (xy 123.063342 72.80305) (xy 123.15305 72.713342) (xy 123.210646 72.600304)
+				(xy 123.217025 72.560026) (xy 123.244802 72.50551) (xy 123.299318 72.477732) (xy 123.35975 72.487303)
+				(xy 123.403015 72.530567) (xy 123.409393 72.546285) (xy 123.409425 72.546391) (xy 123.445895 72.620991)
+				(xy 123.460802 72.651483) (xy 123.543517 72.734198) (xy 123.59278 72.758281) (xy 123.648604 72.785572)
+				(xy 123.648605 72.785572) (xy 123.648607 72.785573) (xy 123.71674 72.7955) (xy 123.716743 72.7955)
+				(xy 125.083257 72.7955) (xy 125.08326 72.7955) (xy 125.151393 72.785573) (xy 125.256483 72.734198)
+				(xy 125.339198 72.651483) (xy 125.390573 72.546393) (xy 125.4005 72.47826) (xy 125.4005 72.11174)
+				(xy 125.390573 72.043607) (xy 125.390281 72.04301) (xy 125.352603 71.965938) (xy 125.339198 71.938517)
+				(xy 125.256483 71.855802) (xy 125.245237 71.850304) (xy 125.151395 71.804427) (xy 125.124139 71.800456)
+				(xy 125.08326 71.7945) (xy 125.083257 71.7945) (xy 124.774216 71.7945) (xy 124.716025 71.775593)
+				(xy 124.68848 71.745001) (xy 124.665465 71.705138) (xy 124.429828 71.469501) (xy 124.402053 71.414987)
+				(xy 124.411624 71.354555) (xy 124.454889 71.31129) (xy 124.499834 71.3005) (xy 127.839563 71.3005)
+				(xy 127.839563 71.300499) (xy 127.915989 71.280021) (xy 127.984511 71.24046) (xy 128.04046 71.184511)
+				(xy 128.08481 71.140161) (xy 132.6 71.140161) (xy 132.6 71.219999) (xy 132.600001 71.22) (xy 133.01 71.22)
 				(xy 133.01 70.840001) (xy 133.009999 70.84) (xy 132.900161 70.84) (xy 132.850645 70.846519) (xy 132.850638 70.846521)
 				(xy 132.741978 70.89719) (xy 132.65719 70.981978) (xy 132.606521 71.090638) (xy 132.606519 71.090645)
 				(xy 132.6 71.140161) (xy 128.08481 71.140161) (xy 128.76546 70.459511) (xy 128.770797 70.450265)
@@ -39611,94 +39685,95 @@
 				(xy 130.984291 70.069654) (xy 131.038106 69.951817) (xy 131.041961 69.925001) (xy 131.325001 69.925001)
 				(xy 131.325001 70.056485) (xy 131.339833 70.150141) (xy 131.339836 70.150151) (xy 131.397358 70.263043)
 				(xy 131.486956 70.352641) (xy 131.599848 70.410163) (xy 131.599852 70.410164) (xy 131.693515 70.424999)
-				(xy 131.899998 70.424999) (xy 131.9 70.424998) (xy 131.9 69.925001) (xy 131.899999 69.925) (xy 131.325002 69.925)
-				(xy 131.325001 69.925001) (xy 131.041961 69.925001) (xy 131.054073 69.840762) (xy 131.056542 69.823593)
-				(xy 131.056542 69.823588) (xy 131.038106 69.695365) (xy 130.991577 69.593482) (xy 130.984291 69.577528)
-				(xy 130.899458 69.479624) (xy 130.899457 69.479623) (xy 130.899455 69.479621) (xy 130.894108 69.474988)
-				(xy 130.896108 69.472679) (xy 130.865638 69.435401) (xy 130.862156 69.374314) (xy 130.895245 69.322848)
-				(xy 130.952266 69.30066) (xy 130.957899 69.3005) (xy 131.279857 69.3005) (xy 131.338048 69.319407)
-				(xy 131.374012 69.368907) (xy 131.374012 69.430093) (xy 131.368066 69.444446) (xy 131.339836 69.499848)
-				(xy 131.339835 69.499852) (xy 131.325 69.593515) (xy 131.325 69.724999) (xy 131.325001 69.725) (xy 132.001 69.725)
-				(xy 132.059191 69.743907) (xy 132.095155 69.793407) (xy 132.1 69.824) (xy 132.1 70.424998) (xy 132.100001 70.424999)
-				(xy 132.306483 70.424999) (xy 132.306485 70.424998) (xy 132.400141 70.410166) (xy 132.400151 70.410163)
-				(xy 132.513044 70.35264) (xy 132.513046 70.352639) (xy 132.556212 70.309473) (xy 132.610728 70.281695)
-				(xy 132.67116 70.291266) (xy 132.696538 70.311125) (xy 132.696595 70.31106) (xy 132.697907 70.312197)
-				(xy 132.701033 70.314643) (xy 132.701944 70.315694) (xy 132.701949 70.315699) (xy 132.701951 70.315701)
-				(xy 132.70675 70.318785) (xy 132.723221 70.332057) (xy 132.723387 70.332223) (xy 132.742757 70.343406)
-				(xy 132.763399 70.355324) (xy 132.767421 70.357776) (xy 132.777765 70.364423) (xy 132.810931 70.385738)
-				(xy 132.810937 70.385739) (xy 132.814954 70.387575) (xy 132.819859 70.38967) (xy 132.820117 70.389049)
-				(xy 132.826109 70.39153) (xy 132.826114 70.391533) (xy 132.877096 70.405193) (xy 132.879254 70.405798)
-				(xy 132.935228 70.422234) (xy 132.940691 70.422234) (xy 133.224123 70.422234) (xy 133.282314 70.441141)
-				(xy 133.294127 70.45123) (xy 133.430504 70.587607) (xy 133.458281 70.642124) (xy 133.4595 70.657611)
-				(xy 133.4595 70.745498) (xy 133.440593 70.803689) (xy 133.391093 70.839653) (xy 133.34758 70.843651)
-				(xy 133.319846 70.84) (xy 133.210001 70.84) (xy 133.21 70.840001) (xy 133.21 71.321) (xy 133.191093 71.379191)
-				(xy 133.141593 71.415155) (xy 133.111 71.42) (xy 132.600001 71.42) (xy 132.6 71.420001) (xy 132.6 71.499838)
-				(xy 132.606519 71.549354) (xy 132.606521 71.549361) (xy 132.65719 71.658021) (xy 132.659665 71.660496)
-				(xy 132.661647 71.664387) (xy 132.66216 71.665119) (xy 132.662057 71.665191) (xy 132.687442 71.715013)
-				(xy 132.677871 71.775445) (xy 132.634606 71.81871) (xy 132.589661 71.8295) (xy 132.425585 71.8295)
-				(xy 132.382105 71.819441) (xy 132.368059 71.812574) (xy 132.351394 71.804427) (xy 132.334359 71.801945)
-				(xy 132.28326 71.7945) (xy 130.91674 71.7945) (xy 130.882673 71.799463) (xy 130.848604 71.804427)
-				(xy 130.743518 71.855801) (xy 130.660801 71.938518) (xy 130.609427 72.043604) (xy 130.609427 72.043607)
-				(xy 130.5995 72.11174) (xy 130.5995 72.47826) (xy 130.605226 72.51756) (xy 130.609427 72.546395)
-				(xy 130.645895 72.620991) (xy 130.660802 72.651483) (xy 130.743517 72.734198) (xy 130.79278 72.758281)
-				(xy 130.848604 72.785572) (xy 130.848605 72.785572) (xy 130.848607 72.785573) (xy 130.91674 72.7955)
-				(xy 130.916743 72.7955) (xy 132.283257 72.7955) (xy 132.28326 72.7955) (xy 132.351393 72.785573)
-				(xy 132.412788 72.755559) (xy 132.456268 72.7455) (xy 132.810398 72.7455) (xy 132.842985 72.752725)
-				(xy 132.84324 72.751852) (xy 132.85051 72.75397) (xy 132.850513 72.753972) (xy 132.900099 72.7605)
-				(xy 133.3199 72.760499) (xy 133.369487 72.753972) (xy 133.369494 72.753968) (xy 133.371179 72.753478)
-				(xy 133.372856 72.753529) (xy 133.376998 72.752984) (xy 133.377086 72.753657) (xy 133.432336 72.75534)
-				(xy 133.464539 72.774416) (xy 133.53776 72.839283) (xy 133.677635 72.912696) (xy 133.831015 72.9505)
-				(xy 133.831018 72.9505) (xy 133.988982 72.9505) (xy 133.988985 72.9505) (xy 134.142365 72.912696)
-				(xy 134.28224 72.839283) (xy 134.400483 72.73453) (xy 134.49022 72.604523) (xy 134.546237 72.456818)
-				(xy 134.565278 72.3) (xy 134.563397 72.284511) (xy 134.546237 72.143183) (xy 134.546237 72.143182)
-				(xy 134.49022 71.995477) (xy 134.43536 71.915998) (xy 134.400484 71.865471) (xy 134.400483 71.86547)
-				(xy 134.39385 71.859594) (xy 134.362832 71.806855) (xy 134.3605 71.785492) (xy 134.3605 71.258279)
-				(xy 134.379407 71.200088) (xy 134.428907 71.164124) (xy 134.474988 71.160498) (xy 134.566546 71.174999)
-				(xy 134.725 71.174999) (xy 134.725 70.600001) (xy 134.925 70.600001) (xy 134.925 71.174998) (xy 134.925001 71.174999)
-				(xy 135.083453 71.174999) (xy 135.182965 71.159239) (xy 135.182969 71.159237) (xy 135.302921 71.098118)
-				(xy 135.398118 71.002921) (xy 135.459237 70.882969) (xy 135.475 70.783453) (xy 135.475 70.600001)
-				(xy 135.474999 70.6) (xy 134.925001 70.6) (xy 134.925 70.600001) (xy 134.725 70.600001) (xy 134.725 69.825001)
-				(xy 134.925 69.825001) (xy 134.925 70.399999) (xy 134.925001 70.4) (xy 135.474998 70.4) (xy 135.474999 70.399999)
-				(xy 135.474999 70.216546) (xy 135.459239 70.117034) (xy 135.459237 70.11703) (xy 135.398118 69.997078)
-				(xy 135.302921 69.901881) (xy 135.182969 69.840762) (xy 135.18297 69.840762) (xy 135.083454 69.825)
-				(xy 134.925001 69.825) (xy 134.925 69.825001) (xy 134.725 69.825001) (xy 134.724999 69.825) (xy 134.566547 69.825)
-				(xy 134.566546 69.825001) (xy 134.467034 69.84076) (xy 134.46703 69.840762) (xy 134.347077 69.901882)
-				(xy 134.347075 69.901883) (xy 134.253034 69.995924) (xy 134.198518 70.023701) (xy 134.138085 70.014129)
-				(xy 134.113028 69.995924) (xy 133.728348 69.611245) (xy 133.728343 69.611241) (xy 133.625624 69.551936)
-				(xy 133.62562 69.551934) (xy 133.594398 69.543568) (xy 133.594398 69.543569) (xy 133.523876 69.524672)
-				(xy 133.472563 69.491349) (xy 133.450636 69.434227) (xy 133.4505 69.429046) (xy 133.4505 68.533453)
-				(xy 133.825 68.533453) (xy 133.84076 68.632965) (xy 133.840762 68.632969) (xy 133.901881 68.752921)
-				(xy 133.997078 68.848118) (xy 134.11703 68.909237) (xy 134.117029 68.909237) (xy 134.216545 68.924999)
-				(xy 134.4 68.924999) (xy 134.4 68.375001) (xy 134.6 68.375001) (xy 134.6 68.924998) (xy 134.600001 68.924999)
-				(xy 134.783453 68.924999) (xy 134.882965 68.909239) (xy 134.882969 68.909237) (xy 135.002921 68.848118)
-				(xy 135.098118 68.752921) (xy 135.159237 68.632969) (xy 135.175 68.533453) (xy 135.175 68.375001)
-				(xy 135.174999 68.375) (xy 134.600001 68.375) (xy 134.6 68.375001) (xy 134.4 68.375001) (xy 134.399999 68.375)
-				(xy 133.825002 68.375) (xy 133.825001 68.375001) (xy 133.825001 68.533453) (xy 133.825 68.533453)
-				(xy 133.4505 68.533453) (xy 133.4505 68.12761) (xy 133.469407 68.069419) (xy 133.47949 68.057612)
-				(xy 133.666845 67.870257) (xy 133.721361 67.842481) (xy 133.781793 67.852052) (xy 133.825058 67.895317)
-				(xy 133.834629 67.955749) (xy 133.825 68.016545) (xy 133.825 68.174999) (xy 133.825001 68.175) (xy 134.399999 68.175)
-				(xy 134.4 68.174999) (xy 134.4 67.625001) (xy 134.6 67.625001) (xy 134.6 68.174999) (xy 134.600001 68.175)
-				(xy 135.174998 68.175) (xy 135.174999 68.174999) (xy 135.174999 68.016546) (xy 135.159239 67.917034)
-				(xy 135.159237 67.91703) (xy 135.098118 67.797078) (xy 135.002921 67.701881) (xy 134.882969 67.640762)
-				(xy 134.88297 67.640762) (xy 134.783454 67.625) (xy 134.600001 67.625) (xy 134.6 67.625001) (xy 134.4 67.625001)
-				(xy 134.399999 67.625) (xy 134.21655 67.625) (xy 134.155745 67.63463) (xy 134.095314 67.625056)
-				(xy 134.05205 67.581791) (xy 134.04248 67.521358) (xy 134.070255 67.466846) (xy 134.133443 67.403658)
-				(xy 134.187958 67.375883) (xy 134.212573 67.37589) (xy 134.212628 67.375195) (xy 134.216506 67.3755)
-				(xy 134.216512 67.3755) (xy 134.78349 67.3755) (xy 134.804885 67.372111) (xy 134.883126 67.359719)
-				(xy 135.00322 67.298528) (xy 135.098528 67.20322) (xy 135.133173 67.135225) (xy 135.148801 67.104555)
-				(xy 135.192065 67.06129) (xy 135.23701 67.0505) (xy 135.755463 67.0505) (xy 135.813654 67.069407)
-				(xy 135.849618 67.118907) (xy 135.853428 67.135225) (xy 135.859426 67.176392) (xy 135.875709 67.209699)
-				(xy 135.910802 67.281483) (xy 135.993517 67.364198) (xy 136.017434 67.37589) (xy 136.098604 67.415572)
-				(xy 136.098605 67.415572) (xy 136.098607 67.415573) (xy 136.16674 67.4255) (xy 136.166743 67.4255)
-				(xy 136.533257 67.4255) (xy 136.53326 67.4255) (xy 136.601393 67.415573) (xy 136.706483 67.364198)
-				(xy 136.789198 67.281483) (xy 136.840573 67.176393) (xy 136.8505 67.10826) (xy 136.8505 66.01674)
-				(xy 137.7495 66.01674) (xy 137.7495 67.10826) (xy 137.756118 67.153682) (xy 137.759427 67.176395)
+				(xy 131.899998 70.424999) (xy 131.9 70.424998) (xy 131.9 69.925) (xy 131.325002 69.925) (xy 131.325001 69.925001)
+				(xy 131.041961 69.925001) (xy 131.054073 69.840762) (xy 131.056542 69.823593) (xy 131.056542 69.823588)
+				(xy 131.038106 69.695365) (xy 130.991577 69.593482) (xy 130.984291 69.577528) (xy 130.899458 69.479624)
+				(xy 130.899457 69.479623) (xy 130.899455 69.479621) (xy 130.894108 69.474988) (xy 130.896108 69.472679)
+				(xy 130.865638 69.435401) (xy 130.862156 69.374314) (xy 130.895245 69.322848) (xy 130.952266 69.30066)
+				(xy 130.957899 69.3005) (xy 131.279857 69.3005) (xy 131.338048 69.319407) (xy 131.374012 69.368907)
+				(xy 131.374012 69.430093) (xy 131.368066 69.444446) (xy 131.339836 69.499848) (xy 131.339835 69.499852)
+				(xy 131.325 69.593515) (xy 131.325 69.724999) (xy 131.325001 69.725) (xy 131.901 69.725) (xy 131.959191 69.743907)
+				(xy 131.995155 69.793407) (xy 132 69.824) (xy 132 69.825) (xy 132.001 69.825) (xy 132.059191 69.843907)
+				(xy 132.095155 69.893407) (xy 132.1 69.924) (xy 132.1 70.424998) (xy 132.100001 70.424999) (xy 132.306483 70.424999)
+				(xy 132.306485 70.424998) (xy 132.400141 70.410166) (xy 132.400151 70.410163) (xy 132.513044 70.35264)
+				(xy 132.513046 70.352639) (xy 132.556212 70.309473) (xy 132.610728 70.281695) (xy 132.67116 70.291266)
+				(xy 132.696538 70.311125) (xy 132.696595 70.31106) (xy 132.697907 70.312197) (xy 132.701033 70.314643)
+				(xy 132.701944 70.315694) (xy 132.701949 70.315699) (xy 132.701951 70.315701) (xy 132.70675 70.318785)
+				(xy 132.723221 70.332057) (xy 132.723387 70.332223) (xy 132.742757 70.343406) (xy 132.763399 70.355324)
+				(xy 132.767421 70.357776) (xy 132.777765 70.364423) (xy 132.810931 70.385738) (xy 132.810937 70.385739)
+				(xy 132.814954 70.387575) (xy 132.819859 70.38967) (xy 132.820117 70.389049) (xy 132.826109 70.39153)
+				(xy 132.826114 70.391533) (xy 132.877096 70.405193) (xy 132.879254 70.405798) (xy 132.935228 70.422234)
+				(xy 132.940691 70.422234) (xy 133.224123 70.422234) (xy 133.282314 70.441141) (xy 133.294127 70.45123)
+				(xy 133.430504 70.587607) (xy 133.458281 70.642124) (xy 133.4595 70.657611) (xy 133.4595 70.745498)
+				(xy 133.440593 70.803689) (xy 133.391093 70.839653) (xy 133.34758 70.843651) (xy 133.319846 70.84)
+				(xy 133.210001 70.84) (xy 133.21 70.840001) (xy 133.21 71.221) (xy 133.191093 71.279191) (xy 133.141593 71.315155)
+				(xy 133.111 71.32) (xy 133.11 71.32) (xy 133.11 71.321) (xy 133.091093 71.379191) (xy 133.041593 71.415155)
+				(xy 133.011 71.42) (xy 132.600001 71.42) (xy 132.6 71.420001) (xy 132.6 71.499838) (xy 132.606519 71.549354)
+				(xy 132.606521 71.549361) (xy 132.65719 71.658021) (xy 132.659665 71.660496) (xy 132.661647 71.664387)
+				(xy 132.66216 71.665119) (xy 132.662057 71.665191) (xy 132.687442 71.715013) (xy 132.677871 71.775445)
+				(xy 132.634606 71.81871) (xy 132.589661 71.8295) (xy 132.425585 71.8295) (xy 132.382105 71.819441)
+				(xy 132.368059 71.812574) (xy 132.351394 71.804427) (xy 132.334359 71.801945) (xy 132.28326 71.7945)
+				(xy 130.91674 71.7945) (xy 130.882673 71.799463) (xy 130.848604 71.804427) (xy 130.743518 71.855801)
+				(xy 130.660801 71.938518) (xy 130.609427 72.043604) (xy 130.609427 72.043607) (xy 130.5995 72.11174)
+				(xy 130.5995 72.47826) (xy 130.605226 72.51756) (xy 130.609427 72.546395) (xy 130.645895 72.620991)
+				(xy 130.660802 72.651483) (xy 130.743517 72.734198) (xy 130.79278 72.758281) (xy 130.848604 72.785572)
+				(xy 130.848605 72.785572) (xy 130.848607 72.785573) (xy 130.91674 72.7955) (xy 130.916743 72.7955)
+				(xy 132.283257 72.7955) (xy 132.28326 72.7955) (xy 132.351393 72.785573) (xy 132.412788 72.755559)
+				(xy 132.456268 72.7455) (xy 132.810398 72.7455) (xy 132.842985 72.752725) (xy 132.84324 72.751852)
+				(xy 132.85051 72.75397) (xy 132.850513 72.753972) (xy 132.900099 72.7605) (xy 133.3199 72.760499)
+				(xy 133.369487 72.753972) (xy 133.369494 72.753968) (xy 133.371179 72.753478) (xy 133.372856 72.753529)
+				(xy 133.376998 72.752984) (xy 133.377086 72.753657) (xy 133.432336 72.75534) (xy 133.464539 72.774416)
+				(xy 133.53776 72.839283) (xy 133.677635 72.912696) (xy 133.831015 72.9505) (xy 133.831018 72.9505)
+				(xy 133.988982 72.9505) (xy 133.988985 72.9505) (xy 134.142365 72.912696) (xy 134.28224 72.839283)
+				(xy 134.400483 72.73453) (xy 134.49022 72.604523) (xy 134.546237 72.456818) (xy 134.565278 72.3)
+				(xy 134.563397 72.284511) (xy 134.546237 72.143183) (xy 134.546237 72.143182) (xy 134.49022 71.995477)
+				(xy 134.43536 71.915998) (xy 134.400484 71.865471) (xy 134.400483 71.86547) (xy 134.39385 71.859594)
+				(xy 134.362832 71.806855) (xy 134.3605 71.785492) (xy 134.3605 71.258279) (xy 134.379407 71.200088)
+				(xy 134.428907 71.164124) (xy 134.474988 71.160498) (xy 134.566546 71.174999) (xy 134.725 71.174999)
+				(xy 134.725 70.600001) (xy 134.925 70.600001) (xy 134.925 71.174998) (xy 134.925001 71.174999) (xy 135.083453 71.174999)
+				(xy 135.182965 71.159239) (xy 135.182969 71.159237) (xy 135.302921 71.098118) (xy 135.398118 71.002921)
+				(xy 135.459237 70.882969) (xy 135.475 70.783453) (xy 135.475 70.600001) (xy 135.474999 70.6) (xy 134.925001 70.6)
+				(xy 134.925 70.600001) (xy 134.725 70.600001) (xy 134.725 69.825001) (xy 134.925 69.825001) (xy 134.925 70.399999)
+				(xy 134.925001 70.4) (xy 135.474998 70.4) (xy 135.474999 70.399999) (xy 135.474999 70.216546) (xy 135.459239 70.117034)
+				(xy 135.459237 70.11703) (xy 135.398118 69.997078) (xy 135.302921 69.901881) (xy 135.182969 69.840762)
+				(xy 135.18297 69.840762) (xy 135.083454 69.825) (xy 134.925001 69.825) (xy 134.925 69.825001) (xy 134.725 69.825001)
+				(xy 134.724999 69.825) (xy 134.566547 69.825) (xy 134.566546 69.825001) (xy 134.467034 69.84076)
+				(xy 134.46703 69.840762) (xy 134.347077 69.901882) (xy 134.347075 69.901883) (xy 134.253034 69.995924)
+				(xy 134.198518 70.023701) (xy 134.138085 70.014129) (xy 134.113028 69.995924) (xy 133.728348 69.611245)
+				(xy 133.728343 69.611241) (xy 133.625624 69.551936) (xy 133.62562 69.551934) (xy 133.594398 69.543568)
+				(xy 133.594398 69.543569) (xy 133.523876 69.524672) (xy 133.472563 69.491349) (xy 133.450636 69.434227)
+				(xy 133.4505 69.429046) (xy 133.4505 68.533453) (xy 133.825 68.533453) (xy 133.84076 68.632965)
+				(xy 133.840762 68.632969) (xy 133.901881 68.752921) (xy 133.997078 68.848118) (xy 134.11703 68.909237)
+				(xy 134.117029 68.909237) (xy 134.216545 68.924999) (xy 134.4 68.924999) (xy 134.4 68.375001) (xy 134.6 68.375001)
+				(xy 134.6 68.924998) (xy 134.600001 68.924999) (xy 134.783453 68.924999) (xy 134.882965 68.909239)
+				(xy 134.882969 68.909237) (xy 135.002921 68.848118) (xy 135.098118 68.752921) (xy 135.159237 68.632969)
+				(xy 135.175 68.533453) (xy 135.175 68.375001) (xy 135.174999 68.375) (xy 134.600001 68.375) (xy 134.6 68.375001)
+				(xy 134.4 68.375001) (xy 134.399999 68.375) (xy 133.825002 68.375) (xy 133.825001 68.375001) (xy 133.825001 68.533453)
+				(xy 133.825 68.533453) (xy 133.4505 68.533453) (xy 133.4505 68.12761) (xy 133.469407 68.069419)
+				(xy 133.47949 68.057612) (xy 133.666845 67.870257) (xy 133.721361 67.842481) (xy 133.781793 67.852052)
+				(xy 133.825058 67.895317) (xy 133.834629 67.955749) (xy 133.825 68.016545) (xy 133.825 68.174999)
+				(xy 133.825001 68.175) (xy 134.399999 68.175) (xy 134.4 68.174999) (xy 134.4 67.625001) (xy 134.6 67.625001)
+				(xy 134.6 68.174999) (xy 134.600001 68.175) (xy 135.174998 68.175) (xy 135.174999 68.174999) (xy 135.174999 68.016546)
+				(xy 135.159239 67.917034) (xy 135.159237 67.91703) (xy 135.098118 67.797078) (xy 135.002921 67.701881)
+				(xy 134.882969 67.640762) (xy 134.88297 67.640762) (xy 134.783454 67.625) (xy 134.600001 67.625)
+				(xy 134.6 67.625001) (xy 134.4 67.625001) (xy 134.399999 67.625) (xy 134.21655 67.625) (xy 134.155745 67.63463)
+				(xy 134.095314 67.625056) (xy 134.05205 67.581791) (xy 134.04248 67.521358) (xy 134.070255 67.466846)
+				(xy 134.133443 67.403658) (xy 134.187958 67.375883) (xy 134.212573 67.37589) (xy 134.212628 67.375195)
+				(xy 134.216506 67.3755) (xy 134.216512 67.3755) (xy 134.78349 67.3755) (xy 134.804885 67.372111)
+				(xy 134.883126 67.359719) (xy 135.00322 67.298528) (xy 135.098528 67.20322) (xy 135.133173 67.135225)
+				(xy 135.148801 67.104555) (xy 135.192065 67.06129) (xy 135.23701 67.0505) (xy 135.755463 67.0505)
+				(xy 135.813654 67.069407) (xy 135.849618 67.118907) (xy 135.853428 67.135225) (xy 135.859426 67.176392)
+				(xy 135.875709 67.209699) (xy 135.910802 67.281483) (xy 135.993517 67.364198) (xy 136.017434 67.37589)
+				(xy 136.098604 67.415572) (xy 136.098605 67.415572) (xy 136.098607 67.415573) (xy 136.16674 67.4255)
+				(xy 136.166743 67.4255) (xy 136.533257 67.4255) (xy 136.53326 67.4255) (xy 136.601393 67.415573)
+				(xy 136.706483 67.364198) (xy 136.789198 67.281483) (xy 136.840573 67.176393) (xy 136.8505 67.10826)
+				(xy 136.8505 66.01674) (xy 137.7495 66.01674) (xy 137.7495 67.10826) (xy 137.756118 67.153682) (xy 137.759427 67.176395)
 				(xy 137.802085 67.263652) (xy 137.810802 67.281483) (xy 137.893517 67.364198) (xy 137.917434 67.37589)
 				(xy 137.998604 67.415572) (xy 137.998605 67.415572) (xy 137.998607 67.415573) (xy 138.06674 67.4255)
 				(xy 138.066743 67.4255) (xy 138.433257 67.4255) (xy 138.43326 67.4255) (xy 138.501393 67.415573)
 				(xy 138.606483 67.364198) (xy 138.689198 67.281483) (xy 138.740573 67.176393) (xy 138.7505 67.10826)
 				(xy 138.7505 66.01674) (xy 138.740573 65.948607) (xy 138.718201 65.902845) (xy 138.715483 65.897285)
-				(xy 138.689198 65.843517) (xy 138.606483 65.760802) (xy 138.600152 65.757707) (xy 138.501395 65.709427)
+				(xy 138.689198 65.843517) (xy 138.606483 65.760802) (xy 138.606481 65.760801) (xy 138.501395 65.709427)
 				(xy 138.474139 65.705456) (xy 138.43326 65.6995) (xy 138.06674 65.6995) (xy 138.032673 65.704463)
 				(xy 137.998604 65.709427) (xy 137.893518 65.760801) (xy 137.810801 65.843518) (xy 137.759427 65.948604)
 				(xy 137.759427 65.948607) (xy 137.7495 66.01674) (xy 136.8505 66.01674) (xy 136.840573 65.948607)
@@ -39726,62 +39801,196 @@
 				(xy 134.33341 57.117018) (xy 133.795913 56.57952) (xy 133.79591 56.579518) (xy 133.795908 56.579516)
 				(xy 133.704591 56.526794) (xy 133.704593 56.526794) (xy 133.66507 56.516204) (xy 133.602727 56.4995)
 				(xy 120.752727 56.4995) (xy 120.647273 56.4995) (xy 120.584929 56.516204) (xy 120.545407 56.526794)
-				(xy 120.454091 56.579516) (xy 118.679516 58.354091) (xy 118.626795 58.445406) (xy 118.612033 58.500499)
-				(xy 118.5995 58.547273) (xy 118.5995 59.0505) (xy 118.580593 59.108691) (xy 118.531093 59.144655)
-				(xy 118.5005 59.1495) (xy 116.430252 59.1495) (xy 116.430251 59.1495) (xy 116.430241 59.149501)
-				(xy 116.371772 59.161132) (xy 116.371766 59.161134) (xy 116.305451 59.205445) (xy 116.305445 59.205451)
-				(xy 116.261134 59.271766) (xy 116.261132 59.271772) (xy 116.249501 59.330241) (xy 116.2495 59.330253)
-				(xy 116.2495 59.6255) (xy 116.230593 59.683691) (xy 116.181093 59.719655) (xy 116.1505 59.7245)
-				(xy 107.6495 59.7245) (xy 107.591309 59.705593) (xy 107.555345 59.656093) (xy 107.5505 59.6255)
-				(xy 107.5505 59.330253) (xy 107.550498 59.330241) (xy 107.543858 59.296861) (xy 107.538867 59.271769)
-				(xy 107.494552 59.205448) (xy 107.465008 59.185707) (xy 107.428233 59.161134) (xy 107.428231 59.161133)
-				(xy 107.428228 59.161132) (xy 107.428227 59.161132) (xy 107.369758 59.149501) (xy 107.369748 59.1495)
-				(xy 105.230252 59.1495) (xy 105.230251 59.1495) (xy 105.230241 59.149501) (xy 105.171772 59.161132)
-				(xy 105.171766 59.161134) (xy 105.105451 59.205445) (xy 105.105445 59.205451) (xy 105.061134 59.271766)
-				(xy 105.061132 59.271772) (xy 105.049501 59.330241) (xy 105.0495 59.330253) (xy 105.0495 60.769746)
-				(xy 105.049501 60.769758) (xy 105.061132 60.828227) (xy 105.061134 60.828233) (xy 105.100324 60.886884)
-				(xy 105.105448 60.894552) (xy 105.171769 60.938867) (xy 105.216231 60.947711) (xy 105.230241 60.950498)
-				(xy 105.230246 60.950498) (xy 105.230252 60.9505) (xy 105.230253 60.9505) (xy 107.369747 60.9505)
-				(xy 107.369748 60.9505) (xy 107.428231 60.938867) (xy 107.494552 60.894552) (xy 107.538867 60.828231)
-				(xy 107.5505 60.769748) (xy 107.5505 60.4745) (xy 107.569407 60.416309) (xy 107.618907 60.380345)
-				(xy 107.6495 60.3755) (xy 116.1505 60.3755) (xy 116.208691 60.394407) (xy 116.244655 60.443907)
-				(xy 116.2495 60.4745) (xy 116.2495 60.769746) (xy 116.249501 60.769758) (xy 116.261132 60.828227)
-				(xy 116.261134 60.828233) (xy 116.300324 60.886884) (xy 116.305448 60.894552) (xy 116.371769 60.938867)
-				(xy 116.416231 60.947711) (xy 116.430241 60.950498) (xy 116.430246 60.950498) (xy 116.430252 60.9505)
-				(xy 117.0755 60.9505) (xy 117.133691 60.969407) (xy 117.169655 61.018907) (xy 117.1745 61.0495)
-				(xy 117.1745 61.069609) (xy 117.1745 61.155315) (xy 117.1808 61.178826) (xy 117.196683 61.238105)
-				(xy 117.239531 61.312319) (xy 117.239533 61.312321) (xy 117.239535 61.312324) (xy 118.645505 62.718294)
-				(xy 118.673281 62.772809) (xy 118.6745 62.788296) (xy 118.6745 63.551092) (xy 118.655593 63.609283)
-				(xy 118.606093 63.645247) (xy 118.574561 63.648673) (xy 118.574561 63.65) (xy 117.600001 63.65)
-				(xy 117.6 63.650001) (xy 117.6 65.449999) (xy 117.600001 65.45) (xy 118.574561 65.45) (xy 118.574561 65.452318)
-				(xy 118.625514 65.463469) (xy 118.666181 65.509183) (xy 118.6745 65.548907) (xy 118.6745 65.557147)
-				(xy 118.6745 65.642853) (xy 118.676657 65.650902) (xy 118.696683 65.725643) (xy 118.739531 65.799857)
-				(xy 118.739533 65.799859) (xy 118.739535 65.799862) (xy 119.239533 66.299859) (xy 119.239535 66.299862)
-				(xy 119.275171 66.335498) (xy 119.302947 66.390013) (xy 119.293376 66.450445) (xy 119.250111 66.49371)
-				(xy 119.205166 66.5045) (xy 116.070858 66.5045) (xy 116.012667 66.485593) (xy 115.976703 66.436093)
-				(xy 115.971858 66.4055) (xy 115.971858 66.169983) (xy 115.961359 66.067211) (xy 115.961358 66.067209)
-				(xy 115.961358 66.067203) (xy 115.906173 65.900666) (xy 115.814071 65.751344) (xy 115.690015 65.627288)
-				(xy 115.690012 65.627286) (xy 115.690011 65.627285) (xy 115.540695 65.535187) (xy 115.540694 65.535186)
-				(xy 115.540693 65.535186) (xy 115.374156 65.480001) (xy 115.374153 65.48) (xy 115.271375 65.4695)
-				(xy 114.646342 65.4695) (xy 114.54357 65.479999) (xy 114.543558 65.480002) (xy 114.377022 65.535187)
-				(xy 114.227706 65.627285) (xy 114.103644 65.751347) (xy 114.011546 65.900662) (xy 113.981039 65.992727)
-				(xy 113.944787 66.042016) (xy 113.886487 66.060584) (xy 113.828407 66.041338) (xy 113.803861 66.012862)
-				(xy 113.803558 66.013087) (xy 113.800597 66.009075) (xy 113.799535 66.007843) (xy 113.799153 66.007122)
-				(xy 113.799152 66.007118) (xy 113.722199 65.90285) (xy 113.718513 65.897855) (xy 113.718511 65.897853)
-				(xy 113.718509 65.89785) (xy 113.718505 65.897847) (xy 113.718503 65.897845) (xy 113.609242 65.817207)
-				(xy 113.481062 65.772355) (xy 113.481053 65.772353) (xy 113.450633 65.7695) (xy 113.450625 65.7695)
-				(xy 112.817093 65.7695) (xy 112.817084 65.7695) (xy 112.786664 65.772353) (xy 112.786655 65.772355)
-				(xy 112.658475 65.817207) (xy 112.549214 65.897845) (xy 112.549204 65.897855) (xy 112.468566 66.007116)
-				(xy 112.423714 66.135296) (xy 112.423712 66.135305) (xy 112.420859 66.165725) (xy 112.420859 66.881665)
-				(xy 112.401952 66.939856) (xy 112.391863 66.951669) (xy 112.198028 67.145504) (xy 112.143511 67.173281)
-				(xy 112.128024 67.1745) (xy 111.1695 67.1745) (xy 111.111309 67.155593) (xy 111.075345 67.106093)
-				(xy 111.0705 67.0755) (xy 111.0705 66.170727) (xy 111.070499 66.170725) (xy 111.07043 66.169991)
-				(xy 111.067646 66.140301) (xy 111.022793 66.012118) (xy 111.020547 66.009075) (xy 110.942154 65.902855)
-				(xy 110.942152 65.902853) (xy 110.94215 65.90285) (xy 110.942146 65.902847) (xy 110.942144 65.902845)
-				(xy 110.832883 65.822207) (xy 110.704703 65.777355) (xy 110.704694 65.777353) (xy 110.674274 65.7745)
-				(xy 110.674266 65.7745) (xy 110.040734 65.7745) (xy 110.040725 65.7745) (xy 110.010305 65.777353)
-				(xy 110.010296 65.777355) (xy 109.882116 65.822207) (xy 109.772855 65.902845) (xy 109.772845 65.902855)
-				(xy 109.692207 66.012116) (xy 109.647355 66.140296) (xy 109.647353 66.140305) (xy 109.6445 66.170725)
+				(xy 120.454091 56.579516) (xy 118.679516 58.354091) (xy 118.626795 58.445406) (xy 118.626793 58.44541)
+				(xy 118.626793 58.445412) (xy 118.612033 58.500499) (xy 118.5995 58.547273) (xy 118.5995 61.817273)
+				(xy 118.5995 61.922727) (xy 118.61388 61.976394) (xy 118.626794 62.024592) (xy 118.679516 62.115908)
+				(xy 118.679518 62.11591) (xy 118.67952 62.115913) (xy 119.333556 62.769949) (xy 119.361332 62.824464)
+				(xy 119.362551 62.839951) (xy 119.362551 64.711211) (xy 119.343644 64.769402) (xy 119.336327 64.777969)
+				(xy 119.238513 64.905442) (xy 119.238513 64.905443) (xy 119.178008 65.051515) (xy 119.178006 65.051523)
+				(xy 119.157369 65.208281) (xy 119.157369 65.208282) (xy 119.178006 65.36504) (xy 119.178008 65.365048)
+				(xy 119.238513 65.51112) (xy 119.238513 65.511121) (xy 119.334764 65.636558) (xy 119.334769 65.636564)
+				(xy 119.46021 65.732818) (xy 119.460211 65.732818) (xy 119.460212 65.732819) (xy 119.574523 65.780168)
+				(xy 119.606289 65.793326) (xy 119.72386 65.808804) (xy 119.76305 65.813964) (xy 119.76954 65.813964)
+				(xy 119.76954 65.81683) (xy 119.817943 65.825767) (xy 119.82021 65.827035) (xy 119.900182 65.873207)
+				(xy 120.002039 65.9005) (xy 120.002041 65.900501) (xy 120.002042 65.900501) (xy 120.113559 65.900501)
+				(xy 120.113575 65.9005) (xy 124.252725 65.9005) (xy 124.252727 65.9005) (xy 124.354588 65.873207)
+				(xy 124.35459 65.873205) (xy 124.354592 65.873205) (xy 124.445908 65.820483) (xy 124.445908 65.820482)
+				(xy 124.445913 65.82048) (xy 124.77048 65.495913) (xy 124.781911 65.476114) (xy 124.781913 65.476112)
+				(xy 124.803687 65.438396) (xy 124.823207 65.404587) (xy 124.8505 65.302727) (xy 124.8505 65.069865)
+				(xy 124.869407 65.011674) (xy 124.907448 64.983381) (xy 124.906326 64.981258) (xy 124.912879 64.977793)
+				(xy 124.912882 64.977793) (xy 125.02215 64.89715) (xy 125.102793 64.787882) (xy 125.147646 64.659699)
+				(xy 125.148488 64.650712) (xy 125.14947 64.640255) (xy 125.173728 64.584085) (xy 125.22637 64.5529)
+				(xy 125.248037 64.5505) (xy 125.559309 64.5505) (xy 125.649669 64.526287) (xy 125.649672 64.526287)
+				(xy 125.662903 64.522741) (xy 125.673887 64.519799) (xy 125.776614 64.460489) (xy 126.460489 63.776614)
+				(xy 126.519799 63.673887) (xy 126.526199 63.650001) (xy 126.532728 63.625638) (xy 126.539463 63.6005)
+				(xy 126.5505 63.559309) (xy 126.5505 62.6745) (xy 126.569407 62.616309) (xy 126.618907 62.580345)
+				(xy 126.6495 62.5755) (xy 126.761882 62.5755) (xy 126.761882 62.575499) (xy 126.785333 62.572779)
+				(xy 126.881267 62.53042) (xy 126.95542 62.456267) (xy 126.997779 62.360333) (xy 127.0005 62.33688)
+				(xy 127.0005 61.767501) (xy 132.08 61.767501) (xy 132.08 62.055856) (xy 132.095231 62.132423) (xy 132.09523 62.132423)
+				(xy 132.153246 62.219249) (xy 132.153251 62.219254) (xy 132.240075 62.277269) (xy 132.240078 62.27727)
+				(xy 132.304999 62.290183) (xy 132.305 62.290182) (xy 132.305 61.767501) (xy 132.304999 61.7675)
+				(xy 132.080001 61.7675) (xy 132.08 61.767501) (xy 127.0005 61.767501) (xy 127.0005 61.61312) (xy 126.997779 61.589667)
+				(xy 126.95542 61.493733) (xy 126.881267 61.41958) (xy 126.785333 61.377221) (xy 126.785332 61.37722)
+				(xy 126.78533 61.37722) (xy 126.761884 61.3745) (xy 126.76188 61.3745) (xy 125.43812 61.3745) (xy 125.438115 61.3745)
+				(xy 125.414669 61.37722) (xy 125.318731 61.419581) (xy 125.25658 61.481732) (xy 125.202063 61.509509)
+				(xy 125.141631 61.499937) (xy 125.098367 61.456672) (xy 125.087882 61.403963) (xy 125.097706 61.279143)
+				(xy 132.08 61.279143) (xy 132.08 61.567499) (xy 132.080001 61.5675) (xy 132.304999 61.5675) (xy 132.305 61.567499)
+				(xy 132.305 61.044816) (xy 132.505 61.044816) (xy 132.505 61.567499) (xy 132.505001 61.5675) (xy 132.805 61.5675)
+				(xy 132.805 61.044816) (xy 132.740075 61.057731) (xy 132.740074 61.057731) (xy 132.710001 61.077826)
+				(xy 132.651113 61.094434) (xy 132.599999 61.077826) (xy 132.569925 61.057731) (xy 132.505 61.044816)
+				(xy 132.305 61.044816) (xy 132.240076 61.057731) (xy 132.15325 61.115746) (xy 132.153246 61.11575)
+				(xy 132.095231 61.202576) (xy 132.08 61.279143) (xy 125.097706 61.279143) (xy 125.1 61.25) (xy 125.087882 61.096036)
+				(xy 125.102165 61.036544) (xy 125.148691 60.996807) (xy 125.209688 60.992006) (xy 125.256578 61.018265)
+				(xy 125.318733 61.08042) (xy 125.414667 61.122779) (xy 125.438116 61.125499) (xy 125.438118 61.1255)
+				(xy 125.43812 61.1255) (xy 126.761882 61.1255) (xy 126.761882 61.125499) (xy 126.785333 61.122779)
+				(xy 126.881267 61.08042) (xy 126.95542 61.006267) (xy 126.997779 60.910333) (xy 126.997779 60.910327)
+				(xy 126.999734 60.903147) (xy 127.001762 60.903699) (xy 127.022943 60.85747) (xy 127.076257 60.827448)
+				(xy 127.095799 60.8255) (xy 129.214563 60.8255) (xy 129.214563 60.825499) (xy 129.290989 60.805021)
+				(xy 129.359511 60.76546) (xy 129.41546 60.709511) (xy 131.027975 59.096996) (xy 131.082492 59.069219)
+				(xy 131.097979 59.068) (xy 131.981115 59.068) (xy 132.039306 59.086907) (xy 132.07527 59.136407)
+				(xy 132.078357 59.151168) (xy 132.078552 59.15113) (xy 132.094759 59.232616) (xy 132.09476 59.232618)
+				(xy 132.137686 59.296861) (xy 132.152888 59.319612) (xy 132.239883 59.37774) (xy 132.316599 59.393)
+				(xy 132.4934 59.392999) (xy 132.570117 59.37774) (xy 132.599998 59.357773) (xy 132.658886 59.341165)
+				(xy 132.710002 59.357774) (xy 132.739879 59.377738) (xy 132.73988 59.377738) (xy 132.739883 59.37774)
+				(xy 132.816599 59.393) (xy 132.9934 59.392999) (xy 133.070117 59.37774) (xy 133.099998 59.357773)
+				(xy 133.158886 59.341165) (xy 133.210002 59.357774) (xy 133.239879 59.377738) (xy 133.23988 59.377738)
+				(xy 133.239883 59.37774) (xy 133.316599 59.393) (xy 133.4934 59.392999) (xy 133.570117 59.37774)
+				(xy 133.599998 59.357773) (xy 133.658886 59.341165) (xy 133.710002 59.357774) (xy 133.739879 59.377738)
+				(xy 133.73988 59.377738) (xy 133.739883 59.37774) (xy 133.816599 59.393) (xy 133.9934 59.392999)
+				(xy 134.070117 59.37774) (xy 134.099998 59.357773) (xy 134.158886 59.341165) (xy 134.210002 59.357774)
+				(xy 134.239879 59.377738) (xy 134.23988 59.377738) (xy 134.239883 59.37774) (xy 134.316599 59.393)
+				(xy 134.4934 59.392999) (xy 134.570117 59.37774) (xy 134.570116 59.37774) (xy 134.57968 59.375838)
+				(xy 134.580399 59.379453) (xy 134.623569 59.376036) (xy 134.675752 59.407982) (xy 134.699191 59.4645)
+				(xy 134.6995 59.472311) (xy 134.6995 60.962688) (xy 134.680593 61.020879) (xy 134.631093 61.056843)
+				(xy 134.58014 61.056843) (xy 134.579679 61.059162) (xy 134.49341 61.042001) (xy 134.493402 61.042)
+				(xy 134.493401 61.042) (xy 134.4934 61.042) (xy 134.316602 61.042) (xy 134.316595 61.042001) (xy 134.239884 61.057259)
+				(xy 134.21 61.077227) (xy 134.151111 61.093834) (xy 134.099999 61.077226) (xy 134.070119 61.057261)
+				(xy 134.070117 61.05726) (xy 134.070114 61.057259) (xy 134.070113 61.057259) (xy 133.99341 61.042001)
+				(xy 133.993402 61.042) (xy 133.993401 61.042) (xy 133.9934 61.042) (xy 133.816602 61.042) (xy 133.816595 61.042001)
+				(xy 133.739884 61.057259) (xy 133.71 61.077227) (xy 133.651111 61.093834) (xy 133.599999 61.077226)
+				(xy 133.570119 61.057261) (xy 133.570117 61.05726) (xy 133.570114 61.057259) (xy 133.570113 61.057259)
+				(xy 133.49341 61.042001) (xy 133.493402 61.042) (xy 133.493401 61.042) (xy 133.4934 61.042) (xy 133.316602 61.042)
+				(xy 133.316595 61.042001) (xy 133.239884 61.057259) (xy 133.239882 61.05726) (xy 133.209549 61.077527)
+				(xy 133.15066 61.094134) (xy 133.099548 61.077525) (xy 133.069924 61.057731) (xy 133.005 61.044816)
+				(xy 133.005 61.5685) (xy 132.986093 61.626691) (xy 132.936593 61.662655) (xy 132.906 61.6675) (xy 132.905 61.6675)
+				(xy 132.905 61.6685) (xy 132.886093 61.726691) (xy 132.836593 61.762655) (xy 132.806 61.7675) (xy 132.505001 61.7675)
+				(xy 132.505 61.767501) (xy 132.505 62.292322) (xy 132.5351 62.339344) (xy 132.531498 62.400423)
+				(xy 132.509312 62.434345) (xy 126.915489 68.028168) (xy 126.915488 68.028167) (xy 126.859539 68.084117)
+				(xy 126.81998 68.152635) (xy 126.819978 68.152639) (xy 126.7995 68.229063) (xy 126.7995 68.834521)
+				(xy 126.780593 68.892712) (xy 126.770503 68.904525) (xy 126.614701 69.060326) (xy 126.560185 69.088103)
+				(xy 126.499753 69.078532) (xy 126.456488 69.035267) (xy 126.446321 68.979237) (xy 126.455249 68.900003)
+				(xy 126.455249 68.899995) (xy 126.436314 68.731946) (xy 126.436311 68.731934) (xy 126.40168 68.632965)
+				(xy 126.380456 68.57231) (xy 126.35604 68.533453) (xy 126.290479 68.429113) (xy 126.290478 68.429112)
+				(xy 126.290477 68.42911) (xy 126.17089 68.309523) (xy 126.170887 68.309521) (xy 126.170886 68.30952)
+				(xy 126.027691 68.219544) (xy 125.868065 68.163688) (xy 125.868053 68.163685) (xy 125.700004 68.144751)
+				(xy 125.699996 68.144751) (xy 125.531946 68.163685) (xy 125.531934 68.163688) (xy 125.372309 68.219544)
+				(xy 125.372308 68.219544) (xy 125.308997 68.259326) (xy 125.256326 68.2745) (xy 124.523943 68.2745)
+				(xy 124.465752 68.255593) (xy 124.429788 68.206093) (xy 124.429788 68.144907) (xy 124.43389 68.134372)
+				(xy 124.436698 68.128223) (xy 124.455133 68.000002) (xy 124.455133 67.999997) (xy 124.436697 67.871774)
+				(xy 124.406793 67.806295) (xy 124.382882 67.753937) (xy 124.298049 67.656033) (xy 124.298048 67.656032)
+				(xy 124.298047 67.656031) (xy 124.189073 67.585998) (xy 124.18907 67.585996) (xy 124.189069 67.585996)
+				(xy 124.174748 67.581791) (xy 124.064774 67.5495) (xy 124.064772 67.5495) (xy 124.050835 67.5495)
+				(xy 123.992644 67.530593) (xy 123.980831 67.520504) (xy 123.340498 66.880171) (xy 122.699862 66.239535)
+				(xy 122.699859 66.239533) (xy 122.699858 66.239532) (xy 122.699857 66.239531) (xy 122.625642 66.196683)
+				(xy 122.625644 66.196683) (xy 122.593521 66.188076) (xy 122.542853 66.1745) (xy 122.542851 66.1745)
+				(xy 119.475835 66.1745) (xy 119.417644 66.155593) (xy 119.405831 66.145504) (xy 118.854496 65.594169)
+				(xy 118.826719 65.539652) (xy 118.8255 65.524165) (xy 118.8255 63.457148) (xy 118.8255 63.457147)
+				(xy 118.805904 63.384012) (xy 118.803318 63.374361) (xy 118.796253 63.362124) (xy 118.781893 63.337251)
+				(xy 118.781889 63.337247) (xy 118.760465 63.300138) (xy 118.699862 63.239535) (xy 118.699859 63.239533)
+				(xy 116.804496 61.344169) (xy 116.776719 61.289652) (xy 116.7755 61.274165) (xy 116.7755 61.0495)
+				(xy 116.794407 60.991309) (xy 116.843907 60.955345) (xy 116.8745 60.9505) (xy 117.519747 60.9505)
+				(xy 117.519748 60.9505) (xy 117.578231 60.938867) (xy 117.644552 60.894552) (xy 117.688867 60.828231)
+				(xy 117.7005 60.769748) (xy 117.7005 59.330252) (xy 117.688867 59.271769) (xy 117.644552 59.205448)
+				(xy 117.615008 59.185707) (xy 117.578233 59.161134) (xy 117.578231 59.161133) (xy 117.578228 59.161132)
+				(xy 117.578227 59.161132) (xy 117.519758 59.149501) (xy 117.519748 59.1495) (xy 115.380252 59.1495)
+				(xy 115.380251 59.1495) (xy 115.380241 59.149501) (xy 115.321772 59.161132) (xy 115.321766 59.161134)
+				(xy 115.255451 59.205445) (xy 115.255445 59.205451) (xy 115.211134 59.271766) (xy 115.211132 59.271772)
+				(xy 115.199501 59.330241) (xy 115.1995 59.330253) (xy 115.1995 59.6255) (xy 115.180593 59.683691)
+				(xy 115.131093 59.719655) (xy 115.1005 59.7245) (xy 108.6995 59.7245) (xy 108.641309 59.705593)
+				(xy 108.605345 59.656093) (xy 108.6005 59.6255) (xy 108.6005 59.330253) (xy 108.600498 59.330241)
+				(xy 108.593858 59.296861) (xy 108.588867 59.271769) (xy 108.544552 59.205448) (xy 108.515008 59.185707)
+				(xy 108.478233 59.161134) (xy 108.478231 59.161133) (xy 108.478228 59.161132) (xy 108.478227 59.161132)
+				(xy 108.419758 59.149501) (xy 108.419748 59.1495) (xy 106.280252 59.1495) (xy 106.280251 59.1495)
+				(xy 106.280241 59.149501) (xy 106.221772 59.161132) (xy 106.221766 59.161134) (xy 106.155451 59.205445)
+				(xy 106.155445 59.205451) (xy 106.111134 59.271766) (xy 106.111132 59.271772) (xy 106.099501 59.330241)
+				(xy 106.0995 59.330253) (xy 106.0995 60.769746) (xy 106.099501 60.769758) (xy 106.111132 60.828227)
+				(xy 106.111134 60.828233) (xy 106.150324 60.886884) (xy 106.155448 60.894552) (xy 106.221769 60.938867)
+				(xy 106.266231 60.947711) (xy 106.280241 60.950498) (xy 106.280246 60.950498) (xy 106.280252 60.9505)
+				(xy 106.280253 60.9505) (xy 108.419747 60.9505) (xy 108.419748 60.9505) (xy 108.478231 60.938867)
+				(xy 108.544552 60.894552) (xy 108.588867 60.828231) (xy 108.6005 60.769748) (xy 108.6005 60.4745)
+				(xy 108.619407 60.416309) (xy 108.668907 60.380345) (xy 108.6995 60.3755) (xy 115.1005 60.3755)
+				(xy 115.158691 60.394407) (xy 115.194655 60.443907) (xy 115.1995 60.4745) (xy 115.1995 60.769746)
+				(xy 115.199501 60.769758) (xy 115.211132 60.828227) (xy 115.211134 60.828233) (xy 115.250324 60.886884)
+				(xy 115.255448 60.894552) (xy 115.321769 60.938867) (xy 115.366231 60.947711) (xy 115.380241 60.950498)
+				(xy 115.380246 60.950498) (xy 115.380252 60.9505) (xy 116.0255 60.9505) (xy 116.083691 60.969407)
+				(xy 116.119655 61.018907) (xy 116.1245 61.0495) (xy 116.1245 61.407147) (xy 116.1245 61.492853)
+				(xy 116.128557 61.507993) (xy 116.146683 61.575643) (xy 116.189531 61.649857) (xy 116.189533 61.649859)
+				(xy 116.189535 61.649862) (xy 117.183581 62.643907) (xy 118.145504 63.60583) (xy 118.173281 63.660347)
+				(xy 118.1745 63.675834) (xy 118.1745 65.657147) (xy 118.1745 65.742853) (xy 118.190172 65.801344)
+				(xy 118.196683 65.825643) (xy 118.239531 65.899857) (xy 118.239535 65.899862) (xy 118.545169 66.205497)
+				(xy 118.572946 66.260013) (xy 118.563375 66.320445) (xy 118.52011 66.36371) (xy 118.475165 66.3745)
+				(xy 116.33138 66.3745) (xy 116.273189 66.355593) (xy 116.261376 66.345504) (xy 116.187141 66.271269)
+				(xy 116.187141 66.271268) (xy 116.100017 66.184143) (xy 116.04817 66.1495) (xy 116.034403 66.140301)
+				(xy 115.99997 66.117293) (xy 115.962092 66.069244) (xy 115.961012 66.066161) (xy 115.906173 65.900666)
+				(xy 115.844911 65.801344) (xy 115.814073 65.751347) (xy 115.814072 65.751346) (xy 115.814071 65.751344)
+				(xy 115.690015 65.627288) (xy 115.690012 65.627286) (xy 115.690011 65.627285) (xy 115.689213 65.626654)
+				(xy 115.68888 65.626154) (xy 115.685937 65.623211) (xy 115.686527 65.62262) (xy 115.655297 65.575729)
+				(xy 115.657792 65.514594) (xy 115.695744 65.466601) (xy 115.750621 65.45) (xy 116.349999 65.45)
+				(xy 116.35 65.449999) (xy 116.35 64.650001) (xy 116.55 64.650001) (xy 116.55 65.449999) (xy 116.550001 65.45)
+				(xy 117.519697 65.45) (xy 117.5197 65.449999) (xy 117.578036 65.438396) (xy 117.644189 65.394193)
+				(xy 117.644193 65.394189) (xy 117.688396 65.328036) (xy 117.699999 65.2697) (xy 117.7 65.269697)
+				(xy 117.7 64.650001) (xy 117.699999 64.65) (xy 116.550001 64.65) (xy 116.55 64.650001) (xy 116.35 64.650001)
+				(xy 116.349999 64.65) (xy 115.200001 64.65) (xy 115.2 64.650001) (xy 115.2 65.2697) (xy 115.211603 65.328036)
+				(xy 115.2135 65.332614) (xy 115.218301 65.393611) (xy 115.186332 65.44578) (xy 115.129804 65.469195)
+				(xy 115.122036 65.4695) (xy 114.646342 65.4695) (xy 114.54357 65.479999) (xy 114.543558 65.480002)
+				(xy 114.377022 65.535187) (xy 114.227706 65.627285) (xy 114.103644 65.751347) (xy 114.011546 65.900662)
+				(xy 113.981039 65.992727) (xy 113.944787 66.042016) (xy 113.886487 66.060584) (xy 113.828407 66.041338)
+				(xy 113.803861 66.012862) (xy 113.803558 66.013087) (xy 113.800597 66.009075) (xy 113.799535 66.007843)
+				(xy 113.799153 66.007122) (xy 113.799152 66.007118) (xy 113.722199 65.90285) (xy 113.718513 65.897855)
+				(xy 113.718511 65.897853) (xy 113.718509 65.89785) (xy 113.718505 65.897847) (xy 113.718503 65.897845)
+				(xy 113.609242 65.817207) (xy 113.481062 65.772355) (xy 113.481053 65.772353) (xy 113.450633 65.7695)
+				(xy 113.450625 65.7695) (xy 112.817093 65.7695) (xy 112.817084 65.7695) (xy 112.786664 65.772353)
+				(xy 112.786655 65.772355) (xy 112.658475 65.817207) (xy 112.549214 65.897845) (xy 112.549204 65.897855)
+				(xy 112.468566 66.007116) (xy 112.423714 66.135296) (xy 112.423712 66.135305) (xy 112.420859 66.165725)
+				(xy 112.420859 66.881665) (xy 112.401952 66.939856) (xy 112.391863 66.951669) (xy 112.198028 67.145504)
+				(xy 112.143511 67.173281) (xy 112.128024 67.1745) (xy 111.1695 67.1745) (xy 111.111309 67.155593)
+				(xy 111.075345 67.106093) (xy 111.0705 67.0755) (xy 111.0705 66.170727) (xy 111.070499 66.170725)
+				(xy 111.06908 66.155593) (xy 111.067646 66.140301) (xy 111.022793 66.012118) (xy 111.020547 66.009075)
+				(xy 110.942154 65.902855) (xy 110.942152 65.902853) (xy 110.94215 65.90285) (xy 110.942146 65.902847)
+				(xy 110.942144 65.902845) (xy 110.832883 65.822207) (xy 110.704703 65.777355) (xy 110.704694 65.777353)
+				(xy 110.674274 65.7745) (xy 110.674266 65.7745) (xy 110.132334 65.7745) (xy 110.074143 65.755593)
+				(xy 110.038179 65.706093) (xy 110.038179 65.644907) (xy 110.06233 65.605496) (xy 111.837527 63.830299)
+				(xy 115.2 63.830299) (xy 115.2 64.449999) (xy 115.200001 64.45) (xy 116.349999 64.45) (xy 116.35 64.449999)
+				(xy 116.35 63.650001) (xy 116.55 63.650001) (xy 116.55 64.449999) (xy 116.550001 64.45) (xy 117.699999 64.45)
+				(xy 117.7 64.449999) (xy 117.7 63.830302) (xy 117.699999 63.830299) (xy 117.688396 63.771963) (xy 117.644193 63.70581)
+				(xy 117.644189 63.705806) (xy 117.578036 63.661603) (xy 117.5197 63.65) (xy 116.550001 63.65) (xy 116.55 63.650001)
+				(xy 116.35 63.650001) (xy 116.349999 63.65) (xy 115.380299 63.65) (xy 115.321963 63.661603) (xy 115.25581 63.705806)
+				(xy 115.255806 63.70581) (xy 115.211603 63.771963) (xy 115.2 63.830299) (xy 111.837527 63.830299)
+				(xy 112.51333 63.154496) (xy 112.567847 63.126719) (xy 112.583334 63.1255) (xy 116.044147 63.1255)
+				(xy 116.09767 63.141216) (xy 116.153902 63.177354) (xy 116.210931 63.214004) (xy 116.335228 63.2505)
+				(xy 116.33523 63.2505) (xy 116.46477 63.2505) (xy 116.464772 63.2505) (xy 116.589069 63.214004)
+				(xy 116.698049 63.143967) (xy 116.782882 63.046063) (xy 116.836697 62.928226) (xy 116.850025 62.835528)
+				(xy 116.855133 62.800002) (xy 116.855133 62.799997) (xy 116.836697 62.671774) (xy 116.823078 62.641954)
+				(xy 116.782882 62.553937) (xy 116.698049 62.456033) (xy 116.698048 62.456032) (xy 116.698047 62.456031)
+				(xy 116.589073 62.385998) (xy 116.58907 62.385996) (xy 116.589069 62.385996) (xy 116.573345 62.381379)
+				(xy 116.464774 62.3495) (xy 116.464772 62.3495) (xy 116.335228 62.3495) (xy 116.335225 62.3495)
+				(xy 116.210933 62.385995) (xy 116.210926 62.385998) (xy 116.09767 62.458784) (xy 116.044147 62.4745)
+				(xy 112.456432 62.4745) (xy 112.456416 62.474499) (xy 112.450353 62.474499) (xy 112.364648 62.474499)
+				(xy 112.364645 62.474499) (xy 112.286273 62.4955) (xy 112.283356 62.496281) (xy 112.281857 62.496683)
+				(xy 112.207638 62.539534) (xy 112.147034 62.600137) (xy 112.147035 62.600138) (xy 112.147033 62.60014)
+				(xy 108.990443 65.756728) (xy 108.935926 65.784505) (xy 108.887741 65.780168) (xy 108.879699 65.777354)
+				(xy 108.879697 65.777353) (xy 108.879695 65.777353) (xy 108.849274 65.7745) (xy 108.849266 65.7745)
+				(xy 108.215734 65.7745) (xy 108.215725 65.7745) (xy 108.185305 65.777353) (xy 108.185296 65.777355)
+				(xy 108.057116 65.822207) (xy 107.947855 65.902845) (xy 107.947845 65.902855) (xy 107.867207 66.012116)
+				(xy 107.822355 66.140296) (xy 107.822353 66.140305) (xy 107.8195 66.170725) (xy 107.8195 67.179274)
+				(xy 107.822353 67.209694) (xy 107.822355 67.209703) (xy 107.867207 67.337883) (xy 107.947845 67.447144)
+				(xy 107.947847 67.447146) (xy 107.94785 67.44715) (xy 107.947853 67.447152) (xy 107.947855 67.447154)
+				(xy 108.057116 67.527792) (xy 108.057117 67.527792) (xy 108.057118 67.527793) (xy 108.185301 67.572646)
+				(xy 108.215725 67.575499) (xy 108.215727 67.5755) (xy 108.215734 67.5755) (xy 108.849273 67.5755)
+				(xy 108.849273 67.575499) (xy 108.879699 67.572646) (xy 109.007882 67.527793) (xy 109.11715 67.44715)
+				(xy 109.197793 67.337882) (xy 109.242646 67.209699) (xy 109.245499 67.179273) (xy 109.2455 67.179273)
+				(xy 109.2455 66.463334) (xy 109.264407 66.405143) (xy 109.274496 66.39333) (xy 109.475496 66.19233)
+				(xy 109.530013 66.164553) (xy 109.590445 66.174124) (xy 109.63371 66.217389) (xy 109.6445 66.262334)
 				(xy 109.6445 67.179274) (xy 109.647353 67.209694) (xy 109.647355 67.209703) (xy 109.692207 67.337883)
 				(xy 109.772845 67.447144) (xy 109.772847 67.447146) (xy 109.77285 67.44715) (xy 109.772853 67.447152)
 				(xy 109.772855 67.447154) (xy 109.888087 67.532199) (xy 109.88643 67.534443) (xy 109.920335 67.569368)
@@ -39795,117 +40004,82 @@
 				(xy 106.81249 67.687018) (xy 106.77454 67.647913) (xy 106.765875 67.587344) (xy 106.794466 67.53325)
 				(xy 106.832269 67.510321) (xy 106.924334 67.479814) (xy 107.073656 67.387712) (xy 107.197712 67.263656)
 				(xy 107.289814 67.114334) (xy 107.344999 66.947797) (xy 107.3555 66.845009) (xy 107.355499 66.219992)
-				(xy 107.355499 66.219991) (xy 107.355499 66.219983) (xy 107.350467 66.170725) (xy 107.8195 66.170725)
-				(xy 107.8195 67.179274) (xy 107.822353 67.209694) (xy 107.822355 67.209703) (xy 107.867207 67.337883)
-				(xy 107.947845 67.447144) (xy 107.947847 67.447146) (xy 107.94785 67.44715) (xy 107.947853 67.447152)
-				(xy 107.947855 67.447154) (xy 108.057116 67.527792) (xy 108.057117 67.527792) (xy 108.057118 67.527793)
-				(xy 108.185301 67.572646) (xy 108.215725 67.575499) (xy 108.215727 67.5755) (xy 108.215734 67.5755)
-				(xy 108.849273 67.5755) (xy 108.849273 67.575499) (xy 108.879699 67.572646) (xy 109.007882 67.527793)
-				(xy 109.11715 67.44715) (xy 109.197793 67.337882) (xy 109.242646 67.209699) (xy 109.245499 67.179273)
-				(xy 109.2455 67.179273) (xy 109.2455 66.170727) (xy 109.245499 66.170725) (xy 109.24543 66.169991)
-				(xy 109.242646 66.140301) (xy 109.197793 66.012118) (xy 109.195547 66.009075) (xy 109.117154 65.902855)
-				(xy 109.117152 65.902853) (xy 109.11715 65.90285) (xy 109.117146 65.902847) (xy 109.117144 65.902845)
-				(xy 109.007885 65.822208) (xy 109.002946 65.82048) (xy 108.95676 65.804318) (xy 108.908081 65.767254)
-				(xy 108.890484 65.708654) (xy 108.910692 65.650902) (xy 108.919448 65.640878) (xy 109.705831 64.854496)
-				(xy 109.760348 64.826719) (xy 109.775835 64.8255) (xy 115.242851 64.8255) (xy 115.242853 64.8255)
-				(xy 115.325639 64.803318) (xy 115.325641 64.803316) (xy 115.325643 64.803316) (xy 115.399857 64.760468)
-				(xy 115.399857 64.760467) (xy 115.399862 64.760465) (xy 115.510326 64.650001) (xy 116.25 64.650001)
-				(xy 116.25 65.2697) (xy 116.261603 65.328036) (xy 116.305806 65.394189) (xy 116.30581 65.394193)
-				(xy 116.371963 65.438396) (xy 116.430299 65.449999) (xy 116.430303 65.45) (xy 117.399999 65.45)
-				(xy 117.4 65.449999) (xy 117.4 64.650001) (xy 117.399999 64.65) (xy 116.250001 64.65) (xy 116.25 64.650001)
-				(xy 115.510326 64.650001) (xy 115.531124 64.629203) (xy 115.580832 64.579496) (xy 115.635348 64.551719)
-				(xy 115.650835 64.5505) (xy 115.66477 64.5505) (xy 115.664772 64.5505) (xy 115.789069 64.514004)
-				(xy 115.898049 64.443967) (xy 115.982882 64.346063) (xy 116.036697 64.228226) (xy 116.048591 64.145502)
-				(xy 116.053008 64.114782) (xy 116.059581 64.101412) (xy 116.057426 64.096102) (xy 116.241885 64.096102)
-				(xy 116.25 64.128871) (xy 116.25 64.449999) (xy 116.250001 64.45) (xy 117.399999 64.45) (xy 117.4 64.449999)
-				(xy 117.4 63.650001) (xy 117.399999 63.65) (xy 116.430299 63.65) (xy 116.371963 63.661603) (xy 116.30581 63.705806)
-				(xy 116.305806 63.70581) (xy 116.261603 63.771963) (xy 116.25 63.830299) (xy 116.25 64.071128) (xy 116.241885 64.096102)
-				(xy 116.057426 64.096102) (xy 116.053008 64.085217) (xy 116.036697 63.971774) (xy 115.982882 63.853938)
-				(xy 115.982882 63.853937) (xy 115.898049 63.756033) (xy 115.898048 63.756032) (xy 115.898047 63.756031)
-				(xy 115.789073 63.685998) (xy 115.78907 63.685996) (xy 115.789069 63.685996) (xy 115.789066 63.685995)
-				(xy 115.664774 63.6495) (xy 115.664772 63.6495) (xy 115.535228 63.6495) (xy 115.535225 63.6495)
-				(xy 115.410933 63.685995) (xy 115.410926 63.685998) (xy 115.301952 63.756031) (xy 115.217117 63.853938)
-				(xy 115.163302 63.971774) (xy 115.150428 64.061318) (xy 115.123432 64.116226) (xy 115.122441 64.117231)
-				(xy 115.094171 64.145502) (xy 115.039655 64.173281) (xy 115.024166 64.1745) (xy 109.642853 64.1745)
-				(xy 109.557147 64.1745) (xy 109.506478 64.188076) (xy 109.474356 64.196683) (xy 109.400142 64.239531)
-				(xy 108.272031 65.367642) (xy 108.229183 65.441857) (xy 108.229181 65.441861) (xy 108.220003 65.476112)
-				(xy 108.220004 65.476113) (xy 108.207 65.524647) (xy 108.207 65.699516) (xy 108.188093 65.757707)
-				(xy 108.140699 65.79296) (xy 108.057115 65.822207) (xy 107.947855 65.902845) (xy 107.947845 65.902855)
-				(xy 107.867207 66.012116) (xy 107.822355 66.140296) (xy 107.822353 66.140305) (xy 107.8195 66.170725)
-				(xy 107.350467 66.170725) (xy 107.345 66.117211) (xy 107.344999 66.117209) (xy 107.344999 66.117203)
-				(xy 107.289814 65.950666) (xy 107.197712 65.801344) (xy 107.073656 65.677288) (xy 107.073653 65.677286)
-				(xy 107.073652 65.677285) (xy 107.002277 65.633261) (xy 106.962675 65.58662) (xy 106.958052 65.525609)
-				(xy 106.990173 65.473533) (xy 107.046768 65.450283) (xy 107.054249 65.45) (xy 107.369697 65.45)
-				(xy 107.3697 65.449999) (xy 107.428036 65.438396) (xy 107.494189 65.394193) (xy 107.494193 65.394189)
-				(xy 107.538396 65.328036) (xy 107.549999 65.2697) (xy 107.55 65.269697) (xy 107.55 64.650001) (xy 107.549999 64.65)
-				(xy 105.050001 64.65) (xy 105.05 64.650001) (xy 105.05 65.2697) (xy 105.061603 65.328036) (xy 105.105806 65.394189)
-				(xy 105.10581 65.394193) (xy 105.171963 65.438396) (xy 105.230299 65.449999) (xy 105.230303 65.45)
-				(xy 105.255751 65.45) (xy 105.313942 65.468907) (xy 105.349906 65.518407) (xy 105.349906 65.579593)
-				(xy 105.313942 65.629093) (xy 105.307723 65.633261) (xy 105.236347 65.677285) (xy 105.112285 65.801347)
-				(xy 105.020187 65.950663) (xy 104.965 66.117205) (xy 104.9545 66.219983) (xy 104.9545 66.655255)
-				(xy 104.935593 66.713446) (xy 104.925504 66.725259) (xy 103.231286 68.419478) (xy 103.231284 68.41948)
-				(xy 103.231283 68.419479) (xy 103.119479 68.531284) (xy 103.07749 68.604012) (xy 103.040425 68.668209)
-				(xy 103.040423 68.668213) (xy 103.040423 68.668215) (xy 102.999499 68.820943) (xy 102.999499 68.820945)
-				(xy 102.999499 68.987031) (xy 102.9995 68.987044) (xy 102.9995 84.614863) (xy 102.999499 84.614881)
-				(xy 102.999499 84.620943) (xy 102.999499 84.779057) (xy 103.040423 84.931785) (xy 103.040424 84.931787)
-				(xy 103.059871 84.96547) (xy 103.05987 84.96547) (xy 103.117513 85.065309) (xy 103.11948 85.068716)
-				(xy 103.220505 85.169741) (xy 103.248281 85.224256) (xy 103.2495 85.239743) (xy 103.2495 116.164863)
-				(xy 103.249499 116.164881) (xy 103.249499 116.170943) (xy 103.249499 116.329057) (xy 103.290423 116.481784)
-				(xy 103.290425 116.481788) (xy 103.31936 116.531905) (xy 103.319361 116.531905) (xy 103.36948 116.618716)
-				(xy 103.481284 116.73052) (xy 103.481286 116.730521) (xy 105.681261 118.930496) (xy 105.709038 118.985013)
-				(xy 105.699467 119.045445) (xy 105.656202 119.08871) (xy 105.611257 119.0995) (xy 105.110435 119.0995)
-				(xy 105.034011 119.119978) (xy 105.034007 119.11998) (xy 104.965491 119.159538) (xy 103.015489 121.10954)
-				(xy 103.015488 121.109539) (xy 102.959539 121.165489) (xy 102.91998 121.234007) (xy 102.919978 121.234011)
-				(xy 102.8995 121.310435) (xy 102.8995 141.239564) (xy 102.919977 141.315985) (xy 102.919979 141.31599)
-				(xy 102.948446 141.365296) (xy 102.948449 141.365301) (xy 102.95954 141.384511) (xy 105.415489 143.84046)
-				(xy 105.415491 143.840461) (xy 105.415493 143.840463) (xy 105.484008 143.88002) (xy 105.484006 143.88002)
-				(xy 105.48401 143.880021) (xy 105.484012 143.880022) (xy 105.560438 143.9005) (xy 105.639562 143.9005)
-				(xy 107.434521 143.9005) (xy 107.492712 143.919407) (xy 107.504525 143.929496) (xy 110.00954 146.434511)
-				(xy 110.009539 146.434511) (xy 110.065489 146.49046) (xy 110.134007 146.530019) (xy 110.134011 146.530021)
-				(xy 110.210435 146.550499) (xy 110.210437 146.5505) (xy 110.210438 146.5505) (xy 134.189563 146.5505)
-				(xy 134.189563 146.550499) (xy 134.265989 146.530021) (xy 134.334511 146.49046) (xy 134.39046 146.434511)
-				(xy 136.045475 144.779496) (xy 136.099992 144.751719) (xy 136.115479 144.7505) (xy 138.789563 144.7505)
-				(xy 138.789563 144.750499) (xy 138.865989 144.730021) (xy 138.934511 144.69046) (xy 138.99046 144.634511)
-				(xy 143.96046 139.664511) (xy 143.970834 139.646542) (xy 144.000021 139.595989) (xy 144.0205 139.519562)
-				(xy 144.0205 100.6995) (xy 144.039407 100.641309) (xy 144.088907 100.605345) (xy 144.1195 100.6005)
-				(xy 144.185618 100.6005) (xy 144.185618 100.600499) (xy 144.211156 100.597537) (xy 144.31564 100.551403)
-				(xy 144.330498 100.536544) (xy 144.385013 100.508769) (xy 144.445445 100.51834) (xy 144.48871 100.561605)
-				(xy 144.4995 100.60655) (xy 144.4995 146.03626) (xy 144.480593 146.094451) (xy 144.431093 146.130415)
-				(xy 144.369907 146.130415) (xy 144.320407 146.094451) (xy 144.301049 146.067808) (xy 144.220793 145.957344)
-				(xy 144.042656 145.779207) (xy 143.838845 145.63113) (xy 143.838844 145.631129) (xy 143.838842 145.631128)
-				(xy 143.614379 145.516759) (xy 143.37478 145.438908) (xy 143.125965 145.3995) (xy 143.125962 145.3995)
-				(xy 142.874038 145.3995) (xy 142.874035 145.3995) (xy 142.625219 145.438908) (xy 142.38562 145.516759)
-				(xy 142.161157 145.631128) (xy 141.957345 145.779206) (xy 141.779206 145.957345) (xy 141.631128 146.161157)
-				(xy 141.516759 146.38562) (xy 141.438908 146.625219) (xy 141.3995 146.874034) (xy 141.3995 147.125965)
-				(xy 141.438908 147.37478) (xy 141.43891 147.374785) (xy 141.516759 147.614379) (xy 141.63113 147.838845)
-				(xy 141.779207 148.042656) (xy 141.957344 148.220793) (xy 142.094452 148.320408) (xy 142.130416 148.369907)
-				(xy 142.130416 148.431093) (xy 142.094452 148.480593) (xy 142.036261 148.4995) (xy 104.963739 148.4995)
-				(xy 104.905548 148.480593) (xy 104.869584 148.431093) (xy 104.869584 148.369907) (xy 104.905547 148.320408)
-				(xy 105.042656 148.220793) (xy 105.220793 148.042656) (xy 105.36887 147.838845) (xy 105.483241 147.614379)
-				(xy 105.56109 147.374785) (xy 105.6005 147.125962) (xy 105.6005 146.874038) (xy 105.6005 146.874034)
-				(xy 105.561091 146.625219) (xy 105.56109 146.625215) (xy 105.483241 146.385621) (xy 105.36887 146.161155)
-				(xy 105.220793 145.957344) (xy 105.042656 145.779207) (xy 104.838845 145.63113) (xy 104.838844 145.631129)
-				(xy 104.838842 145.631128) (xy 104.614379 145.516759) (xy 104.37478 145.438908) (xy 104.125965 145.3995)
-				(xy 104.125962 145.3995) (xy 103.874038 145.3995) (xy 103.874035 145.3995) (xy 103.625219 145.438908)
-				(xy 103.38562 145.516759) (xy 103.161157 145.631128) (xy 102.957345 145.779206) (xy 102.779206 145.957345)
-				(xy 102.679593 146.094451) (xy 102.630092 146.130415) (xy 102.568907 146.130415) (xy 102.519407 146.094451)
-				(xy 102.5005 146.03626) (xy 102.5005 63.830299) (xy 105.05 63.830299) (xy 105.05 64.449999) (xy 105.050001 64.45)
-				(xy 106.199999 64.45) (xy 106.2 64.449999) (xy 106.2 63.650001) (xy 106.4 63.650001) (xy 106.4 64.449999)
-				(xy 106.400001 64.45) (xy 107.549999 64.45) (xy 107.55 64.449999) (xy 107.55 63.830302) (xy 107.549999 63.830299)
-				(xy 107.538396 63.771963) (xy 107.494193 63.70581) (xy 107.494189 63.705806) (xy 107.428036 63.661603)
-				(xy 107.3697 63.65) (xy 106.400001 63.65) (xy 106.4 63.650001) (xy 106.2 63.650001) (xy 106.199999 63.65)
-				(xy 105.230299 63.65) (xy 105.171963 63.661603) (xy 105.10581 63.705806) (xy 105.105806 63.70581)
-				(xy 105.061603 63.771963) (xy 105.05 63.830299) (xy 102.5005 63.830299) (xy 102.5005 56.963739)
-				(xy 102.519407 56.905548) (xy 102.568907 56.869584) (xy 102.630093 56.869584) (xy 102.679591 56.905547)
-				(xy 102.779207 57.042656) (xy 102.957344 57.220793) (xy 103.161155 57.36887) (xy 103.385621 57.483241)
-				(xy 103.625215 57.56109) (xy 103.625216 57.56109) (xy 103.625219 57.561091) (xy 103.874035 57.6005)
-				(xy 103.874038 57.6005) (xy 104.125965 57.6005) (xy 104.37478 57.561091) (xy 104.374781 57.56109)
-				(xy 104.374785 57.56109) (xy 104.614379 57.483241) (xy 104.838845 57.36887) (xy 105.042656 57.220793)
-				(xy 105.220793 57.042656) (xy 105.36887 56.838845) (xy 105.483241 56.614379) (xy 105.56109 56.374785)
-				(xy 105.6005 56.125962) (xy 105.6005 55.874038) (xy 105.6005 55.874034) (xy 105.561091 55.625219)
-				(xy 105.56109 55.625215) (xy 105.483241 55.385621) (xy 105.36887 55.161155) (xy 105.220793 54.957344)
-				(xy 105.042656 54.779207) (xy 104.905547 54.679591) (xy 104.869584 54.630093) (xy 104.869584 54.568907)
-				(xy 104.905548 54.519407) (xy 104.963739 54.5005) (xy 142.036261 54.5005)
+				(xy 107.355499 66.219991) (xy 107.355499 66.219983) (xy 107.345 66.117211) (xy 107.344999 66.117209)
+				(xy 107.344999 66.117203) (xy 107.289814 65.950666) (xy 107.197712 65.801344) (xy 107.073656 65.677288)
+				(xy 107.073653 65.677286) (xy 107.073652 65.677285) (xy 107.002277 65.633261) (xy 106.962675 65.58662)
+				(xy 106.958052 65.525609) (xy 106.990173 65.473533) (xy 107.046768 65.450283) (xy 107.054249 65.45)
+				(xy 107.249999 65.45) (xy 107.25 65.449999) (xy 107.25 64.650001) (xy 107.45 64.650001) (xy 107.45 65.449999)
+				(xy 107.450001 65.45) (xy 108.419697 65.45) (xy 108.4197 65.449999) (xy 108.478036 65.438396) (xy 108.544189 65.394193)
+				(xy 108.544193 65.394189) (xy 108.588396 65.328036) (xy 108.599999 65.2697) (xy 108.6 65.269697)
+				(xy 108.6 64.650001) (xy 108.599999 64.65) (xy 107.450001 64.65) (xy 107.45 64.650001) (xy 107.25 64.650001)
+				(xy 107.249999 64.65) (xy 106.100001 64.65) (xy 106.1 64.650001) (xy 106.1 65.2697) (xy 106.111603 65.328036)
+				(xy 106.136635 65.365498) (xy 106.153244 65.424387) (xy 106.132066 65.48179) (xy 106.081193 65.515783)
+				(xy 106.05432 65.5195) (xy 105.654983 65.5195) (xy 105.552211 65.529999) (xy 105.552199 65.530002)
+				(xy 105.385663 65.585187) (xy 105.236347 65.677285) (xy 105.112285 65.801347) (xy 105.020187 65.950663)
+				(xy 104.965 66.117205) (xy 104.9545 66.219983) (xy 104.9545 66.842755) (xy 104.935593 66.900946)
+				(xy 104.925504 66.912759) (xy 103.331286 68.506978) (xy 103.331284 68.50698) (xy 103.331283 68.506979)
+				(xy 103.219479 68.618784) (xy 103.172878 68.6995) (xy 103.140425 68.755709) (xy 103.140423 68.755713)
+				(xy 103.140423 68.755715) (xy 103.099499 68.908443) (xy 103.099499 68.908445) (xy 103.099499 69.074531)
+				(xy 103.0995 69.074544) (xy 103.0995 83.614863) (xy 103.099499 83.614881) (xy 103.099499 83.620943)
+				(xy 103.099499 83.779057) (xy 103.138739 83.9255) (xy 103.140424 83.931787) (xy 103.162774 83.970499)
+				(xy 103.186758 84.01204) (xy 103.21948 84.068716) (xy 103.331284 84.18052) (xy 103.331286 84.180521)
+				(xy 103.370504 84.219739) (xy 103.398281 84.274256) (xy 103.3995 84.289743) (xy 103.3995 116.314863)
+				(xy 103.399499 116.314881) (xy 103.399499 116.320943) (xy 103.399499 116.479057) (xy 103.437067 116.619263)
+				(xy 103.440424 116.631789) (xy 103.450649 116.649497) (xy 103.45065 116.6495) (xy 103.51379 116.758861)
+				(xy 103.51948 116.768716) (xy 103.631284 116.88052) (xy 103.631286 116.880521) (xy 105.681261 118.930496)
+				(xy 105.709038 118.985013) (xy 105.699467 119.045445) (xy 105.656202 119.08871) (xy 105.611257 119.0995)
+				(xy 105.110435 119.0995) (xy 105.034011 119.119978) (xy 105.034007 119.11998) (xy 104.965491 119.159538)
+				(xy 103.015489 121.10954) (xy 103.015488 121.109539) (xy 102.959539 121.165489) (xy 102.91998 121.234007)
+				(xy 102.919978 121.234011) (xy 102.8995 121.310435) (xy 102.8995 141.239564) (xy 102.919977 141.315985)
+				(xy 102.919979 141.31599) (xy 102.948446 141.365296) (xy 102.948449 141.365301) (xy 102.95954 141.384511)
+				(xy 105.415489 143.84046) (xy 105.415491 143.840461) (xy 105.415493 143.840463) (xy 105.484008 143.88002)
+				(xy 105.484006 143.88002) (xy 105.48401 143.880021) (xy 105.484012 143.880022) (xy 105.560438 143.9005)
+				(xy 105.639562 143.9005) (xy 107.434521 143.9005) (xy 107.492712 143.919407) (xy 107.504525 143.929496)
+				(xy 110.00954 146.434511) (xy 110.009539 146.434511) (xy 110.065489 146.49046) (xy 110.134007 146.530019)
+				(xy 110.134011 146.530021) (xy 110.210435 146.550499) (xy 110.210437 146.5505) (xy 110.210438 146.5505)
+				(xy 134.189563 146.5505) (xy 134.189563 146.550499) (xy 134.265989 146.530021) (xy 134.334511 146.49046)
+				(xy 134.39046 146.434511) (xy 136.045475 144.779496) (xy 136.099992 144.751719) (xy 136.115479 144.7505)
+				(xy 138.789563 144.7505) (xy 138.789563 144.750499) (xy 138.865989 144.730021) (xy 138.934511 144.69046)
+				(xy 138.99046 144.634511) (xy 143.96046 139.664511) (xy 143.970834 139.646542) (xy 144.000021 139.595989)
+				(xy 144.0205 139.519562) (xy 144.0205 100.6995) (xy 144.039407 100.641309) (xy 144.088907 100.605345)
+				(xy 144.1195 100.6005) (xy 144.185618 100.6005) (xy 144.185618 100.600499) (xy 144.211156 100.597537)
+				(xy 144.31564 100.551403) (xy 144.330498 100.536544) (xy 144.385013 100.508769) (xy 144.445445 100.51834)
+				(xy 144.48871 100.561605) (xy 144.4995 100.60655) (xy 144.4995 146.03626) (xy 144.480593 146.094451)
+				(xy 144.431093 146.130415) (xy 144.369907 146.130415) (xy 144.320407 146.094451) (xy 144.301049 146.067808)
+				(xy 144.220793 145.957344) (xy 144.042656 145.779207) (xy 143.838845 145.63113) (xy 143.838844 145.631129)
+				(xy 143.838842 145.631128) (xy 143.614379 145.516759) (xy 143.37478 145.438908) (xy 143.125965 145.3995)
+				(xy 143.125962 145.3995) (xy 142.874038 145.3995) (xy 142.874035 145.3995) (xy 142.625219 145.438908)
+				(xy 142.38562 145.516759) (xy 142.161157 145.631128) (xy 141.957345 145.779206) (xy 141.779206 145.957345)
+				(xy 141.631128 146.161157) (xy 141.516759 146.38562) (xy 141.438908 146.625219) (xy 141.3995 146.874034)
+				(xy 141.3995 147.125965) (xy 141.438908 147.37478) (xy 141.43891 147.374785) (xy 141.516759 147.614379)
+				(xy 141.63113 147.838845) (xy 141.779207 148.042656) (xy 141.957344 148.220793) (xy 142.094452 148.320408)
+				(xy 142.130416 148.369907) (xy 142.130416 148.431093) (xy 142.094452 148.480593) (xy 142.036261 148.4995)
+				(xy 104.963739 148.4995) (xy 104.905548 148.480593) (xy 104.869584 148.431093) (xy 104.869584 148.369907)
+				(xy 104.905547 148.320408) (xy 105.042656 148.220793) (xy 105.220793 148.042656) (xy 105.36887 147.838845)
+				(xy 105.483241 147.614379) (xy 105.56109 147.374785) (xy 105.6005 147.125962) (xy 105.6005 146.874038)
+				(xy 105.6005 146.874034) (xy 105.561091 146.625219) (xy 105.56109 146.625215) (xy 105.483241 146.385621)
+				(xy 105.36887 146.161155) (xy 105.220793 145.957344) (xy 105.042656 145.779207) (xy 104.838845 145.63113)
+				(xy 104.838844 145.631129) (xy 104.838842 145.631128) (xy 104.614379 145.516759) (xy 104.37478 145.438908)
+				(xy 104.125965 145.3995) (xy 104.125962 145.3995) (xy 103.874038 145.3995) (xy 103.874035 145.3995)
+				(xy 103.625219 145.438908) (xy 103.38562 145.516759) (xy 103.161157 145.631128) (xy 102.957345 145.779206)
+				(xy 102.779206 145.957345) (xy 102.679593 146.094451) (xy 102.630092 146.130415) (xy 102.568907 146.130415)
+				(xy 102.519407 146.094451) (xy 102.5005 146.03626) (xy 102.5005 63.830299) (xy 106.1 63.830299)
+				(xy 106.1 64.449999) (xy 106.100001 64.45) (xy 107.249999 64.45) (xy 107.25 64.449999) (xy 107.25 63.650001)
+				(xy 107.45 63.650001) (xy 107.45 64.449999) (xy 107.450001 64.45) (xy 108.599999 64.45) (xy 108.6 64.449999)
+				(xy 108.6 63.830302) (xy 108.599999 63.830299) (xy 108.588396 63.771963) (xy 108.544193 63.70581)
+				(xy 108.544189 63.705806) (xy 108.478036 63.661603) (xy 108.4197 63.65) (xy 107.450001 63.65) (xy 107.45 63.650001)
+				(xy 107.25 63.650001) (xy 107.249999 63.65) (xy 106.280299 63.65) (xy 106.221963 63.661603) (xy 106.15581 63.705806)
+				(xy 106.155806 63.70581) (xy 106.111603 63.771963) (xy 106.1 63.830299) (xy 102.5005 63.830299)
+				(xy 102.5005 56.963739) (xy 102.519407 56.905548) (xy 102.568907 56.869584) (xy 102.630093 56.869584)
+				(xy 102.679591 56.905547) (xy 102.779207 57.042656) (xy 102.957344 57.220793) (xy 103.161155 57.36887)
+				(xy 103.385621 57.483241) (xy 103.625215 57.56109) (xy 103.625216 57.56109) (xy 103.625219 57.561091)
+				(xy 103.874035 57.6005) (xy 103.874038 57.6005) (xy 104.125965 57.6005) (xy 104.37478 57.561091)
+				(xy 104.374781 57.56109) (xy 104.374785 57.56109) (xy 104.614379 57.483241) (xy 104.838845 57.36887)
+				(xy 105.042656 57.220793) (xy 105.220793 57.042656) (xy 105.36887 56.838845) (xy 105.483241 56.614379)
+				(xy 105.56109 56.374785) (xy 105.6005 56.125962) (xy 105.6005 55.874038) (xy 105.6005 55.874034)
+				(xy 105.561091 55.625219) (xy 105.56109 55.625215) (xy 105.483241 55.385621) (xy 105.36887 55.161155)
+				(xy 105.220793 54.957344) (xy 105.042656 54.779207) (xy 104.905547 54.679591) (xy 104.869584 54.630093)
+				(xy 104.869584 54.568907) (xy 104.905548 54.519407) (xy 104.963739 54.5005) (xy 142.036261 54.5005)
 			)
 		)
 		(filled_polygon
@@ -39982,25 +40156,25 @@
 				(xy 115.6255 132.206519) (xy 115.625499 132.131881) (xy 115.644406 132.073693) (xy 115.693905 132.037729)
 				(xy 115.75509 132.037728) (xy 115.804591 132.073691) (xy 115.817942 132.099183) (xy 115.822652 132.112644)
 				(xy 115.903207 132.22179) (xy 115.903209 132.221792) (xy 116.012352 132.302345) (xy 116.140398 132.347149)
-				(xy 116.170789 132.349999) (xy 116.599998 132.349999) (xy 116.6 132.349998) (xy 116.6 131.750001)
-				(xy 116.8 131.750001) (xy 116.8 132.349998) (xy 116.800001 132.349999) (xy 117.229203 132.349999)
-				(xy 117.2596 132.347149) (xy 117.259602 132.347149) (xy 117.387647 132.302345) (xy 117.49679 132.221792)
-				(xy 117.496792 132.22179) (xy 117.577345 132.112647) (xy 117.622149 131.984601) (xy 117.624999 131.954211)
-				(xy 117.625 131.95421) (xy 117.625 131.750001) (xy 117.624999 131.75) (xy 116.800001 131.75) (xy 116.8 131.750001)
-				(xy 116.6 131.750001) (xy 116.6 131.649) (xy 116.618907 131.590809) (xy 116.668407 131.554845) (xy 116.699 131.55)
-				(xy 117.624998 131.55) (xy 117.624999 131.549999) (xy 117.624999 131.345796) (xy 117.622149 131.315399)
-				(xy 117.622149 131.315397) (xy 117.577345 131.187352) (xy 117.496792 131.078209) (xy 117.49679 131.078207)
-				(xy 117.387647 130.997654) (xy 117.259601 130.95285) (xy 117.229211 130.95) (xy 117.045255 130.95)
-				(xy 116.987064 130.931093) (xy 116.9511 130.881593) (xy 116.9511 130.820407) (xy 116.959519 130.8015)
-				(xy 117.003317 130.725639) (xy 117.003318 130.725638) (xy 117.0255 130.642853) (xy 117.0255 130.5495)
-				(xy 117.044407 130.491309) (xy 117.093907 130.455345) (xy 117.1245 130.4505) (xy 117.229273 130.4505)
-				(xy 117.229273 130.450499) (xy 117.259699 130.447646) (xy 117.387882 130.402793) (xy 117.49715 130.32215)
-				(xy 117.577793 130.212882) (xy 117.622646 130.084699) (xy 117.625499 130.054273) (xy 117.6255 130.054273)
-				(xy 117.6255 129.445727) (xy 117.625499 129.445725) (xy 117.622646 129.415301) (xy 117.577793 129.287118)
-				(xy 117.568092 129.273974) (xy 117.497154 129.177855) (xy 117.497152 129.177853) (xy 117.49715 129.17785)
-				(xy 117.497146 129.177847) (xy 117.497144 129.177845) (xy 117.387883 129.097207) (xy 117.382564 129.094396)
-				(xy 117.339951 129.05049) (xy 117.331283 128.989921) (xy 117.358816 128.936866) (xy 117.66463 128.631052)
-				(xy 117.719145 128.603277)
+				(xy 116.170789 132.349999) (xy 116.599998 132.349999) (xy 116.6 132.349998) (xy 116.8 132.349998)
+				(xy 116.800001 132.349999) (xy 117.229203 132.349999) (xy 117.2596 132.347149) (xy 117.259602 132.347149)
+				(xy 117.387647 132.302345) (xy 117.49679 132.221792) (xy 117.496792 132.22179) (xy 117.577345 132.112647)
+				(xy 117.622149 131.984601) (xy 117.624999 131.954211) (xy 117.625 131.95421) (xy 117.625 131.750001)
+				(xy 117.624999 131.75) (xy 116.8 131.75) (xy 116.8 132.349998) (xy 116.6 132.349998) (xy 116.6 131.749)
+				(xy 116.618907 131.690809) (xy 116.668407 131.654845) (xy 116.699 131.65) (xy 116.7 131.65) (xy 116.7 131.649)
+				(xy 116.718907 131.590809) (xy 116.768407 131.554845) (xy 116.799 131.55) (xy 117.624998 131.55)
+				(xy 117.624999 131.549999) (xy 117.624999 131.345796) (xy 117.622149 131.315399) (xy 117.622149 131.315397)
+				(xy 117.577345 131.187352) (xy 117.496792 131.078209) (xy 117.49679 131.078207) (xy 117.387647 130.997654)
+				(xy 117.259601 130.95285) (xy 117.229211 130.95) (xy 117.045255 130.95) (xy 116.987064 130.931093)
+				(xy 116.9511 130.881593) (xy 116.9511 130.820407) (xy 116.959519 130.8015) (xy 117.003317 130.725639)
+				(xy 117.003318 130.725638) (xy 117.0255 130.642853) (xy 117.0255 130.5495) (xy 117.044407 130.491309)
+				(xy 117.093907 130.455345) (xy 117.1245 130.4505) (xy 117.229273 130.4505) (xy 117.229273 130.450499)
+				(xy 117.259699 130.447646) (xy 117.387882 130.402793) (xy 117.49715 130.32215) (xy 117.577793 130.212882)
+				(xy 117.622646 130.084699) (xy 117.625499 130.054273) (xy 117.6255 130.054273) (xy 117.6255 129.445727)
+				(xy 117.625499 129.445725) (xy 117.622646 129.415301) (xy 117.577793 129.287118) (xy 117.568092 129.273974)
+				(xy 117.497154 129.177855) (xy 117.497152 129.177853) (xy 117.49715 129.17785) (xy 117.497146 129.177847)
+				(xy 117.497144 129.177845) (xy 117.387883 129.097207) (xy 117.382564 129.094396) (xy 117.339951 129.05049)
+				(xy 117.331283 128.989921) (xy 117.358816 128.936866) (xy 117.66463 128.631052) (xy 117.719145 128.603277)
 			)
 		)
 		(filled_polygon
@@ -40009,12 +40183,13 @@
 				(xy 122.429004 126.219661) (xy 123.334839 127.125496) (xy 123.362616 127.180013) (xy 123.353045 127.240445)
 				(xy 123.30978 127.28371) (xy 123.264835 127.2945) (xy 121.6045 127.2945) (xy 121.546309 127.275593)
 				(xy 121.510345 127.226093) (xy 121.5055 127.1955) (xy 121.5055 127.109) (xy 121.524407 127.050809)
-				(xy 121.573907 127.014845) (xy 121.6045 127.01) (xy 121.679999 127.01) (xy 121.68 127.009999) (xy 121.68 126.600001)
-				(xy 121.88 126.600001) (xy 121.88 127.009999) (xy 121.880001 127.01) (xy 121.959838 127.01) (xy 122.009354 127.00348)
-				(xy 122.009361 127.003478) (xy 122.118021 126.952809) (xy 122.202809 126.868021) (xy 122.253478 126.759361)
-				(xy 122.25348 126.759354) (xy 122.26 126.709838) (xy 122.26 126.600001) (xy 122.259999 126.6) (xy 121.880001 126.6)
-				(xy 121.88 126.600001) (xy 121.68 126.600001) (xy 121.68 126.499) (xy 121.698907 126.440809) (xy 121.748407 126.404845)
-				(xy 121.779 126.4) (xy 122.259999 126.4) (xy 122.26 126.399999) (xy 122.26 126.289665) (xy 122.278907 126.231474)
+				(xy 121.573907 127.014845) (xy 121.6045 127.01) (xy 121.679999 127.01) (xy 121.68 127.009999) (xy 121.88 127.009999)
+				(xy 121.880001 127.01) (xy 121.959838 127.01) (xy 122.009354 127.00348) (xy 122.009361 127.003478)
+				(xy 122.118021 126.952809) (xy 122.202809 126.868021) (xy 122.253478 126.759361) (xy 122.25348 126.759354)
+				(xy 122.26 126.709838) (xy 122.26 126.600001) (xy 122.259999 126.6) (xy 121.88 126.6) (xy 121.88 127.009999)
+				(xy 121.68 127.009999) (xy 121.68 126.599) (xy 121.698907 126.540809) (xy 121.748407 126.504845)
+				(xy 121.779 126.5) (xy 121.78 126.5) (xy 121.78 126.499) (xy 121.798907 126.440809) (xy 121.848407 126.404845)
+				(xy 121.879 126.4) (xy 122.259999 126.4) (xy 122.26 126.399999) (xy 122.26 126.289665) (xy 122.278907 126.231474)
 				(xy 122.328407 126.19551) (xy 122.389593 126.19551)
 			)
 		)
@@ -40141,50 +40316,52 @@
 				(xy 109.470886 118.10952) (xy 109.327691 118.019544) (xy 109.168065 117.963688) (xy 109.168053 117.963685)
 				(xy 109.000004 117.944751) (xy 108.999996 117.944751) (xy 108.831946 117.963685) (xy 108.831934 117.963688)
 				(xy 108.672309 118.019544) (xy 108.672308 118.019544) (xy 108.56921 118.084326) (xy 108.516539 118.0995)
-				(xy 106.589743 118.0995) (xy 106.531552 118.080593) (xy 106.519739 118.070504) (xy 104.479496 116.030261)
-				(xy 104.451719 115.975744) (xy 104.4505 115.960257) (xy 104.4505 84.870943) (xy 104.44745 84.859562)
-				(xy 104.447449 84.859558) (xy 104.425879 84.779057) (xy 104.425879 84.779056) (xy 104.414845 84.737876)
-				(xy 104.409577 84.718216) (xy 104.33052 84.581284) (xy 104.229494 84.480258) (xy 104.201719 84.425744)
-				(xy 104.2005 84.410257) (xy 104.2005 81.414479) (xy 104.219407 81.356288) (xy 104.268907 81.320324)
-				(xy 104.330093 81.320324) (xy 104.369504 81.344475) (xy 105.720504 82.695475) (xy 105.748281 82.749992)
-				(xy 105.7495 82.765479) (xy 105.7495 113.089564) (xy 105.769977 113.165985) (xy 105.769981 113.165993)
-				(xy 105.786037 113.193805) (xy 105.786038 113.193805) (xy 105.78604 113.193808) (xy 105.80954 113.234511)
-				(xy 106.5355 113.960471) (xy 106.563276 114.014986) (xy 106.553705 114.075418) (xy 106.51044 114.118683)
-				(xy 106.484812 114.12757) (xy 106.441771 114.136132) (xy 106.441766 114.136134) (xy 106.375451 114.180445)
-				(xy 106.375445 114.180451) (xy 106.331134 114.246766) (xy 106.331132 114.246772) (xy 106.319501 114.305241)
-				(xy 106.3195 114.305253) (xy 106.3195 117.494746) (xy 106.319501 117.494758) (xy 106.331132 117.553227)
-				(xy 106.331134 117.553233) (xy 106.375445 117.619548) (xy 106.375448 117.619552) (xy 106.441769 117.663867)
-				(xy 106.486231 117.672711) (xy 106.500241 117.675498) (xy 106.500246 117.675498) (xy 106.500252 117.6755)
-				(xy 106.500253 117.6755) (xy 107.539747 117.6755) (xy 107.539748 117.6755) (xy 107.598231 117.663867)
-				(xy 107.664552 117.619552) (xy 107.708867 117.553231) (xy 107.7205 117.494748) (xy 107.7205 114.305252)
-				(xy 107.72001 114.302791) (xy 107.717711 114.291231) (xy 107.708867 114.246769) (xy 107.664552 114.180448)
-				(xy 107.664548 114.180445) (xy 107.598233 114.136134) (xy 107.598231 114.136133) (xy 107.598228 114.136132)
-				(xy 107.598227 114.136132) (xy 107.539758 114.124501) (xy 107.539748 114.1245) (xy 107.539747 114.1245)
-				(xy 107.4195 114.1245) (xy 107.361309 114.105593) (xy 107.325345 114.056093) (xy 107.3205 114.0255)
-				(xy 107.3205 113.980437) (xy 107.320499 113.980435) (xy 107.313486 113.954264) (xy 107.300021 113.904011)
-				(xy 107.293249 113.892282) (xy 107.26046 113.835489) (xy 107.204511 113.779539) (xy 107.204511 113.77954)
-				(xy 106.379496 112.954525) (xy 106.351719 112.900008) (xy 106.3505 112.884521) (xy 106.3505 112.715834)
-				(xy 106.369407 112.657643) (xy 106.418907 112.621679) (xy 106.468816 112.618737) (xy 106.500294 112.624999)
-				(xy 106.500303 112.625) (xy 106.919999 112.625) (xy 106.92 112.624999) (xy 106.92 110.950001) (xy 107.12 110.950001)
-				(xy 107.12 112.624999) (xy 107.120001 112.625) (xy 107.539697 112.625) (xy 107.5397 112.624999)
-				(xy 107.598036 112.613396) (xy 107.664189 112.569193) (xy 107.664193 112.569189) (xy 107.708396 112.503036)
-				(xy 107.719999 112.4447) (xy 107.72 112.444697) (xy 107.72 110.950001) (xy 108.86 110.950001) (xy 108.86 112.4447)
-				(xy 108.871603 112.503036) (xy 108.915806 112.569189) (xy 108.91581 112.569193) (xy 108.981963 112.613396)
-				(xy 109.040299 112.624999) (xy 109.040303 112.625) (xy 109.459999 112.625) (xy 109.46 112.624999)
-				(xy 109.46 110.950001) (xy 109.459999 110.95) (xy 108.860001 110.95) (xy 108.86 110.950001) (xy 107.72 110.950001)
-				(xy 107.719999 110.95) (xy 107.120001 110.95) (xy 107.12 110.950001) (xy 106.92 110.950001) (xy 106.92 109.075001)
-				(xy 107.12 109.075001) (xy 107.12 110.749999) (xy 107.120001 110.75) (xy 107.719999 110.75) (xy 107.72 110.749999)
-				(xy 107.72 109.255302) (xy 107.719999 109.255299) (xy 108.86 109.255299) (xy 108.86 110.749999)
-				(xy 108.860001 110.75) (xy 109.459999 110.75) (xy 109.46 110.749999) (xy 109.46 109.075001) (xy 109.459999 109.075)
-				(xy 109.040299 109.075) (xy 108.981963 109.086603) (xy 108.91581 109.130806) (xy 108.915806 109.13081)
-				(xy 108.871603 109.196963) (xy 108.86 109.255299) (xy 107.719999 109.255299) (xy 107.708396 109.196963)
-				(xy 107.664193 109.13081) (xy 107.664189 109.130806) (xy 107.598036 109.086603) (xy 107.5397 109.075)
-				(xy 107.120001 109.075) (xy 107.12 109.075001) (xy 106.92 109.075001) (xy 106.919999 109.075) (xy 106.500299 109.075)
-				(xy 106.468814 109.081263) (xy 106.408052 109.074071) (xy 106.363123 109.032538) (xy 106.3505 108.984165)
-				(xy 106.3505 82.560437) (xy 106.350499 82.560435) (xy 106.34831 82.552267) (xy 106.330021 82.484011)
-				(xy 106.329371 82.482886) (xy 106.29046 82.415489) (xy 106.234511 82.359539) (xy 106.234511 82.35954)
-				(xy 104.429496 80.554525) (xy 104.401719 80.500008) (xy 104.4005 80.484521) (xy 104.4005 77.764479)
-				(xy 104.419407 77.706288) (xy 104.468907 77.670324) (xy 104.530093 77.670324)
+				(xy 106.589743 118.0995) (xy 106.531552 118.080593) (xy 106.519739 118.070504) (xy 104.629496 116.180261)
+				(xy 104.601719 116.125744) (xy 104.6005 116.110257) (xy 104.6005 83.920944) (xy 104.6005 83.920943)
+				(xy 104.581357 83.8495) (xy 104.559577 83.768215) (xy 104.538709 83.732072) (xy 104.530639 83.718094)
+				(xy 104.530639 83.718093) (xy 104.530637 83.718091) (xy 104.480524 83.631289) (xy 104.480521 83.631286)
+				(xy 104.48052 83.631284) (xy 104.368716 83.51948) (xy 104.368713 83.519478) (xy 104.329496 83.480261)
+				(xy 104.301719 83.425744) (xy 104.3005 83.410257) (xy 104.3005 81.514479) (xy 104.319407 81.456288)
+				(xy 104.368907 81.420324) (xy 104.430093 81.420324) (xy 104.469504 81.444475) (xy 105.720504 82.695475)
+				(xy 105.748281 82.749992) (xy 105.7495 82.765479) (xy 105.7495 113.089564) (xy 105.769977 113.165985)
+				(xy 105.769981 113.165993) (xy 105.786037 113.193805) (xy 105.786038 113.193805) (xy 105.78604 113.193808)
+				(xy 105.80954 113.234511) (xy 106.5355 113.960471) (xy 106.563276 114.014986) (xy 106.553705 114.075418)
+				(xy 106.51044 114.118683) (xy 106.484812 114.12757) (xy 106.441771 114.136132) (xy 106.441766 114.136134)
+				(xy 106.375451 114.180445) (xy 106.375445 114.180451) (xy 106.331134 114.246766) (xy 106.331132 114.246772)
+				(xy 106.319501 114.305241) (xy 106.3195 114.305253) (xy 106.3195 117.494746) (xy 106.319501 117.494758)
+				(xy 106.331132 117.553227) (xy 106.331134 117.553233) (xy 106.375445 117.619548) (xy 106.375448 117.619552)
+				(xy 106.441769 117.663867) (xy 106.486231 117.672711) (xy 106.500241 117.675498) (xy 106.500246 117.675498)
+				(xy 106.500252 117.6755) (xy 106.500253 117.6755) (xy 107.539747 117.6755) (xy 107.539748 117.6755)
+				(xy 107.598231 117.663867) (xy 107.664552 117.619552) (xy 107.708867 117.553231) (xy 107.7205 117.494748)
+				(xy 107.7205 114.305252) (xy 107.72001 114.302791) (xy 107.717711 114.291231) (xy 107.708867 114.246769)
+				(xy 107.664552 114.180448) (xy 107.664548 114.180445) (xy 107.598233 114.136134) (xy 107.598231 114.136133)
+				(xy 107.598228 114.136132) (xy 107.598227 114.136132) (xy 107.539758 114.124501) (xy 107.539748 114.1245)
+				(xy 107.539747 114.1245) (xy 107.4195 114.1245) (xy 107.361309 114.105593) (xy 107.325345 114.056093)
+				(xy 107.3205 114.0255) (xy 107.3205 113.980437) (xy 107.320499 113.980435) (xy 107.313486 113.954264)
+				(xy 107.300021 113.904011) (xy 107.293249 113.892282) (xy 107.26046 113.835489) (xy 107.204511 113.779539)
+				(xy 107.204511 113.77954) (xy 106.379496 112.954525) (xy 106.351719 112.900008) (xy 106.3505 112.884521)
+				(xy 106.3505 112.715834) (xy 106.369407 112.657643) (xy 106.418907 112.621679) (xy 106.468816 112.618737)
+				(xy 106.500294 112.624999) (xy 106.500303 112.625) (xy 106.919999 112.625) (xy 106.92 112.624999)
+				(xy 106.92 110.950001) (xy 107.12 110.950001) (xy 107.12 112.624999) (xy 107.120001 112.625) (xy 107.539697 112.625)
+				(xy 107.5397 112.624999) (xy 107.598036 112.613396) (xy 107.664189 112.569193) (xy 107.664193 112.569189)
+				(xy 107.708396 112.503036) (xy 107.719999 112.4447) (xy 107.72 112.444697) (xy 107.72 110.950001)
+				(xy 108.86 110.950001) (xy 108.86 112.4447) (xy 108.871603 112.503036) (xy 108.915806 112.569189)
+				(xy 108.91581 112.569193) (xy 108.981963 112.613396) (xy 109.040299 112.624999) (xy 109.040303 112.625)
+				(xy 109.459999 112.625) (xy 109.46 112.624999) (xy 109.46 110.950001) (xy 109.459999 110.95) (xy 108.860001 110.95)
+				(xy 108.86 110.950001) (xy 107.72 110.950001) (xy 107.719999 110.95) (xy 107.120001 110.95) (xy 107.12 110.950001)
+				(xy 106.92 110.950001) (xy 106.92 109.075001) (xy 107.12 109.075001) (xy 107.12 110.749999) (xy 107.120001 110.75)
+				(xy 107.719999 110.75) (xy 107.72 110.749999) (xy 107.72 109.255302) (xy 107.719999 109.255299)
+				(xy 108.86 109.255299) (xy 108.86 110.749999) (xy 108.860001 110.75) (xy 109.459999 110.75) (xy 109.46 110.749999)
+				(xy 109.46 109.075001) (xy 109.459999 109.075) (xy 109.040299 109.075) (xy 108.981963 109.086603)
+				(xy 108.91581 109.130806) (xy 108.915806 109.13081) (xy 108.871603 109.196963) (xy 108.86 109.255299)
+				(xy 107.719999 109.255299) (xy 107.708396 109.196963) (xy 107.664193 109.13081) (xy 107.664189 109.130806)
+				(xy 107.598036 109.086603) (xy 107.5397 109.075) (xy 107.120001 109.075) (xy 107.12 109.075001)
+				(xy 106.92 109.075001) (xy 106.919999 109.075) (xy 106.500299 109.075) (xy 106.468814 109.081263)
+				(xy 106.408052 109.074071) (xy 106.363123 109.032538) (xy 106.3505 108.984165) (xy 106.3505 82.560437)
+				(xy 106.350499 82.560435) (xy 106.34831 82.552267) (xy 106.330021 82.484011) (xy 106.329371 82.482886)
+				(xy 106.29046 82.415489) (xy 106.234511 82.359539) (xy 106.234511 82.35954) (xy 104.429496 80.554525)
+				(xy 104.401719 80.500008) (xy 104.4005 80.484521) (xy 104.4005 77.764479) (xy 104.419407 77.706288)
+				(xy 104.468907 77.670324) (xy 104.530093 77.670324)
 			)
 		)
 		(filled_polygon
@@ -40420,16 +40597,16 @@
 				(xy 139.165009 97.362585) (xy 139.190135 97.3655) (xy 139.479864 97.365499) (xy 139.489095 97.364428)
 				(xy 139.549076 97.376506) (xy 139.590503 97.421533) (xy 139.5995 97.462769) (xy 139.5995 99.717229)
 				(xy 139.580593 99.77542) (xy 139.531093 99.811384) (xy 139.489098 99.81557) (xy 139.479869 99.8145)
-				(xy 139.19014 99.8145) (xy 139.190135 99.814501) (xy 139.165009 99.817414) (xy 139.110638 99.841422)
+				(xy 139.19014 99.8145) (xy 139.190135 99.814501) (xy 139.165009 99.817414) (xy 139.102811 99.844878)
 				(xy 139.062235 99.862794) (xy 139.062234 99.862794) (xy 139.053843 99.8665) (xy 139.052794 99.864126)
 				(xy 139.007243 99.877537) (xy 138.96705 99.864477) (xy 138.966157 99.8665) (xy 138.957766 99.862795)
 				(xy 138.957765 99.862794) (xy 138.854991 99.817415) (xy 138.85499 99.817414) (xy 138.854988 99.817414)
 				(xy 138.829868 99.8145) (xy 138.54014 99.8145) (xy 138.540135 99.814501) (xy 138.515009 99.817414)
-				(xy 138.460638 99.841422) (xy 138.412235 99.862794) (xy 138.412234 99.862794) (xy 138.403843 99.8665)
+				(xy 138.452811 99.844878) (xy 138.412235 99.862794) (xy 138.412234 99.862794) (xy 138.403843 99.8665)
 				(xy 138.402794 99.864126) (xy 138.357243 99.877537) (xy 138.31705 99.864477) (xy 138.316157 99.8665)
 				(xy 138.307766 99.862795) (xy 138.307765 99.862794) (xy 138.204991 99.817415) (xy 138.20499 99.817414)
 				(xy 138.204988 99.817414) (xy 138.179868 99.8145) (xy 137.89014 99.8145) (xy 137.890135 99.814501)
-				(xy 137.865009 99.817414) (xy 137.810638 99.841422) (xy 137.762235 99.862794) (xy 137.762234 99.862794)
+				(xy 137.865009 99.817414) (xy 137.802811 99.844878) (xy 137.762235 99.862794) (xy 137.762234 99.862794)
 				(xy 137.753843 99.8665) (xy 137.752794 99.864126) (xy 137.707243 99.877537) (xy 137.66705 99.864477)
 				(xy 137.666157 99.8665) (xy 137.657766 99.862795) (xy 137.657765 99.862794) (xy 137.554991 99.817415)
 				(xy 137.55499 99.817414) (xy 137.554988 99.817414) (xy 137.529868 99.8145) (xy 137.24014 99.8145)
@@ -40624,7 +40801,7 @@
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 115.459191 85.698907) (xy 115.495155 85.748407) (xy 115.5 85.779) (xy 115.5 86.259999) (xy 115.500001 86.26)
+				(xy 115.459191 85.798907) (xy 115.495155 85.848407) (xy 115.5 85.879) (xy 115.5 86.259999) (xy 115.500001 86.26)
 				(xy 115.609838 86.26) (xy 115.659354 86.25348) (xy 115.659358 86.253479) (xy 115.75866 86.207174)
 				(xy 115.81939 86.199717) (xy 115.872904 86.22938) (xy 115.898762 86.284832) (xy 115.8995 86.296898)
 				(xy 115.8995 88.517382) (xy 115.919978 88.593806) (xy 115.932786 88.615989) (xy 115.932786 88.61599)
@@ -40641,8 +40818,8 @@
 				(xy 117.565479 90.7995) (xy 117.507288 90.780593) (xy 117.495475 90.770504) (xy 114.929496 88.204525)
 				(xy 114.901719 88.150008) (xy 114.9005 88.134521) (xy 114.9005 86.296898) (xy 114.919407 86.238707)
 				(xy 114.968907 86.202743) (xy 115.030093 86.202743) (xy 115.04134 86.207174) (xy 115.140641 86.253479)
-				(xy 115.140645 86.25348) (xy 115.190161 86.26) (xy 115.299999 86.26) (xy 115.3 86.259999) (xy 115.3 85.779)
-				(xy 115.318907 85.720809) (xy 115.368407 85.684845) (xy 115.399 85.68) (xy 115.401 85.68)
+				(xy 115.140645 86.25348) (xy 115.190161 86.26) (xy 115.299999 86.26) (xy 115.3 86.259999) (xy 115.3 85.879)
+				(xy 115.318907 85.820809) (xy 115.368407 85.784845) (xy 115.399 85.78) (xy 115.401 85.78)
 			)
 		)
 		(filled_polygon
@@ -40764,7 +40941,7 @@
 				(xy 113.192867 78.16326) (xy 113.191345 78.118134) (xy 113.194952 78.1) (xy 112.984615 78.1) (xy 112.974914 78.099524)
 				(xy 112.974677 78.0995) (xy 112.974674 78.0995) (xy 112.97467 78.0995) (xy 111.565479 78.0995) (xy 111.507288 78.080593)
 				(xy 111.495475 78.070504) (xy 111.309496 77.884525) (xy 111.281719 77.830008) (xy 111.2805 77.814521)
-				(xy 111.2805 75.730438) (xy 111.267512 75.681968) (xy 111.267505 75.681941) (xy 111.260022 75.654012)
+				(xy 111.2805 75.730438) (xy 111.279848 75.728003) (xy 111.267505 75.681941) (xy 111.260022 75.654012)
 				(xy 111.22046 75.585489) (xy 110.594511 74.95954) (xy 110.594508 74.959538) (xy 110.52037 74.916734)
 				(xy 110.521857 74.914158) (xy 110.484673 74.882389) (xy 110.472248 74.843137) (xy 110.470922 74.843312)
 				(xy 110.463972 74.790513) (xy 110.463972 74.790511) (xy 110.413225 74.681686) (xy 110.413224 74.681685)
@@ -40783,37 +40960,38 @@
 				(xy 107.656047 75.85545) (xy 107.611603 75.921964) (xy 107.6 75.980299) (xy 107.6 76.499999) (xy 107.600001 76.5)
 				(xy 109.399999 76.5) (xy 109.4 76.499999) (xy 109.4 76.449839) (xy 109.418907 76.391648) (xy 109.468407 76.355684)
 				(xy 109.529593 76.355684) (xy 109.569004 76.379835) (xy 109.591978 76.402809) (xy 109.700638 76.453478)
-				(xy 109.700645 76.45348) (xy 109.750161 76.46) (xy 109.859999 76.46) (xy 109.86 76.459999) (xy 109.86 76.080001)
-				(xy 110.06 76.080001) (xy 110.06 76.459999) (xy 110.060001 76.46) (xy 110.169838 76.46) (xy 110.219354 76.45348)
-				(xy 110.219361 76.453478) (xy 110.328021 76.402809) (xy 110.412809 76.318021) (xy 110.463478 76.209361)
-				(xy 110.46348 76.209354) (xy 110.47 76.159838) (xy 110.47 76.080001) (xy 110.469999 76.08) (xy 110.060001 76.08)
-				(xy 110.06 76.080001) (xy 109.86 76.080001) (xy 109.86 75.979) (xy 109.878907 75.920809) (xy 109.928407 75.884845)
-				(xy 109.959 75.88) (xy 110.469999 75.88) (xy 110.49751 75.852489) (xy 110.552027 75.824712) (xy 110.612459 75.834283)
-				(xy 110.637518 75.852489) (xy 110.650504 75.865475) (xy 110.678281 75.919992) (xy 110.6795 75.935479)
-				(xy 110.6795 77.9805) (xy 110.660593 78.038691) (xy 110.611093 78.074655) (xy 110.5805 78.0795)
-				(xy 110.235684 78.0795) (xy 110.227382 78.080593) (xy 110.186825 78.085932) (xy 110.186824 78.085932)
-				(xy 110.079598 78.135933) (xy 109.995933 78.219598) (xy 109.989724 78.232915) (xy 109.947995 78.277663)
-				(xy 109.887934 78.289337) (xy 109.832482 78.263478) (xy 109.810276 78.232915) (xy 109.804066 78.219598)
-				(xy 109.804065 78.219597) (xy 109.804065 78.219596) (xy 109.720404 78.135935) (xy 109.720402 78.135934)
-				(xy 109.720401 78.135933) (xy 109.613175 78.085932) (xy 109.572618 78.080593) (xy 109.564316 78.0795)
-				(xy 109.215684 78.0795) (xy 109.207382 78.080593) (xy 109.166825 78.085932) (xy 109.166824 78.085932)
-				(xy 109.059598 78.135933) (xy 108.975933 78.219598) (xy 108.965329 78.24234) (xy 108.923601 78.287088)
-				(xy 108.875605 78.2995) (xy 107.965479 78.2995) (xy 107.907288 78.280593) (xy 107.895475 78.270504)
-				(xy 107.663662 78.038691) (xy 107.404511 77.77954) (xy 107.404508 77.779538) (xy 107.371464 77.76046)
-				(xy 107.371462 77.760459) (xy 107.335989 77.739979) (xy 107.335986 77.739978) (xy 107.259564 77.7195)
-				(xy 107.259562 77.7195) (xy 106.831239 77.7195) (xy 106.773048 77.700593) (xy 106.759921 77.687235)
-				(xy 106.759348 77.687809) (xy 106.753224 77.681685) (xy 106.753224 77.681684) (xy 106.668316 77.596776)
-				(xy 106.668314 77.596775) (xy 106.668313 77.596774) (xy 106.657659 77.591806) (xy 106.612912 77.550076)
-				(xy 106.6005 77.502082) (xy 106.6005 77.4995) (xy 106.619407 77.441309) (xy 106.668907 77.405345)
-				(xy 106.6995 77.4005) (xy 107.019747 77.4005) (xy 107.019748 77.4005) (xy 107.078231 77.388867)
-				(xy 107.144552 77.344552) (xy 107.188867 77.278231) (xy 107.2005 77.219748) (xy 107.2005 76.700001)
-				(xy 107.6 76.700001) (xy 107.6 77.2197) (xy 107.611603 77.278036) (xy 107.655806 77.344189) (xy 107.65581 77.344193)
-				(xy 107.721963 77.388396) (xy 107.780299 77.399999) (xy 107.780303 77.4) (xy 108.399999 77.4) (xy 108.4 77.399999)
-				(xy 108.4 76.700001) (xy 108.6 76.700001) (xy 108.6 77.399999) (xy 108.600001 77.4) (xy 109.219697 77.4)
-				(xy 109.2197 77.399999) (xy 109.278036 77.388396) (xy 109.344189 77.344193) (xy 109.344193 77.344189)
-				(xy 109.388396 77.278036) (xy 109.399999 77.2197) (xy 109.4 77.219697) (xy 109.4 76.700001) (xy 109.399999 76.7)
-				(xy 108.600001 76.7) (xy 108.6 76.700001) (xy 108.4 76.700001) (xy 108.399999 76.7) (xy 107.600001 76.7)
-				(xy 107.6 76.700001) (xy 107.2005 76.700001) (xy 107.2005 75.980252) (xy 107.19939 75.974674) (xy 107.191576 75.935388)
+				(xy 109.700645 76.45348) (xy 109.750161 76.46) (xy 109.859999 76.46) (xy 109.86 76.459999) (xy 110.06 76.459999)
+				(xy 110.060001 76.46) (xy 110.169838 76.46) (xy 110.219354 76.45348) (xy 110.219361 76.453478) (xy 110.328021 76.402809)
+				(xy 110.412809 76.318021) (xy 110.463478 76.209361) (xy 110.46348 76.209354) (xy 110.47 76.159838)
+				(xy 110.47 76.080001) (xy 110.469999 76.08) (xy 110.06 76.08) (xy 110.06 76.459999) (xy 109.86 76.459999)
+				(xy 109.86 76.079) (xy 109.878907 76.020809) (xy 109.928407 75.984845) (xy 109.959 75.98) (xy 109.96 75.98)
+				(xy 109.96 75.979) (xy 109.978907 75.920809) (xy 110.028407 75.884845) (xy 110.059 75.88) (xy 110.469999 75.88)
+				(xy 110.49751 75.852489) (xy 110.552027 75.824712) (xy 110.612459 75.834283) (xy 110.637518 75.852489)
+				(xy 110.650504 75.865475) (xy 110.678281 75.919992) (xy 110.6795 75.935479) (xy 110.6795 77.9805)
+				(xy 110.660593 78.038691) (xy 110.611093 78.074655) (xy 110.5805 78.0795) (xy 110.235684 78.0795)
+				(xy 110.227382 78.080593) (xy 110.186825 78.085932) (xy 110.186824 78.085932) (xy 110.079598 78.135933)
+				(xy 109.995933 78.219598) (xy 109.989724 78.232915) (xy 109.947995 78.277663) (xy 109.887934 78.289337)
+				(xy 109.832482 78.263478) (xy 109.810276 78.232915) (xy 109.804066 78.219598) (xy 109.804065 78.219597)
+				(xy 109.804065 78.219596) (xy 109.720404 78.135935) (xy 109.720402 78.135934) (xy 109.720401 78.135933)
+				(xy 109.613175 78.085932) (xy 109.572618 78.080593) (xy 109.564316 78.0795) (xy 109.215684 78.0795)
+				(xy 109.207382 78.080593) (xy 109.166825 78.085932) (xy 109.166824 78.085932) (xy 109.059598 78.135933)
+				(xy 108.975933 78.219598) (xy 108.965329 78.24234) (xy 108.923601 78.287088) (xy 108.875605 78.2995)
+				(xy 107.965479 78.2995) (xy 107.907288 78.280593) (xy 107.895475 78.270504) (xy 107.663662 78.038691)
+				(xy 107.404511 77.77954) (xy 107.404508 77.779538) (xy 107.371464 77.76046) (xy 107.371462 77.760459)
+				(xy 107.335989 77.739979) (xy 107.335986 77.739978) (xy 107.259564 77.7195) (xy 107.259562 77.7195)
+				(xy 106.831239 77.7195) (xy 106.773048 77.700593) (xy 106.759921 77.687235) (xy 106.759348 77.687809)
+				(xy 106.753224 77.681685) (xy 106.753224 77.681684) (xy 106.668316 77.596776) (xy 106.668314 77.596775)
+				(xy 106.668313 77.596774) (xy 106.657659 77.591806) (xy 106.612912 77.550076) (xy 106.6005 77.502082)
+				(xy 106.6005 77.4995) (xy 106.619407 77.441309) (xy 106.668907 77.405345) (xy 106.6995 77.4005)
+				(xy 107.019747 77.4005) (xy 107.019748 77.4005) (xy 107.078231 77.388867) (xy 107.144552 77.344552)
+				(xy 107.188867 77.278231) (xy 107.2005 77.219748) (xy 107.2005 76.700001) (xy 107.6 76.700001) (xy 107.6 77.2197)
+				(xy 107.611603 77.278036) (xy 107.655806 77.344189) (xy 107.65581 77.344193) (xy 107.721963 77.388396)
+				(xy 107.780299 77.399999) (xy 107.780303 77.4) (xy 108.399999 77.4) (xy 108.4 77.399999) (xy 108.4 76.700001)
+				(xy 108.6 76.700001) (xy 108.6 77.399999) (xy 108.600001 77.4) (xy 109.219697 77.4) (xy 109.2197 77.399999)
+				(xy 109.278036 77.388396) (xy 109.344189 77.344193) (xy 109.344193 77.344189) (xy 109.388396 77.278036)
+				(xy 109.399999 77.2197) (xy 109.4 77.219697) (xy 109.4 76.700001) (xy 109.399999 76.7) (xy 108.600001 76.7)
+				(xy 108.6 76.700001) (xy 108.4 76.700001) (xy 108.399999 76.7) (xy 107.600001 76.7) (xy 107.6 76.700001)
+				(xy 107.2005 76.700001) (xy 107.2005 75.980252) (xy 107.19939 75.974674) (xy 107.191576 75.935388)
 				(xy 107.188867 75.921769) (xy 107.144552 75.855448) (xy 107.144551 75.855447) (xy 107.143953 75.854552)
 				(xy 107.127344 75.795664) (xy 107.143953 75.744547) (xy 107.188396 75.678034) (xy 107.199999 75.6197)
 				(xy 107.2 75.619697) (xy 107.2 75.100001) (xy 107.199999 75.1) (xy 105.400001 75.1) (xy 105.4 75.100001)
@@ -40836,38 +41014,40 @@
 				(xy 106.799006 78.325894) (xy 106.831239 78.3205) (xy 107.054521 78.3205) (xy 107.112712 78.339407)
 				(xy 107.124525 78.349496) (xy 107.55954 78.784511) (xy 107.559539 78.784511) (xy 107.615489 78.84046)
 				(xy 107.684007 78.880019) (xy 107.684011 78.880021) (xy 107.760435 78.900499) (xy 107.760437 78.9005)
-				(xy 107.760438 78.9005) (xy 108.875605 78.9005) (xy 108.933796 78.919407) (xy 108.965329 78.95766)
-				(xy 108.975933 78.980401) (xy 108.975934 78.980402) (xy 108.975935 78.980404) (xy 109.042347 79.046816)
-				(xy 109.070123 79.101331) (xy 109.060552 79.161763) (xy 109.042346 79.186821) (xy 108.997192 79.231975)
-				(xy 108.99719 79.231978) (xy 108.946521 79.340638) (xy 108.946519 79.340645) (xy 108.94 79.390161)
-				(xy 108.94 79.499999) (xy 108.940001 79.5) (xy 109.421 79.5) (xy 109.479191 79.518907) (xy 109.515155 79.568407)
-				(xy 109.52 79.599) (xy 109.52 80.109999) (xy 109.520001 80.11) (xy 109.599838 80.11) (xy 109.649354 80.10348)
-				(xy 109.649361 80.103478) (xy 109.758021 80.052809) (xy 109.829642 79.981189) (xy 109.884159 79.953412)
-				(xy 109.944591 79.962983) (xy 109.969646 79.981186) (xy 110.041684 80.053224) (xy 110.041685 80.053224)
-				(xy 110.041686 80.053225) (xy 110.050837 80.057492) (xy 110.150513 80.103972) (xy 110.200099 80.1105)
-				(xy 110.209828 80.110499) (xy 110.268019 80.129402) (xy 110.303986 80.178899) (xy 110.303991 80.240084)
-				(xy 110.279838 80.279503) (xy 109.998837 80.560504) (xy 109.94432 80.588281) (xy 109.928833 80.5895)
-				(xy 109.700104 80.5895) (xy 109.700092 80.589501) (xy 109.650513 80.596027) (xy 109.650511 80.596027)
-				(xy 109.541686 80.646774) (xy 109.541684 80.646775) (xy 109.541684 80.646776) (xy 109.469647 80.718812)
-				(xy 109.415133 80.746588) (xy 109.354701 80.737017) (xy 109.329642 80.718811) (xy 109.258021 80.64719)
-				(xy 109.149361 80.596521) (xy 109.149354 80.596519) (xy 109.099839 80.59) (xy 109.020001 80.59)
-				(xy 109.02 80.590001) (xy 109.02 81.101) (xy 109.001093 81.159191) (xy 108.951593 81.195155) (xy 108.921 81.2)
-				(xy 108.440001 81.2) (xy 108.44 81.200001) (xy 108.44 81.309838) (xy 108.446519 81.359354) (xy 108.446521 81.359361)
-				(xy 108.49719 81.468021) (xy 108.581978 81.552809) (xy 108.690638 81.603478) (xy 108.697916 81.6056)
-				(xy 108.697231 81.607947) (xy 108.742031 81.629311) (xy 108.771232 81.683079) (xy 108.763251 81.743741)
-				(xy 108.743895 81.771132) (xy 108.574525 81.940503) (xy 108.520008 81.968281) (xy 108.504521 81.9695)
-				(xy 108.275684 81.9695) (xy 108.259398 81.971644) (xy 108.226825 81.975932) (xy 108.226824 81.975932)
-				(xy 108.119598 82.025933) (xy 108.035933 82.109598) (xy 107.989224 82.209767) (xy 107.947496 82.254515)
-				(xy 107.887435 82.266189) (xy 107.831982 82.240331) (xy 107.802319 82.186817) (xy 107.8005 82.167927)
-				(xy 107.8005 81.688255) (xy 107.800499 81.688253) (xy 107.799496 81.684511) (xy 107.780021 81.611829)
-				(xy 107.74046 81.543307) (xy 107.717131 81.519978) (xy 107.684511 81.487357) (xy 107.684511 81.487358)
-				(xy 107.087314 80.890161) (xy 108.44 80.890161) (xy 108.44 80.999999) (xy 108.440001 81) (xy 108.819999 81)
-				(xy 108.82 80.999999) (xy 108.82 80.590001) (xy 108.819999 80.59) (xy 108.740161 80.59) (xy 108.690645 80.596519)
-				(xy 108.690638 80.596521) (xy 108.581978 80.64719) (xy 108.49719 80.731978) (xy 108.446521 80.840638)
-				(xy 108.446519 80.840645) (xy 108.44 80.890161) (xy 107.087314 80.890161) (xy 105.897154 79.700001)
-				(xy 108.94 79.700001) (xy 108.94 79.809838) (xy 108.946519 79.859354) (xy 108.946521 79.859361)
-				(xy 108.99719 79.968021) (xy 109.081978 80.052809) (xy 109.190638 80.103478) (xy 109.190645 80.10348)
-				(xy 109.240161 80.11) (xy 109.319999 80.11) (xy 109.32 80.109999) (xy 109.32 79.700001) (xy 109.319999 79.7)
+				(xy 107.760438 78.9005) (xy 107.839562 78.9005) (xy 108.875605 78.9005) (xy 108.933796 78.919407)
+				(xy 108.965329 78.95766) (xy 108.975933 78.980401) (xy 108.975934 78.980402) (xy 108.975935 78.980404)
+				(xy 109.042347 79.046816) (xy 109.070123 79.101331) (xy 109.060552 79.161763) (xy 109.042346 79.186821)
+				(xy 108.997192 79.231975) (xy 108.99719 79.231978) (xy 108.946521 79.340638) (xy 108.946519 79.340645)
+				(xy 108.94 79.390161) (xy 108.94 79.499999) (xy 108.940001 79.5) (xy 109.321 79.5) (xy 109.379191 79.518907)
+				(xy 109.415155 79.568407) (xy 109.42 79.599) (xy 109.42 79.6) (xy 109.421 79.6) (xy 109.479191 79.618907)
+				(xy 109.515155 79.668407) (xy 109.52 79.699) (xy 109.52 80.109999) (xy 109.520001 80.11) (xy 109.599838 80.11)
+				(xy 109.649354 80.10348) (xy 109.649361 80.103478) (xy 109.758021 80.052809) (xy 109.829642 79.981189)
+				(xy 109.884159 79.953412) (xy 109.944591 79.962983) (xy 109.969646 79.981186) (xy 110.041684 80.053224)
+				(xy 110.041685 80.053224) (xy 110.041686 80.053225) (xy 110.050837 80.057492) (xy 110.150513 80.103972)
+				(xy 110.200099 80.1105) (xy 110.209828 80.110499) (xy 110.268019 80.129402) (xy 110.303986 80.178899)
+				(xy 110.303991 80.240084) (xy 110.279838 80.279503) (xy 109.998837 80.560504) (xy 109.94432 80.588281)
+				(xy 109.928833 80.5895) (xy 109.700104 80.5895) (xy 109.700092 80.589501) (xy 109.650513 80.596027)
+				(xy 109.650511 80.596027) (xy 109.541686 80.646774) (xy 109.541684 80.646775) (xy 109.541684 80.646776)
+				(xy 109.469647 80.718812) (xy 109.415133 80.746588) (xy 109.354701 80.737017) (xy 109.329642 80.718811)
+				(xy 109.258021 80.64719) (xy 109.149361 80.596521) (xy 109.149354 80.596519) (xy 109.099839 80.59)
+				(xy 109.020001 80.59) (xy 109.02 80.590001) (xy 109.02 81.001) (xy 109.001093 81.059191) (xy 108.951593 81.095155)
+				(xy 108.921 81.1) (xy 108.92 81.1) (xy 108.92 81.101) (xy 108.901093 81.159191) (xy 108.851593 81.195155)
+				(xy 108.821 81.2) (xy 108.440001 81.2) (xy 108.44 81.200001) (xy 108.44 81.309838) (xy 108.446519 81.359354)
+				(xy 108.446521 81.359361) (xy 108.49719 81.468021) (xy 108.581978 81.552809) (xy 108.690638 81.603478)
+				(xy 108.697916 81.6056) (xy 108.697231 81.607947) (xy 108.742031 81.629311) (xy 108.771232 81.683079)
+				(xy 108.763251 81.743741) (xy 108.743895 81.771132) (xy 108.574525 81.940503) (xy 108.520008 81.968281)
+				(xy 108.504521 81.9695) (xy 108.275684 81.9695) (xy 108.259398 81.971644) (xy 108.226825 81.975932)
+				(xy 108.226824 81.975932) (xy 108.119598 82.025933) (xy 108.035933 82.109598) (xy 107.989224 82.209767)
+				(xy 107.947496 82.254515) (xy 107.887435 82.266189) (xy 107.831982 82.240331) (xy 107.802319 82.186817)
+				(xy 107.8005 82.167927) (xy 107.8005 81.688255) (xy 107.800499 81.688253) (xy 107.799496 81.684511)
+				(xy 107.780021 81.611829) (xy 107.74046 81.543307) (xy 107.717131 81.519978) (xy 107.684511 81.487357)
+				(xy 107.684511 81.487358) (xy 107.087314 80.890161) (xy 108.44 80.890161) (xy 108.44 80.999999)
+				(xy 108.440001 81) (xy 108.82 81) (xy 108.82 80.590001) (xy 108.819999 80.59) (xy 108.740161 80.59)
+				(xy 108.690645 80.596519) (xy 108.690638 80.596521) (xy 108.581978 80.64719) (xy 108.49719 80.731978)
+				(xy 108.446521 80.840638) (xy 108.446519 80.840645) (xy 108.44 80.890161) (xy 107.087314 80.890161)
+				(xy 105.897154 79.700001) (xy 108.94 79.700001) (xy 108.94 79.809838) (xy 108.946519 79.859354)
+				(xy 108.946521 79.859361) (xy 108.99719 79.968021) (xy 109.081978 80.052809) (xy 109.190638 80.103478)
+				(xy 109.190645 80.10348) (xy 109.240161 80.11) (xy 109.319999 80.11) (xy 109.32 80.109999) (xy 109.32 79.7)
 				(xy 108.940001 79.7) (xy 108.94 79.700001) (xy 105.897154 79.700001) (xy 105.529496 79.332343) (xy 105.501719 79.277826)
 				(xy 105.5005 79.262339) (xy 105.5005 79.080001) (xy 105.79 79.080001) (xy 105.79 79.159838) (xy 105.796519 79.209354)
 				(xy 105.796521 79.209361) (xy 105.84719 79.318021) (xy 105.931978 79.402809) (xy 106.040638 79.453478)
@@ -40941,16 +41121,17 @@
 				(xy 138.399647 80.451394) (xy 138.403406 80.438062) (xy 138.404512 80.432498) (xy 138.404515 80.432495)
 				(xy 138.4205 80.352133) (xy 138.420499 80.147868) (xy 138.416738 80.128959) (xy 138.42393 80.0682)
 				(xy 138.464337 80.02391) (xy 138.487626 80.010465) (xy 138.74486 79.75323) (xy 138.744862 79.753229)
-				(xy 138.805465 79.692626) (xy 138.848318 79.618402) (xy 138.853249 79.6) (xy 138.870501 79.535617)
-				(xy 138.870501 79.449911) (xy 138.870501 79.443849) (xy 138.8705 79.443831) (xy 138.8705 79.058076)
-				(xy 138.870501 79.058063) (xy 138.870501 78.964382) (xy 138.8705 78.96438) (xy 138.848318 78.881598)
-				(xy 138.824567 78.84046) (xy 138.824567 78.840459) (xy 138.805464 78.807373) (xy 138.744862 78.74677)
-				(xy 138.744862 78.746771) (xy 138.74486 78.746769) (xy 138.74486 78.746768) (xy 138.487626 78.489535)
-				(xy 138.487624 78.489533) (xy 138.464336 78.476088) (xy 138.423396 78.430618) (xy 138.41674 78.371035)
-				(xy 138.420499 78.352137) (xy 138.4205 78.352133) (xy 138.420499 78.147868) (xy 138.419843 78.144572)
-				(xy 138.404515 78.067506) (xy 138.404515 78.067505) (xy 138.396159 78.055) (xy 138.379551 77.996114)
-				(xy 138.396159 77.944999) (xy 138.404515 77.932495) (xy 138.4205 77.852133) (xy 138.420499 77.647868)
-				(xy 138.408485 77.587465) (xy 138.415677 77.526705) (xy 138.45721 77.481776) (xy 138.51722 77.469839)
+				(xy 138.805465 79.692626) (xy 138.835586 79.640454) (xy 138.848316 79.618406) (xy 138.848316 79.618404)
+				(xy 138.848318 79.618402) (xy 138.853249 79.6) (xy 138.870501 79.535617) (xy 138.870501 79.449911)
+				(xy 138.870501 79.443849) (xy 138.8705 79.443831) (xy 138.8705 79.058076) (xy 138.870501 79.058063)
+				(xy 138.870501 78.964382) (xy 138.8705 78.96438) (xy 138.848318 78.881598) (xy 138.824567 78.84046)
+				(xy 138.824567 78.840459) (xy 138.805464 78.807373) (xy 138.744862 78.74677) (xy 138.744862 78.746771)
+				(xy 138.74486 78.746769) (xy 138.74486 78.746768) (xy 138.487626 78.489535) (xy 138.487624 78.489533)
+				(xy 138.464336 78.476088) (xy 138.423396 78.430618) (xy 138.41674 78.371035) (xy 138.420499 78.352137)
+				(xy 138.4205 78.352133) (xy 138.420499 78.147868) (xy 138.419843 78.144572) (xy 138.404515 78.067506)
+				(xy 138.404515 78.067505) (xy 138.396159 78.055) (xy 138.379551 77.996114) (xy 138.396159 77.944999)
+				(xy 138.404515 77.932495) (xy 138.4205 77.852133) (xy 138.420499 77.647868) (xy 138.408485 77.587465)
+				(xy 138.415677 77.526705) (xy 138.45721 77.481776) (xy 138.51722 77.469839)
 			)
 		)
 		(filled_polygon
@@ -41059,7 +41240,7 @@
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 105.200445 68.245533) (xy 105.24371 68.288798) (xy 105.2545 68.333743) (xy 105.2545 68.674274)
+				(xy 105.200445 68.433033) (xy 105.24371 68.476298) (xy 105.2545 68.521243) (xy 105.2545 68.674274)
 				(xy 105.257353 68.704694) (xy 105.257355 68.704703) (xy 105.302207 68.832883) (xy 105.382845 68.942144)
 				(xy 105.382847 68.942146) (xy 105.38285 68.94215) (xy 105.382853 68.942152) (xy 105.382855 68.942154)
 				(xy 105.492116 69.022792) (xy 105.492117 69.022792) (xy 105.492118 69.022793) (xy 105.620301 69.067646)
@@ -41099,10 +41280,10 @@
 				(xy 107.260278 71.854636) (xy 107.2745 71.905761) (xy 107.2745 72.394274) (xy 107.277353 72.424694)
 				(xy 107.277355 72.424703) (xy 107.292436 72.467802) (xy 107.293809 72.528972) (xy 107.258965 72.579267)
 				(xy 107.201213 72.599475) (xy 107.198992 72.5995) (xy 105.439562 72.5995) (xy 105.360438 72.5995)
-				(xy 105.319654 72.610428) (xy 105.284007 72.619979) (xy 105.215493 72.659536) (xy 104.369504 73.505525)
-				(xy 104.314987 73.533302) (xy 104.254555 73.523731) (xy 104.21129 73.480466) (xy 104.2005 73.435521)
-				(xy 104.2005 69.189743) (xy 104.219407 69.131552) (xy 104.229496 69.119739) (xy 105.085496 68.263739)
-				(xy 105.140013 68.235962)
+				(xy 105.319654 72.610428) (xy 105.284007 72.619979) (xy 105.215493 72.659536) (xy 104.469504 73.405525)
+				(xy 104.414987 73.433302) (xy 104.354555 73.423731) (xy 104.31129 73.380466) (xy 104.3005 73.335521)
+				(xy 104.3005 69.277243) (xy 104.319407 69.219052) (xy 104.329496 69.207239) (xy 105.085496 68.451239)
+				(xy 105.140013 68.423462)
 			)
 		)
 		(filled_polygon
@@ -41115,7 +41296,7 @@
 				(xy 119.498049 70.893967) (xy 119.549429 70.834669) (xy 119.601824 70.803073) (xy 119.624249 70.8005)
 				(xy 120.966663 70.8005) (xy 121.024854 70.819407) (xy 121.060818 70.868907) (xy 121.061471 70.914356)
 				(xy 121.06431 70.914765) (xy 121.044867 71.049997) (xy 121.044867 71.050002) (xy 121.063302 71.178225)
-				(xy 121.109791 71.280019) (xy 121.117118 71.296063) (xy 121.154998 71.339779) (xy 121.173099 71.360669)
+				(xy 121.109413 71.279191) (xy 121.117118 71.296063) (xy 121.154998 71.339779) (xy 121.173099 71.360669)
 				(xy 121.196916 71.417029) (xy 121.183057 71.476624) (xy 121.136816 71.516692) (xy 121.098279 71.5245)
 				(xy 120.743479 71.5245) (xy 120.743476 71.524501) (xy 120.6497 71.539352) (xy 120.649695 71.539354)
 				(xy 120.536659 71.596949) (xy 120.446949 71.686659) (xy 120.389354 71.799694) (xy 120.378465 71.868444)
@@ -41212,98 +41393,15 @@
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 121.188093 67.774407) (xy 121.199906 67.784496) (xy 122.445906 69.030496) (xy 122.473683 69.085013)
+				(xy 121.058093 67.644407) (xy 121.069906 67.654496) (xy 122.445906 69.030496) (xy 122.473683 69.085013)
 				(xy 122.464112 69.145445) (xy 122.420847 69.18871) (xy 122.375902 69.1995) (xy 119.665479 69.1995)
 				(xy 119.607288 69.180593) (xy 119.595476 69.170504) (xy 119.18451 68.759539) (xy 119.166617 68.749208)
 				(xy 119.166617 68.749209) (xy 119.115989 68.719979) (xy 119.115988 68.719978) (xy 119.115987 68.719978)
 				(xy 119.039564 68.6995) (xy 119.039562 68.6995) (xy 118.920704 68.6995) (xy 118.862513 68.680593)
 				(xy 118.826549 68.631093) (xy 118.826549 68.569907) (xy 118.832494 68.555555) (xy 118.860646 68.500304)
-				(xy 118.8755 68.406519) (xy 118.875499 67.943482) (xy 118.867871 67.895317) (xy 118.86386 67.869986)
-				(xy 118.873432 67.809554) (xy 118.916697 67.76629) (xy 118.961641 67.7555) (xy 121.129902 67.7555)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 132.039306 59.086907) (xy 132.07527 59.136407) (xy 132.078357 59.151168) (xy 132.078552 59.15113)
-				(xy 132.094759 59.232616) (xy 132.09476 59.232618) (xy 132.137686 59.296861) (xy 132.152888 59.319612)
-				(xy 132.239883 59.37774) (xy 132.316599 59.393) (xy 132.4934 59.392999) (xy 132.570117 59.37774)
-				(xy 132.599998 59.357773) (xy 132.658886 59.341165) (xy 132.710002 59.357774) (xy 132.739879 59.377738)
-				(xy 132.73988 59.377738) (xy 132.739883 59.37774) (xy 132.816599 59.393) (xy 132.9934 59.392999)
-				(xy 133.070117 59.37774) (xy 133.099998 59.357773) (xy 133.158886 59.341165) (xy 133.210002 59.357774)
-				(xy 133.239879 59.377738) (xy 133.23988 59.377738) (xy 133.239883 59.37774) (xy 133.316599 59.393)
-				(xy 133.4934 59.392999) (xy 133.570117 59.37774) (xy 133.599998 59.357773) (xy 133.658886 59.341165)
-				(xy 133.710002 59.357774) (xy 133.739879 59.377738) (xy 133.73988 59.377738) (xy 133.739883 59.37774)
-				(xy 133.816599 59.393) (xy 133.9934 59.392999) (xy 134.070117 59.37774) (xy 134.099998 59.357773)
-				(xy 134.158886 59.341165) (xy 134.210002 59.357774) (xy 134.239879 59.377738) (xy 134.23988 59.377738)
-				(xy 134.239883 59.37774) (xy 134.316599 59.393) (xy 134.4934 59.392999) (xy 134.570117 59.37774)
-				(xy 134.570116 59.37774) (xy 134.57968 59.375838) (xy 134.580399 59.379453) (xy 134.623569 59.376036)
-				(xy 134.675752 59.407982) (xy 134.699191 59.4645) (xy 134.6995 59.472311) (xy 134.6995 60.962688)
-				(xy 134.680593 61.020879) (xy 134.631093 61.056843) (xy 134.58014 61.056843) (xy 134.579679 61.059162)
-				(xy 134.49341 61.042001) (xy 134.493402 61.042) (xy 134.493401 61.042) (xy 134.4934 61.042) (xy 134.316602 61.042)
-				(xy 134.316595 61.042001) (xy 134.239884 61.057259) (xy 134.21 61.077227) (xy 134.151111 61.093834)
-				(xy 134.099999 61.077226) (xy 134.070119 61.057261) (xy 134.070117 61.05726) (xy 134.070114 61.057259)
-				(xy 134.070113 61.057259) (xy 133.99341 61.042001) (xy 133.993402 61.042) (xy 133.993401 61.042)
-				(xy 133.9934 61.042) (xy 133.816602 61.042) (xy 133.816595 61.042001) (xy 133.739884 61.057259)
-				(xy 133.71 61.077227) (xy 133.651111 61.093834) (xy 133.599999 61.077226) (xy 133.570119 61.057261)
-				(xy 133.570117 61.05726) (xy 133.570114 61.057259) (xy 133.570113 61.057259) (xy 133.49341 61.042001)
-				(xy 133.493402 61.042) (xy 133.493401 61.042) (xy 133.4934 61.042) (xy 133.316602 61.042) (xy 133.316595 61.042001)
-				(xy 133.239884 61.057259) (xy 133.239882 61.05726) (xy 133.209549 61.077527) (xy 133.15066 61.094134)
-				(xy 133.099548 61.077525) (xy 133.069924 61.057731) (xy 133.005 61.044816) (xy 133.005 61.6685)
-				(xy 132.986093 61.726691) (xy 132.936593 61.762655) (xy 132.906 61.7675) (xy 132.505001 61.7675)
-				(xy 132.505 61.767501) (xy 132.505 62.292322) (xy 132.5351 62.339344) (xy 132.531498 62.400423)
-				(xy 132.509312 62.434345) (xy 126.915489 68.028168) (xy 126.915488 68.028167) (xy 126.859539 68.084117)
-				(xy 126.81998 68.152635) (xy 126.819978 68.152639) (xy 126.7995 68.229063) (xy 126.7995 68.834521)
-				(xy 126.780593 68.892712) (xy 126.770503 68.904525) (xy 126.614701 69.060326) (xy 126.560185 69.088103)
-				(xy 126.499753 69.078532) (xy 126.456488 69.035267) (xy 126.446321 68.979237) (xy 126.455249 68.900003)
-				(xy 126.455249 68.899995) (xy 126.436314 68.731946) (xy 126.436311 68.731934) (xy 126.40168 68.632965)
-				(xy 126.380456 68.57231) (xy 126.35604 68.533453) (xy 126.290479 68.429113) (xy 126.290478 68.429112)
-				(xy 126.290477 68.42911) (xy 126.17089 68.309523) (xy 126.170887 68.309521) (xy 126.170886 68.30952)
-				(xy 126.027691 68.219544) (xy 125.868065 68.163688) (xy 125.868053 68.163685) (xy 125.700004 68.144751)
-				(xy 125.699996 68.144751) (xy 125.531946 68.163685) (xy 125.531934 68.163688) (xy 125.372309 68.219544)
-				(xy 125.372308 68.219544) (xy 125.308997 68.259326) (xy 125.256326 68.2745) (xy 124.223943 68.2745)
-				(xy 124.165752 68.255593) (xy 124.129788 68.206093) (xy 124.129788 68.144907) (xy 124.13389 68.134372)
-				(xy 124.136698 68.128223) (xy 124.155133 68.000002) (xy 124.155133 67.999997) (xy 124.136697 67.871774)
-				(xy 124.115564 67.8255) (xy 124.082882 67.753937) (xy 123.998049 67.656033) (xy 123.998048 67.656032)
-				(xy 123.998047 67.656031) (xy 123.889073 67.585998) (xy 123.88907 67.585996) (xy 123.889069 67.585996)
-				(xy 123.874748 67.581791) (xy 123.764774 67.5495) (xy 123.764772 67.5495) (xy 123.750834 67.5495)
-				(xy 123.692643 67.530593) (xy 123.68083 67.520504) (xy 122.229831 66.069504) (xy 122.202054 66.014987)
-				(xy 122.211625 65.954555) (xy 122.25489 65.91129) (xy 122.299835 65.9005) (xy 124.252725 65.9005)
-				(xy 124.252727 65.9005) (xy 124.354588 65.873207) (xy 124.35459 65.873205) (xy 124.354592 65.873205)
-				(xy 124.445908 65.820483) (xy 124.445908 65.820482) (xy 124.445913 65.82048) (xy 124.77048 65.495913)
-				(xy 124.779667 65.480001) (xy 124.781912 65.476113) (xy 124.823206 65.404588) (xy 124.823207 65.404587)
-				(xy 124.8505 65.302727) (xy 124.8505 65.069865) (xy 124.869407 65.011674) (xy 124.907448 64.983381)
-				(xy 124.906326 64.981258) (xy 124.912879 64.977793) (xy 124.912882 64.977793) (xy 125.02215 64.89715)
-				(xy 125.102793 64.787882) (xy 125.147646 64.659699) (xy 125.148488 64.650712) (xy 125.14947 64.640255)
-				(xy 125.173728 64.584085) (xy 125.22637 64.5529) (xy 125.248037 64.5505) (xy 125.559309 64.5505)
-				(xy 125.649669 64.526287) (xy 125.649672 64.526287) (xy 125.662903 64.522741) (xy 125.673887 64.519799)
-				(xy 125.776614 64.460489) (xy 126.460489 63.776614) (xy 126.519799 63.673887) (xy 126.526332 63.649503)
-				(xy 126.526334 63.6495) (xy 126.526333 63.6495) (xy 126.531399 63.630593) (xy 126.5505 63.559309)
-				(xy 126.5505 62.6745) (xy 126.569407 62.616309) (xy 126.618907 62.580345) (xy 126.6495 62.5755)
-				(xy 126.761882 62.5755) (xy 126.761882 62.575499) (xy 126.785333 62.572779) (xy 126.881267 62.53042)
-				(xy 126.95542 62.456267) (xy 126.997779 62.360333) (xy 127.0005 62.33688) (xy 127.0005 61.767501)
-				(xy 132.08 61.767501) (xy 132.08 62.055856) (xy 132.095231 62.132423) (xy 132.09523 62.132423) (xy 132.153246 62.219249)
-				(xy 132.153251 62.219254) (xy 132.240075 62.277269) (xy 132.240078 62.27727) (xy 132.304999 62.290183)
-				(xy 132.305 62.290182) (xy 132.305 61.767501) (xy 132.304999 61.7675) (xy 132.080001 61.7675) (xy 132.08 61.767501)
-				(xy 127.0005 61.767501) (xy 127.0005 61.61312) (xy 126.997779 61.589667) (xy 126.95542 61.493733)
-				(xy 126.881267 61.41958) (xy 126.785333 61.377221) (xy 126.785332 61.37722) (xy 126.78533 61.37722)
-				(xy 126.761884 61.3745) (xy 126.76188 61.3745) (xy 125.43812 61.3745) (xy 125.438115 61.3745) (xy 125.414669 61.37722)
-				(xy 125.318731 61.419581) (xy 125.25658 61.481732) (xy 125.202063 61.509509) (xy 125.141631 61.499937)
-				(xy 125.098367 61.456672) (xy 125.087882 61.403963) (xy 125.097706 61.279143) (xy 132.08 61.279143)
-				(xy 132.08 61.567499) (xy 132.080001 61.5675) (xy 132.304999 61.5675) (xy 132.305 61.567499) (xy 132.305 61.044816)
-				(xy 132.505 61.044816) (xy 132.505 61.567499) (xy 132.505001 61.5675) (xy 132.804999 61.5675) (xy 132.805 61.567499)
-				(xy 132.805 61.044816) (xy 132.740075 61.057731) (xy 132.740074 61.057731) (xy 132.710001 61.077826)
-				(xy 132.651113 61.094434) (xy 132.599999 61.077826) (xy 132.569925 61.057731) (xy 132.505 61.044816)
-				(xy 132.305 61.044816) (xy 132.240076 61.057731) (xy 132.15325 61.115746) (xy 132.153246 61.11575)
-				(xy 132.095231 61.202576) (xy 132.08 61.279143) (xy 125.097706 61.279143) (xy 125.1 61.25) (xy 125.087882 61.096036)
-				(xy 125.102165 61.036544) (xy 125.148691 60.996807) (xy 125.209688 60.992006) (xy 125.256578 61.018265)
-				(xy 125.318733 61.08042) (xy 125.414667 61.122779) (xy 125.438116 61.125499) (xy 125.438118 61.1255)
-				(xy 125.43812 61.1255) (xy 126.761882 61.1255) (xy 126.761882 61.125499) (xy 126.785333 61.122779)
-				(xy 126.881267 61.08042) (xy 126.95542 61.006267) (xy 126.997779 60.910333) (xy 126.997779 60.910327)
-				(xy 126.999734 60.903147) (xy 127.001762 60.903699) (xy 127.022943 60.85747) (xy 127.076257 60.827448)
-				(xy 127.095799 60.8255) (xy 129.214563 60.8255) (xy 129.214563 60.825499) (xy 129.290989 60.805021)
-				(xy 129.359511 60.76546) (xy 129.41546 60.709511) (xy 131.027975 59.096996) (xy 131.082492 59.069219)
-				(xy 131.097979 59.068) (xy 131.981115 59.068)
+				(xy 118.8755 68.406519) (xy 118.875499 67.943482) (xy 118.865781 67.882118) (xy 118.860647 67.8497)
+				(xy 118.860646 67.849695) (xy 118.833836 67.797078) (xy 118.819755 67.769444) (xy 118.810184 67.709014)
+				(xy 118.837961 67.654497) (xy 118.892477 67.626719) (xy 118.907965 67.6255) (xy 120.999902 67.6255)
 			)
 		)
 		(filled_polygon
@@ -41318,14 +41416,13 @@
 				(xy 131.339352 68.500299) (xy 131.339353 68.500302) (xy 131.367506 68.555555) (xy 131.377077 68.615987)
 				(xy 131.3493 68.670503) (xy 131.294783 68.698281) (xy 131.279296 68.6995) (xy 130.020704 68.6995)
 				(xy 129.962513 68.680593) (xy 129.926549 68.631093) (xy 129.926549 68.569907) (xy 129.932494 68.555555)
-				(xy 129.960646 68.500304) (xy 129.9755 68.406519) (xy 129.975499 67.943482) (xy 129.975498 67.943478)
-				(xy 129.975498 67.943476) (xy 129.960647 67.8497) (xy 129.960646 67.849698) (xy 129.960646 67.849696)
-				(xy 129.90305 67.736658) (xy 129.813342 67.64695) (xy 129.700304 67.589354) (xy 129.700306 67.589354)
-				(xy 129.68401 67.586773) (xy 129.629494 67.558993) (xy 129.601718 67.504476) (xy 129.6005 67.488992)
-				(xy 129.6005 67.365479) (xy 129.619407 67.307288) (xy 129.629496 67.295475) (xy 133.095475 63.829496)
-				(xy 133.149992 63.801719) (xy 133.165479 63.8005) (xy 133.305249 63.8005) (xy 133.305249 63.800499)
-				(xy 133.381675 63.780021) (xy 133.450197 63.74046) (xy 133.506146 63.684511) (xy 134.530498 62.660158)
-				(xy 134.585013 62.632383)
+				(xy 129.960646 68.500304) (xy 129.9755 68.406519) (xy 129.975499 67.943482) (xy 129.965781 67.882118)
+				(xy 129.960647 67.8497) (xy 129.960646 67.849698) (xy 129.960646 67.849696) (xy 129.90305 67.736658)
+				(xy 129.813342 67.64695) (xy 129.700304 67.589354) (xy 129.700306 67.589354) (xy 129.68401 67.586773)
+				(xy 129.629494 67.558993) (xy 129.601718 67.504476) (xy 129.6005 67.488992) (xy 129.6005 67.365479)
+				(xy 129.619407 67.307288) (xy 129.629496 67.295475) (xy 133.095475 63.829496) (xy 133.149992 63.801719)
+				(xy 133.165479 63.8005) (xy 133.305249 63.8005) (xy 133.305249 63.800499) (xy 133.381675 63.780021)
+				(xy 133.450197 63.74046) (xy 133.506146 63.684511) (xy 134.530498 62.660158) (xy 134.585013 62.632383)
 			)
 		)
 		(filled_polygon
@@ -41338,15 +41435,15 @@
 				(xy 138.282882 58.510293) (xy 138.39215 58.42965) (xy 138.447918 58.354087) (xy 138.452254 58.348212)
 				(xy 138.502021 58.312619) (xy 138.531909 58.308) (xy 138.629889 58.308) (xy 138.68808 58.326907)
 				(xy 138.699893 58.336996) (xy 139.020504 58.657607) (xy 139.048281 58.712124) (xy 139.0495 58.727611)
-				(xy 139.0495 61.21927) (xy 139.030593 61.277461) (xy 138.986266 61.311584) (xy 138.9769 61.315212)
-				(xy 138.962599 61.320753) (xy 138.828213 61.403961) (xy 138.773438 61.437876) (xy 138.631248 61.5675)
-				(xy 138.609019 61.587764) (xy 138.594657 61.606782) (xy 138.474943 61.765309) (xy 138.474938 61.765318)
+				(xy 139.0495 61.21927) (xy 139.030593 61.277461) (xy 138.986266 61.311584) (xy 138.977002 61.315173)
+				(xy 138.962599 61.320753) (xy 138.802987 61.41958) (xy 138.773438 61.437876) (xy 138.630151 61.5685)
+				(xy 138.609019 61.587764) (xy 138.589875 61.613115) (xy 138.474943 61.765309) (xy 138.474938 61.765318)
 				(xy 138.375772 61.964469) (xy 138.375771 61.964472) (xy 138.314885 62.178464) (xy 138.294357 62.4)
-				(xy 138.314885 62.621536) (xy 138.362332 62.788296) (xy 138.375772 62.83553) (xy 138.394413 62.872966)
+				(xy 138.314885 62.621536) (xy 138.365662 62.8) (xy 138.375772 62.83553) (xy 138.394413 62.872966)
 				(xy 138.403426 62.933484) (xy 138.375796 62.987098) (xy 135.989508 65.373389) (xy 135.989507 65.37339)
-				(xy 135.9302 65.476112) (xy 135.9302 65.476113) (xy 135.930201 65.476114) (xy 135.918576 65.519501)
+				(xy 135.9302 65.476112) (xy 135.9302 65.476113) (xy 135.930201 65.476114) (xy 135.915763 65.529999)
 				(xy 135.8995 65.590692) (xy 135.8995 65.843731) (xy 135.889441 65.887211) (xy 135.859427 65.948604)
-				(xy 135.859427 65.948607) (xy 135.849756 66.014987) (xy 135.8495 66.016743) (xy 135.8495 66.0505)
+				(xy 135.859427 65.948607) (xy 135.850033 66.013087) (xy 135.8495 66.016743) (xy 135.8495 66.0505)
 				(xy 135.830593 66.108691) (xy 135.781093 66.144655) (xy 135.7505 66.1495) (xy 135.023118 66.1495)
 				(xy 134.978173 66.13871) (xy 134.97149 66.135305) (xy 134.883126 66.090281) (xy 134.78349 66.0745)
 				(xy 134.783488 66.0745) (xy 134.216512 66.0745) (xy 134.21651 66.0745) (xy 134.116874 66.090281)
@@ -41368,23 +41465,23 @@
 				(xy 135.3005 59.857501) (xy 135.3005 59.512839) (xy 135.319407 59.454648) (xy 135.368907 59.418684)
 				(xy 135.430093 59.418684) (xy 135.469504 59.442835) (xy 135.516978 59.490309) (xy 135.625638 59.540978)
 				(xy 135.625645 59.54098) (xy 135.675161 59.5475) (xy 135.784999 59.5475) (xy 135.785 59.547499)
-				(xy 135.785 59.167501) (xy 135.985 59.167501) (xy 135.985 59.547499) (xy 135.985001 59.5475) (xy 136.094838 59.5475)
-				(xy 136.144354 59.54098) (xy 136.144361 59.540978) (xy 136.253021 59.490309) (xy 136.290042 59.453288)
-				(xy 136.67 59.453288) (xy 136.67 59.657499) (xy 136.670001 59.6575) (xy 137.494999 59.6575) (xy 137.495 59.657499)
-				(xy 137.495 59.057501) (xy 137.695 59.057501) (xy 137.695 59.657499) (xy 137.695001 59.6575) (xy 138.519998 59.6575)
-				(xy 138.519999 59.657499) (xy 138.519999 59.453296) (xy 138.517149 59.422899) (xy 138.517149 59.422897)
-				(xy 138.472345 59.294852) (xy 138.391792 59.185709) (xy 138.39179 59.185707) (xy 138.282647 59.105154)
-				(xy 138.154601 59.06035) (xy 138.124211 59.0575) (xy 137.695001 59.0575) (xy 137.695 59.057501)
-				(xy 137.495 59.057501) (xy 137.494999 59.0575) (xy 137.065796 59.0575) (xy 137.035399 59.06035)
-				(xy 137.035397 59.06035) (xy 136.907352 59.105154) (xy 136.798209 59.185707) (xy 136.798207 59.185709)
-				(xy 136.717654 59.294852) (xy 136.67285 59.422898) (xy 136.67 59.453288) (xy 136.290042 59.453288)
-				(xy 136.337809 59.405521) (xy 136.388478 59.296861) (xy 136.38848 59.296854) (xy 136.395 59.247338)
-				(xy 136.395 59.167501) (xy 136.394999 59.1675) (xy 135.985001 59.1675) (xy 135.985 59.167501) (xy 135.785 59.167501)
-				(xy 135.785 59.0665) (xy 135.803907 59.008309) (xy 135.853407 58.972345) (xy 135.884 58.9675) (xy 136.394999 58.9675)
-				(xy 136.395 58.967499) (xy 136.395 58.887661) (xy 136.38848 58.838145) (xy 136.388478 58.838138)
-				(xy 136.337809 58.729478) (xy 136.266189 58.657858) (xy 136.238412 58.603341) (xy 136.247983 58.542909)
-				(xy 136.266186 58.517853) (xy 136.338224 58.445816) (xy 136.359716 58.399727) (xy 136.375835 58.36516)
-				(xy 136.417563 58.320412) (xy 136.465559 58.308) (xy 136.658091 58.308)
+				(xy 135.985 59.547499) (xy 135.985001 59.5475) (xy 136.094838 59.5475) (xy 136.144354 59.54098)
+				(xy 136.144361 59.540978) (xy 136.253021 59.490309) (xy 136.290042 59.453288) (xy 136.67 59.453288)
+				(xy 136.67 59.657499) (xy 136.670001 59.6575) (xy 137.494999 59.6575) (xy 137.495 59.657499) (xy 137.495 59.057501)
+				(xy 137.695 59.057501) (xy 137.695 59.657499) (xy 137.695001 59.6575) (xy 138.519998 59.6575) (xy 138.519999 59.657499)
+				(xy 138.519999 59.453296) (xy 138.517149 59.422899) (xy 138.517149 59.422897) (xy 138.472345 59.294852)
+				(xy 138.391792 59.185709) (xy 138.39179 59.185707) (xy 138.282647 59.105154) (xy 138.154601 59.06035)
+				(xy 138.124211 59.0575) (xy 137.695001 59.0575) (xy 137.695 59.057501) (xy 137.495 59.057501) (xy 137.494999 59.0575)
+				(xy 137.065796 59.0575) (xy 137.035399 59.06035) (xy 137.035397 59.06035) (xy 136.907352 59.105154)
+				(xy 136.798209 59.185707) (xy 136.798207 59.185709) (xy 136.717654 59.294852) (xy 136.67285 59.422898)
+				(xy 136.67 59.453288) (xy 136.290042 59.453288) (xy 136.337809 59.405521) (xy 136.388478 59.296861)
+				(xy 136.38848 59.296854) (xy 136.395 59.247338) (xy 136.395 59.167501) (xy 136.394999 59.1675) (xy 135.985 59.1675)
+				(xy 135.985 59.547499) (xy 135.785 59.547499) (xy 135.785 59.1665) (xy 135.803907 59.108309) (xy 135.853407 59.072345)
+				(xy 135.884 59.0675) (xy 135.885 59.0675) (xy 135.885 59.0665) (xy 135.903907 59.008309) (xy 135.953407 58.972345)
+				(xy 135.984 58.9675) (xy 136.394999 58.9675) (xy 136.395 58.967499) (xy 136.395 58.887661) (xy 136.38848 58.838145)
+				(xy 136.388478 58.838138) (xy 136.337809 58.729478) (xy 136.266189 58.657858) (xy 136.238412 58.603341)
+				(xy 136.247983 58.542909) (xy 136.266186 58.517853) (xy 136.338224 58.445816) (xy 136.359716 58.399727)
+				(xy 136.375835 58.36516) (xy 136.417563 58.320412) (xy 136.465559 58.308) (xy 136.658091 58.308)
 			)
 		)
 		(filled_polygon
@@ -41397,7 +41494,7 @@
 				(xy 125.6495 62.6745) (xy 125.6495 63.272389) (xy 125.630593 63.33058) (xy 125.620504 63.342393)
 				(xy 125.342393 63.620504) (xy 125.287876 63.648281) (xy 125.272389 63.6495) (xy 125.248037 63.6495)
 				(xy 125.189846 63.630593) (xy 125.153882 63.581093) (xy 125.14947 63.559745) (xy 125.147646 63.540305)
-				(xy 125.147646 63.540301) (xy 125.102793 63.412118) (xy 125.065895 63.362123) (xy 125.022154 63.302855)
+				(xy 125.147646 63.540301) (xy 125.102793 63.412118) (xy 125.082052 63.384015) (xy 125.022154 63.302855)
 				(xy 125.022152 63.302853) (xy 125.02215 63.30285) (xy 125.022146 63.302847) (xy 125.022144 63.302845)
 				(xy 124.912883 63.222207) (xy 124.784703 63.177355) (xy 124.784694 63.177353) (xy 124.754274 63.1745)
 				(xy 124.754266 63.1745) (xy 124.145734 63.1745) (xy 124.145725 63.1745) (xy 124.115305 63.177353)
@@ -41429,13 +41526,14 @@
 				(xy 121.8005 61.812863) (xy 121.819407 61.754672) (xy 121.868907 61.718708) (xy 121.930093 61.718708)
 				(xy 121.979593 61.754672) (xy 121.990964 61.774977) (xy 122.074388 61.976382) (xy 122.074394 61.976394)
 				(xy 122.205569 62.19045) (xy 122.20557 62.190452) (xy 122.205571 62.190454) (xy 122.205573 62.190456)
-				(xy 122.264576 62.25954) (xy 122.332734 62.339344) (xy 122.368629 62.381371) (xy 122.559544 62.544427)
-				(xy 122.559546 62.544428) (xy 122.559547 62.544429) (xy 122.559549 62.54443) (xy 122.773605 62.675605)
-				(xy 122.773617 62.675611) (xy 123.005571 62.771689) (xy 123.005573 62.77169) (xy 123.249705 62.830301)
-				(xy 123.5 62.85) (xy 123.750295 62.830301) (xy 123.994427 62.77169) (xy 124.226385 62.67561) (xy 124.226389 62.675607)
-				(xy 124.226394 62.675605) (xy 124.381877 62.580324) (xy 124.440456 62.544427) (xy 124.631371 62.381371)
-				(xy 124.794427 62.190456) (xy 124.87691 62.055856) (xy 124.925605 61.976394) (xy 124.925607 61.976389)
-				(xy 124.92561 61.976385) (xy 125.009036 61.774977) (xy 125.048773 61.728452) (xy 125.108267 61.714168)
+				(xy 122.264576 62.25954) (xy 122.341408 62.3495) (xy 122.368629 62.381371) (xy 122.368635 62.381376)
+				(xy 122.368638 62.381379) (xy 122.390441 62.4) (xy 122.559544 62.544427) (xy 122.559546 62.544428)
+				(xy 122.559547 62.544429) (xy 122.559549 62.54443) (xy 122.773605 62.675605) (xy 122.773617 62.675611)
+				(xy 123.005571 62.771689) (xy 123.005573 62.77169) (xy 123.249705 62.830301) (xy 123.5 62.85) (xy 123.750295 62.830301)
+				(xy 123.994427 62.77169) (xy 124.226385 62.67561) (xy 124.226389 62.675607) (xy 124.226394 62.675605)
+				(xy 124.323155 62.616309) (xy 124.440456 62.544427) (xy 124.631371 62.381371) (xy 124.794427 62.190456)
+				(xy 124.896071 62.024588) (xy 124.925605 61.976394) (xy 124.925607 61.976389) (xy 124.92561 61.976385)
+				(xy 125.009036 61.774977) (xy 125.048773 61.728452) (xy 125.108267 61.714168)
 			)
 		)
 		(filled_polygon
@@ -41939,98 +42037,13 @@
 				(xy 118.864774 71.8795) (xy 118.864772 71.8795) (xy 118.784479 71.8795) (xy 118.726288 71.860593)
 				(xy 118.690324 71.811093) (xy 118.690324 71.749907) (xy 118.714475 71.710496) (xy 118.795475 71.629496)
 				(xy 118.849992 71.601719) (xy 118.865479 71.6005) (xy 121.289563 71.6005) (xy 121.289563 71.600499)
-				(xy 121.365989 71.580021) (xy 121.434511 71.54046) (xy 121.445476 71.529494) (xy 121.499991 71.501719)
-				(xy 121.515478 71.5005) (xy 121.56477 71.5005) (xy 121.564772 71.5005) (xy 121.689069 71.464004)
-				(xy 121.798049 71.393967) (xy 121.882882 71.296063) (xy 121.936697 71.178226) (xy 121.955133 71.05)
-				(xy 121.955061 71.0495) (xy 121.936697 70.921774) (xy 121.901364 70.844407) (xy 121.882882 70.803937)
-				(xy 121.798049 70.706033) (xy 121.798048 70.706032) (xy 121.798047 70.706031) (xy 121.689073 70.635998)
-				(xy 121.68907 70.635996) (xy 121.689069 70.635996) (xy 121.684352 70.634611) (xy 121.564774 70.5995)
-				(xy 121.564772 70.5995) (xy 121.435228 70.5995) (xy 121.435225 70.5995) (xy 121.310933 70.635995)
-				(xy 121.310926 70.635998) (xy 121.201952 70.706031) (xy 121.117117 70.803938) (xy 121.063303 70.921772)
-				(xy 121.06136 70.928391) (xy 121.026825 70.978898) (xy 120.969198 70.99946) (xy 120.96637 70.9995)
-				(xy 119.623383 70.9995) (xy 119.565192 70.980593) (xy 119.529228 70.931093) (xy 119.529228 70.869907)
-				(xy 119.548561 70.835671) (xy 119.582882 70.796063) (xy 119.636697 70.678226) (xy 119.655133 70.55)
-				(xy 119.636697 70.421774) (xy 119.582882 70.303937) (xy 119.498049 70.206033) (xy 119.498048 70.206032)
-				(xy 119.498047 70.206031) (xy 119.389073 70.135998) (xy 119.38907 70.135996) (xy 119.389069 70.135996)
-				(xy 119.389066 70.135995) (xy 119.264774 70.0995) (xy 119.264772 70.0995) (xy 119.135228 70.0995)
-				(xy 119.135225 70.0995) (xy 119.010933 70.135995) (xy 119.010926 70.135998) (xy 118.901951 70.206032)
-				(xy 118.90195 70.206033) (xy 118.893895 70.21533) (xy 118.8415 70.246927) (xy 118.819075 70.2495)
-				(xy 118.760435 70.2495) (xy 118.684012 70.269978) (xy 118.631774 70.300138) (xy 118.631773 70.300137)
-				(xy 118.615491 70.309538) (xy 115.675489 73.24954) (xy 115.675488 73.249539) (xy 115.619539 73.305489)
-				(xy 115.57998 73.374007) (xy 115.579978 73.374011) (xy 115.5595 73.450435) (xy 115.5595 73.471937)
-				(xy 115.540593 73.530128) (xy 115.53532 73.536767) (xy 115.477118 73.603936) (xy 115.477116 73.60394)
-				(xy 115.423302 73.721774) (xy 115.404867 73.849997) (xy 115.404867 73.850002) (xy 115.423302 73.978225)
-				(xy 115.435313 74.004525) (xy 115.477118 74.096063) (xy 115.504683 74.127875) (xy 115.561952 74.193968)
-				(xy 115.62488 74.234409) (xy 115.670931 74.264004) (xy 115.795228 74.3005) (xy 115.79523 74.3005)
-				(xy 115.895867 74.3005) (xy 115.954058 74.319407) (xy 115.990022 74.368907) (xy 115.993836 74.392995)
-				(xy 115.993859 74.392992) (xy 115.994082 74.394545) (xy 115.994867 74.3995) (xy 115.994867 74.400002)
-				(xy 116.013302 74.528225) (xy 116.039686 74.585996) (xy 116.067118 74.646063) (xy 116.151951 74.743967)
-				(xy 116.151952 74.743968) (xy 116.260926 74.814001) (xy 116.260931 74.814004) (xy 116.385228 74.8505)
-				(xy 116.38523 74.8505) (xy 116.51477 74.8505) (xy 116.514772 74.8505) (xy 116.639069 74.814004)
-				(xy 116.748049 74.743967) (xy 116.832882 74.646063) (xy 116.886697 74.528226) (xy 116.905133 74.4)
-				(xy 116.905132 74.399998) (xy 116.905508 74.397389) (xy 116.932503 74.342481) (xy 116.933427 74.341542)
-				(xy 117.84046 73.434511) (xy 117.840463 73.434506) (xy 117.88002 73.365992) (xy 117.88002 73.36599)
-				(xy 117.880022 73.365988) (xy 117.9005 73.289562) (xy 117.9005 73.210438) (xy 117.9005 72.565479)
-				(xy 117.919407 72.507288) (xy 117.929496 72.495476) (xy 118.176502 72.248469) (xy 118.231019 72.220691)
-				(xy 118.291451 72.230262) (xy 118.334716 72.273527) (xy 118.342903 72.322919) (xy 118.344867 72.322919)
-				(xy 118.344867 72.330002) (xy 118.363302 72.458225) (xy 118.400168 72.538948) (xy 118.417118 72.576063)
-				(xy 118.47532 72.643232) (xy 118.499137 72.699592) (xy 118.4995 72.708063) (xy 118.4995 73.934521)
-				(xy 118.480593 73.992712) (xy 118.470504 74.004525) (xy 117.404525 75.070504) (xy 117.350008 75.098281)
-				(xy 117.334521 75.0995) (xy 114.835479 75.0995) (xy 114.777288 75.080593) (xy 114.765475 75.070504)
-				(xy 114.014378 74.319407) (xy 113.23842 73.543449) (xy 113.238417 73.543447) (xy 113.214368 73.529562)
-				(xy 113.169899 73.503888) (xy 113.169894 73.503886) (xy 113.093473 73.483409) (xy 113.093471 73.483409)
-				(xy 112.547016 73.483409) (xy 112.488825 73.464502) (xy 112.472196 73.449239) (xy 112.46414 73.439942)
-				(xy 112.464139 73.439941) (xy 112.355164 73.369907) (xy 112.355161 73.369905) (xy 112.35516 73.369905)
-				(xy 112.355157 73.369904) (xy 112.230865 73.333409) (xy 112.230863 73.333409) (xy 112.101319 73.333409)
-				(xy 112.101316 73.333409) (xy 111.977024 73.369904) (xy 111.977017 73.369907) (xy 111.868043 73.43994)
-				(xy 111.783208 73.537847) (xy 111.729393 73.655683) (xy 111.710958 73.783906) (xy 111.128388 73.783906)
-				(xy 109.937947 72.593465) (xy 109.91017 72.538948) (xy 109.908951 72.523461) (xy 109.908951 72.208286)
-				(xy 109.927858 72.150095) (xy 109.977358 72.114131) (xy 110.038544 72.114131) (xy 110.077955 72.138282)
-				(xy 110.87244 72.932767) (xy 110.900217 72.987284) (xy 110.900428 72.988682) (xy 110.913302 73.078225)
-				(xy 110.93878 73.134012) (xy 110.967118 73.196063) (xy 111.048134 73.289562) (xy 111.051952 73.293968)
-				(xy 111.113324 73.333409) (xy 111.160931 73.364004) (xy 111.285228 73.4005) (xy 111.28523 73.4005)
-				(xy 111.41477 73.4005) (xy 111.414772 73.4005) (xy 111.539069 73.364004) (xy 111.648049 73.293967)
-				(xy 111.732882 73.196063) (xy 111.786697 73.078226) (xy 111.79708 73.006011) (xy 111.805133 72.950002)
-				(xy 111.805133 72.949997) (xy 111.786697 72.821774) (xy 111.757574 72.758005) (xy 111.732882 72.703937)
-				(xy 111.648049 72.606033) (xy 111.648048 72.606032) (xy 111.648047 72.606031) (xy 111.539073 72.535998)
-				(xy 111.53907 72.535996) (xy 111.539069 72.535996) (xy 111.539066 72.535995) (xy 111.414774 72.4995)
-				(xy 111.414772 72.4995) (xy 111.400835 72.4995) (xy 111.342644 72.480593) (xy 111.330831 72.470504)
-				(xy 110.454496 71.594169) (xy 110.426719 71.539652) (xy 110.4255 71.524165) (xy 110.4255 70.957148)
-				(xy 110.4255 70.957147) (xy 110.403318 70.874362) (xy 110.403318 70.874361) (xy 110.375705 70.826535)
-				(xy 110.375705 70.826534) (xy 110.360466 70.80014) (xy 110.360465 70.800138) (xy 110.299862 70.739535)
-				(xy 110.299859 70.739533) (xy 109.799862 70.239535) (xy 109.799859 70.239533) (xy 109.799857 70.239531)
-				(xy 109.725642 70.196683) (xy 109.725644 70.196683) (xy 109.693521 70.188076) (xy 109.642853 70.1745)
-				(xy 109.642851 70.1745) (xy 107.848932 70.1745) (xy 107.848916 70.174499) (xy 107.842853 70.174499)
-				(xy 107.757148 70.174499) (xy 107.757145 70.174499) (xy 107.674365 70.19668) (xy 107.637793 70.217795)
-				(xy 107.603499 70.237595) (xy 107.600135 70.239537) (xy 107.539534 70.300137) (xy 107.539535 70.300138)
-				(xy 106.819169 71.020504) (xy 106.764652 71.048281) (xy 106.749165 71.0495) (xy 106.735225 71.0495)
-				(xy 106.610933 71.085995) (xy 106.610926 71.085998) (xy 106.501952 71.156031) (xy 106.417117 71.253938)
-				(xy 106.363302 71.371774) (xy 106.344867 71.499997) (xy 102.5005 71.499997) (xy 102.5005 68.819997)
-				(xy 107.544867 68.819997) (xy 107.544867 68.820002) (xy 107.563302 68.948225) (xy 107.617117 69.066061)
-				(xy 107.617118 69.066063) (xy 107.618848 69.068059) (xy 107.701952 69.163968) (xy 107.810926 69.234001)
-				(xy 107.810931 69.234004) (xy 107.935228 69.2705) (xy 107.93523 69.2705) (xy 108.06477 69.2705)
-				(xy 108.064772 69.2705) (xy 108.189069 69.234004) (xy 108.298049 69.163967) (xy 108.382882 69.066063)
-				(xy 108.428042 68.967175) (xy 108.448091 68.938301) (xy 108.781897 68.604496) (xy 108.836413 68.576719)
-				(xy 108.8519 68.5755) (xy 115.077929 68.5755) (xy 115.13612 68.594407) (xy 115.144687 68.601723)
-				(xy 115.146716 68.60328) (xy 115.146718 68.603282) (xy 115.272159 68.699536) (xy 115.27216 68.699536)
-				(xy 115.272161 68.699537) (xy 115.404211 68.754234) (xy 115.418238 68.760044) (xy 115.535809 68.775522)
-				(xy 115.574999 68.780682) (xy 115.575 68.780682) (xy 115.575001 68.780682) (xy 115.606352 68.776554)
-				(xy 115.731762 68.760044) (xy 115.877841 68.699536) (xy 116.003282 68.603282) (xy 116.003281 68.603282)
-				(xy 116.00843 68.599332) (xy 116.00949 68.600713) (xy 116.056584 68.576719) (xy 116.072071 68.5755)
-				(xy 116.849058 68.5755) (xy 116.84906 68.5755) (xy 116.950921 68.548207) (xy 116.950923 68.548205)
-				(xy 116.950925 68.548205) (xy 117.042241 68.495483) (xy 117.042241 68.495482) (xy 117.042246 68.49548)
-				(xy 117.132291 68.405435) (xy 122.9545 68.405435) (xy 122.9545 71.394564) (xy 122.974977 71.470985)
-				(xy 122.974981 71.470993) (xy 122.991806 71.500137) (xy 122.991807 71.500137) (xy 122.99523 71.506065)
-				(xy 123.01454 71.539511) (xy 123.016504 71.541475) (xy 123.017408 71.54325) (xy 123.018491 71.544661)
-				(xy 123.018229 71.544861) (xy 123.04428 71.59599) (xy 123.044491 71.597388) (xy 123.063302 71.728225)
+				(xy 121.291437 71.599997) (xy 123.044867 71.599997) (xy 123.044867 71.600002) (xy 123.063302 71.728225)
 				(xy 123.116161 71.843967) (xy 123.117118 71.846063) (xy 123.177716 71.915998) (xy 123.201952 71.943968)
 				(xy 123.267404 71.986031) (xy 123.310931 72.014004) (xy 123.435228 72.0505) (xy 123.43523 72.0505)
 				(xy 123.56477 72.0505) (xy 123.564772 72.0505) (xy 123.689069 72.014004) (xy 123.798049 71.943967)
 				(xy 123.882882 71.846063) (xy 123.936697 71.728226) (xy 123.950892 71.629496) (xy 123.955133 71.600002)
 				(xy 123.955133 71.599997) (xy 123.936697 71.471774) (xy 123.935578 71.469324) (xy 123.882882 71.353937)
-				(xy 123.798049 71.256033) (xy 123.798048 71.256032) (xy 123.798047 71.256031) (xy 123.689073 71.185998)
-				(xy 123.68907 71.185997) (xy 123.689069 71.185996) (xy 123.654953 71.175978) (xy 123.626608 71.167656)
-				(xy 123.576102 71.13312) (xy 123.55554 71.075493) (xy 123.5555 71.072666) (xy 123.5555 68.899995)
+				(xy 123.824679 71.286766) (xy 123.800863 71.230408) (xy 123.8005 71.221937) (xy 123.8005 68.899995)
 				(xy 124.944751 68.899995) (xy 124.944751 68.900004) (xy 124.963685 69.068053) (xy 124.963688 69.068065)
 				(xy 125.019544 69.22769) (xy 125.019544 69.227691) (xy 125.046443 69.2705) (xy 125.109523 69.37089)
 				(xy 125.22911 69.490477) (xy 125.229112 69.490478) (xy 125.229113 69.490479) (xy 125.367651 69.577529)
@@ -42070,118 +42083,163 @@
 				(xy 130.790475 69.409586) (xy 130.666183 69.373091) (xy 130.666181 69.373091) (xy 130.536637 69.373091)
 				(xy 130.536634 69.373091) (xy 130.412342 69.409586) (xy 130.412335 69.409589) (xy 130.303361 69.479622)
 				(xy 130.218526 69.577529) (xy 130.164711 69.695365) (xy 130.146276 69.823588) (xy 127.508179 69.823588)
-				(xy 126.46233 68.77774) (xy 126.439634 68.73667) (xy 126.43815 68.73719) (xy 126.419708 68.684487)
-				(xy 126.380456 68.57231) (xy 126.367875 68.552288) (xy 126.290479 68.429113) (xy 126.290478 68.429112)
-				(xy 126.290477 68.42911) (xy 126.17089 68.309523) (xy 126.170887 68.309521) (xy 126.170886 68.30952)
-				(xy 126.027691 68.219544) (xy 125.868065 68.163688) (xy 125.868053 68.163685) (xy 125.700004 68.144751)
-				(xy 125.699996 68.144751) (xy 125.531946 68.163685) (xy 125.531934 68.163688) (xy 125.372309 68.219544)
-				(xy 125.372308 68.219544) (xy 125.229113 68.30952) (xy 125.10952 68.429113) (xy 125.019544 68.572308)
-				(xy 125.019544 68.572309) (xy 124.963688 68.731934) (xy 124.963685 68.731946) (xy 124.944751 68.899995)
-				(xy 123.5555 68.899995) (xy 123.5555 68.610479) (xy 123.574407 68.552288) (xy 123.584496 68.540475)
-				(xy 123.645475 68.479496) (xy 123.699992 68.451719) (xy 123.715479 68.4505) (xy 123.76477 68.4505)
-				(xy 123.764772 68.4505) (xy 123.889069 68.414004) (xy 123.998049 68.343967) (xy 124.082882 68.246063)
-				(xy 124.136697 68.128226) (xy 124.155133 68) (xy 124.144937 67.929087) (xy 124.136697 67.871774)
-				(xy 124.128817 67.85452) (xy 124.082882 67.753937) (xy 123.998049 67.656033) (xy 123.998048 67.656032)
-				(xy 123.998047 67.656031) (xy 123.889073 67.585998) (xy 123.88907 67.585996) (xy 123.889069 67.585996)
-				(xy 123.889066 67.585995) (xy 123.764774 67.5495) (xy 123.764772 67.5495) (xy 123.635228 67.5495)
-				(xy 123.635225 67.5495) (xy 123.510933 67.585995) (xy 123.510926 67.585998) (xy 123.401952 67.656031)
-				(xy 123.317117 67.753938) (xy 123.263302 67.871774) (xy 123.244491 68.002611) (xy 123.217495 68.057519)
-				(xy 123.216557 68.05847) (xy 123.070489 68.20454) (xy 123.070488 68.204539) (xy 123.014539 68.260489)
-				(xy 122.97498 68.329007) (xy 122.974978 68.329011) (xy 122.9545 68.405435) (xy 117.132291 68.405435)
-				(xy 119.694765 65.842959) (xy 119.749282 65.815183) (xy 119.760498 65.8143) (xy 119.76305 65.813963)
-				(xy 119.763051 65.813964) (xy 119.919813 65.793326) (xy 120.065892 65.732818) (xy 120.191333 65.636564)
-				(xy 120.287587 65.511123) (xy 120.348095 65.365044) (xy 120.368733 65.208282) (xy 120.348095 65.05152)
-				(xy 120.287588 64.905443) (xy 120.287588 64.905442) (xy 120.191337 64.780005) (xy 120.191336 64.780004)
-				(xy 120.191333 64.78) (xy 120.191328 64.779996) (xy 120.191327 64.779995) (xy 120.065889 64.683744)
-				(xy 119.919817 64.623239) (xy 119.919809 64.623237) (xy 119.763052 64.6026) (xy 119.76305 64.6026)
-				(xy 119.606292 64.623237) (xy 119.606284 64.623239) (xy 119.460212 64.683744) (xy 119.460211 64.683744)
-				(xy 119.334774 64.779995) (xy 119.334764 64.780005) (xy 119.238513 64.905442) (xy 119.238513 64.905443)
-				(xy 119.178008 65.051515) (xy 119.178006 65.051523) (xy 119.156522 65.214715) (xy 119.154793 65.214487)
-				(xy 119.138462 65.264753) (xy 119.128373 65.276566) (xy 116.659436 67.745504) (xy 116.604919 67.773281)
-				(xy 116.589432 67.7745) (xy 116.072071 67.7745) (xy 116.01388 67.755593) (xy 116.005312 67.748276)
-				(xy 116.001699 67.745504) (xy 115.877841 67.650464) (xy 115.87784 67.650463) (xy 115.877838 67.650462)
-				(xy 115.731766 67.589957) (xy 115.731758 67.589955) (xy 115.575001 67.569318) (xy 115.574999 67.569318)
-				(xy 115.418241 67.589955) (xy 115.418233 67.589957) (xy 115.272161 67.650462) (xy 115.27216 67.650462)
-				(xy 115.14157 67.750668) (xy 115.140509 67.749286) (xy 115.093416 67.773281) (xy 115.077929 67.7745)
-				(xy 108.703806 67.7745) (xy 108.70379 67.774499) (xy 108.697727 67.774499) (xy 108.592273 67.774499)
-				(xy 108.490412 67.801793) (xy 108.490411 67.801793) (xy 108.490409 67.801794) (xy 108.464882 67.816532)
-				(xy 108.44475 67.828156) (xy 108.4158 67.84487) (xy 108.399086 67.85452) (xy 108.324519 67.929086)
-				(xy 108.32452 67.929087) (xy 108.324518 67.929089) (xy 108.324517 67.929089) (xy 107.880723 68.372882)
-				(xy 107.838613 68.397867) (xy 107.810936 68.405993) (xy 107.810926 68.405998) (xy 107.701952 68.476031)
-				(xy 107.617117 68.573938) (xy 107.563302 68.691774) (xy 107.544867 68.819997) (xy 102.5005 68.819997)
-				(xy 102.5005 64.099997) (xy 115.144867 64.099997) (xy 115.144867 64.100002) (xy 115.163302 64.228225)
-				(xy 115.217117 64.346061) (xy 115.217118 64.346063) (xy 115.301951 64.443967) (xy 115.301952 64.443968)
-				(xy 115.410926 64.514001) (xy 115.410931 64.514004) (xy 115.535228 64.5505) (xy 115.53523 64.5505)
-				(xy 115.66477 64.5505) (xy 115.664772 64.5505) (xy 115.789069 64.514004) (xy 115.898049 64.443967)
-				(xy 115.982882 64.346063) (xy 116.036697 64.228226) (xy 116.055133 64.1) (xy 116.036697 63.971774)
-				(xy 115.982882 63.853937) (xy 115.898049 63.756033) (xy 115.898048 63.756032) (xy 115.898047 63.756031)
-				(xy 115.789073 63.685998) (xy 115.78907 63.685996) (xy 115.789069 63.685996) (xy 115.789066 63.685995)
-				(xy 115.664774 63.6495) (xy 115.664772 63.6495) (xy 115.535228 63.6495) (xy 115.535225 63.6495)
-				(xy 115.410933 63.685995) (xy 115.410926 63.685998) (xy 115.301952 63.756031) (xy 115.217117 63.853938)
-				(xy 115.163302 63.971774) (xy 115.144867 64.099997) (xy 102.5005 64.099997) (xy 102.5005 61.25)
+				(xy 126.46233 68.77774) (xy 126.439634 68.73667) (xy 126.43815 68.73719) (xy 126.413057 68.665479)
+				(xy 126.380456 68.57231) (xy 126.290477 68.42911) (xy 126.17089 68.309523) (xy 126.170887 68.309521)
+				(xy 126.170886 68.30952) (xy 126.027691 68.219544) (xy 125.868065 68.163688) (xy 125.868053 68.163685)
+				(xy 125.700004 68.144751) (xy 125.699996 68.144751) (xy 125.531946 68.163685) (xy 125.531934 68.163688)
+				(xy 125.372309 68.219544) (xy 125.372308 68.219544) (xy 125.229113 68.30952) (xy 125.10952 68.429113)
+				(xy 125.019544 68.572308) (xy 125.019544 68.572309) (xy 124.963688 68.731934) (xy 124.963685 68.731946)
+				(xy 124.944751 68.899995) (xy 123.8005 68.899995) (xy 123.8005 68.665479) (xy 123.819407 68.607288)
+				(xy 123.829496 68.595475) (xy 123.945475 68.479496) (xy 123.999992 68.451719) (xy 124.015479 68.4505)
+				(xy 124.06477 68.4505) (xy 124.064772 68.4505) (xy 124.189069 68.414004) (xy 124.298049 68.343967)
+				(xy 124.382882 68.246063) (xy 124.436697 68.128226) (xy 124.455133 68) (xy 124.444937 67.929087)
+				(xy 124.436697 67.871774) (xy 124.428817 67.85452) (xy 124.382882 67.753937) (xy 124.298049 67.656033)
+				(xy 124.298048 67.656032) (xy 124.298047 67.656031) (xy 124.189073 67.585998) (xy 124.18907 67.585996)
+				(xy 124.189069 67.585996) (xy 124.189066 67.585995) (xy 124.064774 67.5495) (xy 124.064772 67.5495)
+				(xy 123.935228 67.5495) (xy 123.935225 67.5495) (xy 123.810933 67.585995) (xy 123.810926 67.585998)
+				(xy 123.701952 67.656031) (xy 123.617117 67.753938) (xy 123.563302 67.871774) (xy 123.544491 68.00261)
+				(xy 123.517495 68.057518) (xy 123.516503 68.058524) (xy 123.315489 68.259539) (xy 123.259539 68.315489)
+				(xy 123.21998 68.384007) (xy 123.219978 68.384011) (xy 123.1995 68.460435) (xy 123.1995 71.221937)
+				(xy 123.180593 71.280128) (xy 123.17532 71.286767) (xy 123.117118 71.353936) (xy 123.117116 71.35394)
+				(xy 123.063302 71.471774) (xy 123.044867 71.599997) (xy 121.291437 71.599997) (xy 121.365989 71.580021)
+				(xy 121.434511 71.54046) (xy 121.445476 71.529494) (xy 121.499991 71.501719) (xy 121.515478 71.5005)
+				(xy 121.56477 71.5005) (xy 121.564772 71.5005) (xy 121.689069 71.464004) (xy 121.798049 71.393967)
+				(xy 121.882882 71.296063) (xy 121.936697 71.178226) (xy 121.955133 71.05) (xy 121.955061 71.0495)
+				(xy 121.936697 70.921774) (xy 121.901364 70.844407) (xy 121.882882 70.803937) (xy 121.798049 70.706033)
+				(xy 121.798048 70.706032) (xy 121.798047 70.706031) (xy 121.689073 70.635998) (xy 121.68907 70.635996)
+				(xy 121.689069 70.635996) (xy 121.684352 70.634611) (xy 121.564774 70.5995) (xy 121.564772 70.5995)
+				(xy 121.435228 70.5995) (xy 121.435225 70.5995) (xy 121.310933 70.635995) (xy 121.310926 70.635998)
+				(xy 121.201952 70.706031) (xy 121.117117 70.803938) (xy 121.063303 70.921772) (xy 121.06136 70.928391)
+				(xy 121.026825 70.978898) (xy 120.969198 70.99946) (xy 120.96637 70.9995) (xy 119.623383 70.9995)
+				(xy 119.565192 70.980593) (xy 119.529228 70.931093) (xy 119.529228 70.869907) (xy 119.548561 70.835671)
+				(xy 119.582882 70.796063) (xy 119.636697 70.678226) (xy 119.655133 70.55) (xy 119.636697 70.421774)
+				(xy 119.582882 70.303937) (xy 119.498049 70.206033) (xy 119.498048 70.206032) (xy 119.498047 70.206031)
+				(xy 119.389073 70.135998) (xy 119.38907 70.135996) (xy 119.389069 70.135996) (xy 119.389066 70.135995)
+				(xy 119.264774 70.0995) (xy 119.264772 70.0995) (xy 119.135228 70.0995) (xy 119.135225 70.0995)
+				(xy 119.010933 70.135995) (xy 119.010926 70.135998) (xy 118.901951 70.206032) (xy 118.90195 70.206033)
+				(xy 118.893895 70.21533) (xy 118.8415 70.246927) (xy 118.819075 70.2495) (xy 118.760435 70.2495)
+				(xy 118.684012 70.269978) (xy 118.631774 70.300138) (xy 118.631773 70.300137) (xy 118.615491 70.309538)
+				(xy 115.675489 73.24954) (xy 115.675488 73.249539) (xy 115.619539 73.305489) (xy 115.57998 73.374007)
+				(xy 115.579978 73.374011) (xy 115.5595 73.450435) (xy 115.5595 73.471937) (xy 115.540593 73.530128)
+				(xy 115.53532 73.536767) (xy 115.477118 73.603936) (xy 115.477116 73.60394) (xy 115.423302 73.721774)
+				(xy 115.404867 73.849997) (xy 115.404867 73.850002) (xy 115.423302 73.978225) (xy 115.435313 74.004525)
+				(xy 115.477118 74.096063) (xy 115.504683 74.127875) (xy 115.561952 74.193968) (xy 115.62488 74.234409)
+				(xy 115.670931 74.264004) (xy 115.795228 74.3005) (xy 115.79523 74.3005) (xy 115.895867 74.3005)
+				(xy 115.954058 74.319407) (xy 115.990022 74.368907) (xy 115.993836 74.392995) (xy 115.993859 74.392992)
+				(xy 115.994082 74.394545) (xy 115.994867 74.3995) (xy 115.994867 74.400002) (xy 116.013302 74.528225)
+				(xy 116.039686 74.585996) (xy 116.067118 74.646063) (xy 116.151951 74.743967) (xy 116.151952 74.743968)
+				(xy 116.260926 74.814001) (xy 116.260931 74.814004) (xy 116.385228 74.8505) (xy 116.38523 74.8505)
+				(xy 116.51477 74.8505) (xy 116.514772 74.8505) (xy 116.639069 74.814004) (xy 116.748049 74.743967)
+				(xy 116.832882 74.646063) (xy 116.886697 74.528226) (xy 116.905133 74.4) (xy 116.905132 74.399998)
+				(xy 116.905508 74.397389) (xy 116.932503 74.342481) (xy 116.933427 74.341542) (xy 117.84046 73.434511)
+				(xy 117.840463 73.434506) (xy 117.88002 73.365992) (xy 117.88002 73.36599) (xy 117.880022 73.365988)
+				(xy 117.9005 73.289562) (xy 117.9005 73.210438) (xy 117.9005 72.565479) (xy 117.919407 72.507288)
+				(xy 117.929496 72.495476) (xy 118.176502 72.248469) (xy 118.231019 72.220691) (xy 118.291451 72.230262)
+				(xy 118.334716 72.273527) (xy 118.342903 72.322919) (xy 118.344867 72.322919) (xy 118.344867 72.330002)
+				(xy 118.363302 72.458225) (xy 118.400168 72.538948) (xy 118.417118 72.576063) (xy 118.47532 72.643232)
+				(xy 118.499137 72.699592) (xy 118.4995 72.708063) (xy 118.4995 73.934521) (xy 118.480593 73.992712)
+				(xy 118.470504 74.004525) (xy 117.404525 75.070504) (xy 117.350008 75.098281) (xy 117.334521 75.0995)
+				(xy 114.835479 75.0995) (xy 114.777288 75.080593) (xy 114.765475 75.070504) (xy 114.014378 74.319407)
+				(xy 113.23842 73.543449) (xy 113.238417 73.543447) (xy 113.214368 73.529562) (xy 113.169899 73.503888)
+				(xy 113.169894 73.503886) (xy 113.093473 73.483409) (xy 113.093471 73.483409) (xy 112.547016 73.483409)
+				(xy 112.488825 73.464502) (xy 112.472196 73.449239) (xy 112.46414 73.439942) (xy 112.464139 73.439941)
+				(xy 112.355164 73.369907) (xy 112.355161 73.369905) (xy 112.35516 73.369905) (xy 112.355157 73.369904)
+				(xy 112.230865 73.333409) (xy 112.230863 73.333409) (xy 112.101319 73.333409) (xy 112.101316 73.333409)
+				(xy 111.977024 73.369904) (xy 111.977017 73.369907) (xy 111.868043 73.43994) (xy 111.783208 73.537847)
+				(xy 111.729393 73.655683) (xy 111.710958 73.783906) (xy 111.128388 73.783906) (xy 109.937947 72.593465)
+				(xy 109.91017 72.538948) (xy 109.908951 72.523461) (xy 109.908951 72.208286) (xy 109.927858 72.150095)
+				(xy 109.977358 72.114131) (xy 110.038544 72.114131) (xy 110.077955 72.138282) (xy 110.87244 72.932767)
+				(xy 110.900217 72.987284) (xy 110.900428 72.988682) (xy 110.913302 73.078225) (xy 110.93878 73.134012)
+				(xy 110.967118 73.196063) (xy 111.048134 73.289562) (xy 111.051952 73.293968) (xy 111.113324 73.333409)
+				(xy 111.160931 73.364004) (xy 111.285228 73.4005) (xy 111.28523 73.4005) (xy 111.41477 73.4005)
+				(xy 111.414772 73.4005) (xy 111.539069 73.364004) (xy 111.648049 73.293967) (xy 111.732882 73.196063)
+				(xy 111.786697 73.078226) (xy 111.79708 73.006011) (xy 111.805133 72.950002) (xy 111.805133 72.949997)
+				(xy 111.786697 72.821774) (xy 111.757574 72.758005) (xy 111.732882 72.703937) (xy 111.648049 72.606033)
+				(xy 111.648048 72.606032) (xy 111.648047 72.606031) (xy 111.539073 72.535998) (xy 111.53907 72.535996)
+				(xy 111.539069 72.535996) (xy 111.539066 72.535995) (xy 111.414774 72.4995) (xy 111.414772 72.4995)
+				(xy 111.400835 72.4995) (xy 111.342644 72.480593) (xy 111.330831 72.470504) (xy 110.454496 71.594169)
+				(xy 110.426719 71.539652) (xy 110.4255 71.524165) (xy 110.4255 70.957148) (xy 110.4255 70.957147)
+				(xy 110.403318 70.874362) (xy 110.403318 70.874361) (xy 110.375705 70.826535) (xy 110.375705 70.826534)
+				(xy 110.360466 70.80014) (xy 110.360465 70.800138) (xy 110.299862 70.739535) (xy 110.299859 70.739533)
+				(xy 109.799862 70.239535) (xy 109.799859 70.239533) (xy 109.799857 70.239531) (xy 109.725642 70.196683)
+				(xy 109.725644 70.196683) (xy 109.693521 70.188076) (xy 109.642853 70.1745) (xy 109.642851 70.1745)
+				(xy 107.848932 70.1745) (xy 107.848916 70.174499) (xy 107.842853 70.174499) (xy 107.757148 70.174499)
+				(xy 107.757145 70.174499) (xy 107.674365 70.19668) (xy 107.637793 70.217795) (xy 107.603499 70.237595)
+				(xy 107.600135 70.239537) (xy 107.539534 70.300137) (xy 107.539535 70.300138) (xy 106.819169 71.020504)
+				(xy 106.764652 71.048281) (xy 106.749165 71.0495) (xy 106.735225 71.0495) (xy 106.610933 71.085995)
+				(xy 106.610926 71.085998) (xy 106.501952 71.156031) (xy 106.417117 71.253938) (xy 106.363302 71.371774)
+				(xy 106.344867 71.499997) (xy 102.5005 71.499997) (xy 102.5005 68.819997) (xy 107.544867 68.819997)
+				(xy 107.544867 68.820002) (xy 107.563302 68.948225) (xy 107.617117 69.066061) (xy 107.617118 69.066063)
+				(xy 107.618848 69.068059) (xy 107.701952 69.163968) (xy 107.810926 69.234001) (xy 107.810931 69.234004)
+				(xy 107.935228 69.2705) (xy 107.93523 69.2705) (xy 108.06477 69.2705) (xy 108.064772 69.2705) (xy 108.189069 69.234004)
+				(xy 108.298049 69.163967) (xy 108.382882 69.066063) (xy 108.428042 68.967175) (xy 108.448091 68.938301)
+				(xy 108.781897 68.604496) (xy 108.836413 68.576719) (xy 108.8519 68.5755) (xy 115.077929 68.5755)
+				(xy 115.13612 68.594407) (xy 115.144687 68.601723) (xy 115.146716 68.60328) (xy 115.146718 68.603282)
+				(xy 115.272159 68.699536) (xy 115.27216 68.699536) (xy 115.272161 68.699537) (xy 115.404211 68.754234)
+				(xy 115.418238 68.760044) (xy 115.535809 68.775522) (xy 115.574999 68.780682) (xy 115.575 68.780682)
+				(xy 115.575001 68.780682) (xy 115.606352 68.776554) (xy 115.731762 68.760044) (xy 115.877841 68.699536)
+				(xy 116.003282 68.603282) (xy 116.003281 68.603282) (xy 116.00843 68.599332) (xy 116.00949 68.600713)
+				(xy 116.056584 68.576719) (xy 116.072071 68.5755) (xy 116.849058 68.5755) (xy 116.84906 68.5755)
+				(xy 116.950921 68.548207) (xy 116.950923 68.548205) (xy 116.950925 68.548205) (xy 117.042241 68.495483)
+				(xy 117.042241 68.495482) (xy 117.042246 68.49548) (xy 119.694765 65.842959) (xy 119.749282 65.815183)
+				(xy 119.760498 65.8143) (xy 119.76305 65.813963) (xy 119.763051 65.813964) (xy 119.919813 65.793326)
+				(xy 120.065892 65.732818) (xy 120.191333 65.636564) (xy 120.287587 65.511123) (xy 120.348095 65.365044)
+				(xy 120.368733 65.208282) (xy 120.348095 65.05152) (xy 120.287588 64.905443) (xy 120.287588 64.905442)
+				(xy 120.191337 64.780005) (xy 120.191336 64.780004) (xy 120.191333 64.78) (xy 120.191328 64.779996)
+				(xy 120.191327 64.779995) (xy 120.065889 64.683744) (xy 119.919817 64.623239) (xy 119.919809 64.623237)
+				(xy 119.763052 64.6026) (xy 119.76305 64.6026) (xy 119.606292 64.623237) (xy 119.606284 64.623239)
+				(xy 119.460212 64.683744) (xy 119.460211 64.683744) (xy 119.334774 64.779995) (xy 119.334764 64.780005)
+				(xy 119.238513 64.905442) (xy 119.238513 64.905443) (xy 119.178008 65.051515) (xy 119.178006 65.051523)
+				(xy 119.156522 65.214715) (xy 119.154793 65.214487) (xy 119.138462 65.264753) (xy 119.128373 65.276566)
+				(xy 116.659436 67.745504) (xy 116.604919 67.773281) (xy 116.589432 67.7745) (xy 116.072071 67.7745)
+				(xy 116.01388 67.755593) (xy 116.005312 67.748276) (xy 116.001699 67.745504) (xy 115.877841 67.650464)
+				(xy 115.87784 67.650463) (xy 115.877838 67.650462) (xy 115.731766 67.589957) (xy 115.731758 67.589955)
+				(xy 115.575001 67.569318) (xy 115.574999 67.569318) (xy 115.418241 67.589955) (xy 115.418233 67.589957)
+				(xy 115.272161 67.650462) (xy 115.27216 67.650462) (xy 115.14157 67.750668) (xy 115.140509 67.749286)
+				(xy 115.093416 67.773281) (xy 115.077929 67.7745) (xy 108.703806 67.7745) (xy 108.70379 67.774499)
+				(xy 108.697727 67.774499) (xy 108.592273 67.774499) (xy 108.490412 67.801793) (xy 108.490411 67.801793)
+				(xy 108.490409 67.801794) (xy 108.464882 67.816532) (xy 108.44475 67.828156) (xy 108.4158 67.84487)
+				(xy 108.399086 67.85452) (xy 108.324519 67.929086) (xy 108.32452 67.929087) (xy 108.324518 67.929089)
+				(xy 108.324517 67.929089) (xy 107.880723 68.372882) (xy 107.838613 68.397867) (xy 107.810936 68.405993)
+				(xy 107.810926 68.405998) (xy 107.701952 68.476031) (xy 107.617117 68.573938) (xy 107.563302 68.691774)
+				(xy 107.544867 68.819997) (xy 102.5005 68.819997) (xy 102.5005 62.799997) (xy 115.944867 62.799997)
+				(xy 115.944867 62.800002) (xy 115.963302 62.928225) (xy 116.017117 63.046061) (xy 116.017118 63.046063)
+				(xy 116.101951 63.143967) (xy 116.101952 63.143968) (xy 116.210926 63.214001) (xy 116.210931 63.214004)
+				(xy 116.335228 63.2505) (xy 116.33523 63.2505) (xy 116.46477 63.2505) (xy 116.464772 63.2505) (xy 116.589069 63.214004)
+				(xy 116.698049 63.143967) (xy 116.782882 63.046063) (xy 116.836697 62.928226) (xy 116.847944 62.849999)
+				(xy 116.855133 62.800002) (xy 116.855133 62.799997) (xy 116.836697 62.671774) (xy 116.782882 62.553938)
+				(xy 116.782882 62.553937) (xy 116.698049 62.456033) (xy 116.698048 62.456032) (xy 116.698047 62.456031)
+				(xy 116.589073 62.385998) (xy 116.58907 62.385996) (xy 116.589069 62.385996) (xy 116.573345 62.381379)
+				(xy 116.464774 62.3495) (xy 116.464772 62.3495) (xy 116.335228 62.3495) (xy 116.335225 62.3495)
+				(xy 116.210933 62.385995) (xy 116.210926 62.385998) (xy 116.101952 62.456031) (xy 116.017117 62.553938)
+				(xy 115.963302 62.671774) (xy 115.944867 62.799997) (xy 102.5005 62.799997) (xy 102.5005 61.25)
 				(xy 121.9 61.25) (xy 121.919698 61.500293) (xy 121.97831 61.744428) (xy 122.074388 61.976382) (xy 122.074394 61.976394)
-				(xy 122.205569 62.19045) (xy 122.20557 62.190452) (xy 122.205571 62.190454) (xy 122.205573 62.190456)
-				(xy 122.368629 62.381371) (xy 122.559544 62.544427) (xy 122.559546 62.544428) (xy 122.559547 62.544429)
-				(xy 122.559549 62.54443) (xy 122.773605 62.675605) (xy 122.773617 62.675611) (xy 123.005571 62.771689)
-				(xy 123.005573 62.77169) (xy 123.249705 62.830301) (xy 123.5 62.85) (xy 123.750295 62.830301) (xy 123.994427 62.77169)
-				(xy 124.226385 62.67561) (xy 124.226389 62.675607) (xy 124.226394 62.675605) (xy 124.318912 62.618908)
-				(xy 124.440456 62.544427) (xy 124.631371 62.381371) (xy 124.794427 62.190456) (xy 124.868908 62.068912)
-				(xy 124.925605 61.976394) (xy 124.925607 61.976389) (xy 124.92561 61.976385) (xy 125.02169 61.744427)
-				(xy 125.080301 61.500295) (xy 125.1 61.25) (xy 125.080301 60.999705) (xy 125.02169 60.755573) (xy 124.92561 60.523615)
-				(xy 124.925605 60.523605) (xy 124.79443 60.309549) (xy 124.794429 60.309547) (xy 124.794428 60.309546)
-				(xy 124.794427 60.309544) (xy 124.631371 60.118629) (xy 124.631364 60.118623) (xy 124.631361 60.11862)
-				(xy 124.440452 59.95557) (xy 124.44045 59.955569) (xy 124.226394 59.824394) (xy 124.226382 59.824388)
-				(xy 123.994428 59.72831) (xy 123.994429 59.72831) (xy 123.750293 59.669698) (xy 123.5 59.65) (xy 123.249706 59.669698)
-				(xy 123.005571 59.72831) (xy 122.773617 59.824388) (xy 122.773605 59.824394) (xy 122.559549 59.955569)
-				(xy 122.559547 59.95557) (xy 122.368638 60.11862) (xy 122.36862 60.118638) (xy 122.20557 60.309547)
-				(xy 122.205569 60.309549) (xy 122.074394 60.523605) (xy 122.074388 60.523617) (xy 121.97831 60.755571)
-				(xy 121.919698 60.999706) (xy 121.9 61.25) (xy 102.5005 61.25) (xy 102.5005 56.963739) (xy 102.519407 56.905548)
-				(xy 102.568907 56.869584) (xy 102.630093 56.869584) (xy 102.679591 56.905547) (xy 102.779207 57.042656)
-				(xy 102.957344 57.220793) (xy 103.161155 57.36887) (xy 103.385621 57.483241) (xy 103.625215 57.56109)
-				(xy 103.625216 57.56109) (xy 103.625219 57.561091) (xy 103.874035 57.6005) (xy 103.874038 57.6005)
-				(xy 104.125965 57.6005) (xy 104.37478 57.561091) (xy 104.374781 57.56109) (xy 104.374785 57.56109)
-				(xy 104.614379 57.483241) (xy 104.838845 57.36887) (xy 105.042656 57.220793) (xy 105.220793 57.042656)
-				(xy 105.36887 56.838845) (xy 105.483241 56.614379) (xy 105.56109 56.374785) (xy 105.6005 56.125962)
-				(xy 105.6005 55.874038) (xy 105.6005 55.874034) (xy 105.561091 55.625219) (xy 105.56109 55.625215)
-				(xy 105.483241 55.385621) (xy 105.36887 55.161155) (xy 105.220793 54.957344) (xy 105.042656 54.779207)
-				(xy 104.905547 54.679591) (xy 104.869584 54.630093) (xy 104.869584 54.568907) (xy 104.905548 54.519407)
-				(xy 104.963739 54.5005) (xy 142.036261 54.5005)
-			)
-		)
-	)
-	(zone
-		(net 0)
-		(net_name "")
-		(layers "F.Cu" "In1.Cu" "In2.Cu" "B.Cu")
-		(uuid "b7c604b2-8dce-4247-842b-0d75a582a501")
-		(hatch edge 0.5)
-		(connect_pads
-			(clearance 0)
-		)
-		(min_thickness 0.2)
-		(filled_areas_thickness no)
-		(keepout
-			(tracks allowed)
-			(vias not_allowed)
-			(pads not_allowed)
-			(copperpour not_allowed)
-			(footprints allowed)
-		)
-		(fill
-			(thermal_gap 0.3)
-			(thermal_bridge_width 0.3)
-		)
-		(polygon
-			(pts
-				(xy 125.1 61.25) (xy 125.080301 60.999705) (xy 125.02169 60.755573) (xy 124.92561 60.523615) (xy 124.794427 60.309544)
-				(xy 124.631371 60.118629) (xy 124.440456 59.955573) (xy 124.226385 59.82439) (xy 123.994427 59.72831)
-				(xy 123.750295 59.669699) (xy 123.5 59.65) (xy 123.249705 59.669699) (xy 123.005573 59.72831) (xy 122.773615 59.82439)
-				(xy 122.559544 59.955573) (xy 122.368629 60.118629) (xy 122.205573 60.309544) (xy 122.07439 60.523615)
-				(xy 121.97831 60.755573) (xy 121.919699 60.999705) (xy 121.9 61.25) (xy 121.919699 61.500295) (xy 121.97831 61.744427)
-				(xy 122.07439 61.976385) (xy 122.205573 62.190456) (xy 122.368629 62.381371) (xy 122.559544 62.544427)
-				(xy 122.773615 62.67561) (xy 123.005573 62.77169) (xy 123.249705 62.830301) (xy 123.5 62.85) (xy 123.750295 62.830301)
-				(xy 123.994427 62.77169) (xy 124.226385 62.67561) (xy 124.440456 62.544427) (xy 124.631371 62.381371)
-				(xy 124.794427 62.190456) (xy 124.92561 61.976385) (xy 125.02169 61.744427) (xy 125.080301 61.500295)
+				(xy 122.205569 62.19045) (xy 122.20557 62.190452) (xy 122.341408 62.3495) (xy 122.368629 62.381371)
+				(xy 122.368635 62.381376) (xy 122.368638 62.381379) (xy 122.436954 62.439726) (xy 122.559544 62.544427)
+				(xy 122.559546 62.544428) (xy 122.559547 62.544429) (xy 122.559549 62.54443) (xy 122.773605 62.675605)
+				(xy 122.773617 62.675611) (xy 123.005571 62.771689) (xy 123.005573 62.77169) (xy 123.249705 62.830301)
+				(xy 123.5 62.85) (xy 123.750295 62.830301) (xy 123.994427 62.77169) (xy 124.226385 62.67561) (xy 124.226389 62.675607)
+				(xy 124.226394 62.675605) (xy 124.424935 62.553938) (xy 124.440456 62.544427) (xy 124.631371 62.381371)
+				(xy 124.794427 62.190456) (xy 124.868908 62.068912) (xy 124.925605 61.976394) (xy 124.925607 61.976389)
+				(xy 124.92561 61.976385) (xy 125.02169 61.744427) (xy 125.080301 61.500295) (xy 125.1 61.25) (xy 125.080301 60.999705)
+				(xy 125.02169 60.755573) (xy 124.92561 60.523615) (xy 124.925605 60.523605) (xy 124.79443 60.309549)
+				(xy 124.794429 60.309547) (xy 124.794428 60.309546) (xy 124.794427 60.309544) (xy 124.631371 60.118629)
+				(xy 124.631364 60.118623) (xy 124.631361 60.11862) (xy 124.440452 59.95557) (xy 124.44045 59.955569)
+				(xy 124.226394 59.824394) (xy 124.226382 59.824388) (xy 123.994428 59.72831) (xy 123.994429 59.72831)
+				(xy 123.750293 59.669698) (xy 123.5 59.65) (xy 123.249706 59.669698) (xy 123.005571 59.72831) (xy 122.773617 59.824388)
+				(xy 122.773605 59.824394) (xy 122.559549 59.955569) (xy 122.559547 59.95557) (xy 122.368638 60.11862)
+				(xy 122.36862 60.118638) (xy 122.20557 60.309547) (xy 122.205569 60.309549) (xy 122.074394 60.523605)
+				(xy 122.074388 60.523617) (xy 121.97831 60.755571) (xy 121.919698 60.999706) (xy 121.9 61.25) (xy 102.5005 61.25)
+				(xy 102.5005 56.963739) (xy 102.519407 56.905548) (xy 102.568907 56.869584) (xy 102.630093 56.869584)
+				(xy 102.679591 56.905547) (xy 102.779207 57.042656) (xy 102.957344 57.220793) (xy 103.161155 57.36887)
+				(xy 103.385621 57.483241) (xy 103.625215 57.56109) (xy 103.625216 57.56109) (xy 103.625219 57.561091)
+				(xy 103.874035 57.6005) (xy 103.874038 57.6005) (xy 104.125965 57.6005) (xy 104.37478 57.561091)
+				(xy 104.374781 57.56109) (xy 104.374785 57.56109) (xy 104.614379 57.483241) (xy 104.838845 57.36887)
+				(xy 105.042656 57.220793) (xy 105.220793 57.042656) (xy 105.36887 56.838845) (xy 105.483241 56.614379)
+				(xy 105.56109 56.374785) (xy 105.6005 56.125962) (xy 105.6005 55.874038) (xy 105.6005 55.874034)
+				(xy 105.561091 55.625219) (xy 105.56109 55.625215) (xy 105.483241 55.385621) (xy 105.36887 55.161155)
+				(xy 105.220793 54.957344) (xy 105.042656 54.779207) (xy 104.905547 54.679591) (xy 104.869584 54.630093)
+				(xy 104.869584 54.568907) (xy 104.905548 54.519407) (xy 104.963739 54.5005) (xy 142.036261 54.5005)
 			)
 		)
 	)
@@ -42236,8 +42294,9 @@
 				(xy 129.004043 66.999734) (xy 128.995933 67) (xy 127.084307 67) (xy 127.077316 66.9995) (xy 127.071961 66.9995)
 				(xy 126.928039 66.9995) (xy 126.922684 66.9995) (xy 126.915693 67) (xy 118.004067 67) (xy 117.995957 66.999734)
 				(xy 117.681788 66.979142) (xy 117.665707 66.977025) (xy 117.360925 66.9164) (xy 117.345258 66.912202)
-				(xy 117.050987 66.812311) (xy 117.036001 66.806104) (xy 116.757289 66.668658) (xy 116.743242 66.660548)
-				(xy 116.588025 66.556835) (xy 118.995137 66.556835) (xy 119.039302 66.601) (xy 120.72157 66.601)
+				(xy 117.050987 66.812311) (xy 117.036001 66.806104) (xy 116.89326 66.735712) (xy 116.841841 66.688407)
+				(xy 116.824159 66.620812) (xy 116.830622 66.601) (xy 117.494846 66.601) (xy 118.598835 66.601) (xy 118.642999 66.556836)
+				(xy 118.642998 66.556835) (xy 118.995137 66.556835) (xy 119.039302 66.601) (xy 120.72157 66.601)
 				(xy 120.765734 66.556836) (xy 121.117872 66.556836) (xy 121.162036 66.601) (xy 122.844304 66.601)
 				(xy 122.888468 66.556836) (xy 123.240607 66.556836) (xy 123.284771 66.601) (xy 124.967039 66.601)
 				(xy 125.011203 66.556836) (xy 125.363341 66.556836) (xy 125.407505 66.601) (xy 127.089774 66.601)
@@ -42255,420 +42314,433 @@
 				(xy 119.85776 66.131557) (xy 119.850291 66.131782) (xy 119.675811 66.131782) (xy 119.668342 66.131557)
 				(xy 119.666834 66.131466) (xy 119.659359 66.130787) (xy 119.642967 66.128797) (xy 119.635505 66.12766)
 				(xy 119.634019 66.127387) (xy 119.626751 66.125825) (xy 119.465814 66.086159) (xy 118.995137 66.556835)
-				(xy 116.588025 66.556835) (xy 116.484853 66.487898) (xy 116.471985 66.478024) (xy 116.440603 66.450503)
-				(xy 116.238343 66.273125) (xy 116.226874 66.261656) (xy 116.128643 66.149645) (xy 116.021972 66.028011)
-				(xy 116.012101 66.015146) (xy 115.977366 65.963162) (xy 115.839451 65.756757) (xy 115.831341 65.74271)
-				(xy 115.776922 65.63236) (xy 115.693892 65.463991) (xy 115.687688 65.449012) (xy 115.68656 65.44569)
-				(xy 115.65736 65.359668) (xy 115.946835 65.359668) (xy 116.071867 65.613205) (xy 116.233664 65.855353)
-				(xy 116.425686 66.074311) (xy 116.644647 66.266335) (xy 116.744227 66.332872) (xy 117.127096 65.950003)
-				(xy 117.494353 65.950003) (xy 117.514834 66.092459) (xy 117.558074 66.187139) (xy 117.574623 66.223376)
-				(xy 117.668872 66.332146) (xy 117.789947 66.409956) (xy 117.78995 66.409957) (xy 117.789949 66.409957)
-				(xy 117.928036 66.450502) (xy 117.928038 66.450503) (xy 117.928039 66.450503) (xy 118.071962 66.450503)
-				(xy 118.071962 66.450502) (xy 118.210053 66.409956) (xy 118.331128 66.332146) (xy 118.425377 66.223376)
-				(xy 118.485165 66.09246) (xy 118.505647 65.950003) (xy 118.485165 65.807546) (xy 118.425377 65.67663)
-				(xy 118.331128 65.56786) (xy 118.210053 65.49005) (xy 118.210051 65.490049) (xy 118.210049 65.490048)
-				(xy 118.21005 65.490048) (xy 118.094615 65.456154) (xy 118.595565 65.456154) (xy 118.638089 65.50523)
-				(xy 118.643626 65.5121) (xy 118.644697 65.51353) (xy 118.649764 65.520825) (xy 118.660318 65.537248)
-				(xy 118.664823 65.54484) (xy 118.665679 65.546407) (xy 118.669651 65.554341) (xy 118.737549 65.703016)
-				(xy 118.740937 65.711194) (xy 118.741561 65.712867) (xy 118.744355 65.721263) (xy 118.749856 65.739996)
-				(xy 118.752055 65.748616) (xy 118.752434 65.750361) (xy 118.753997 65.759032) (xy 118.777258 65.920813)
-				(xy 118.778206 65.92964) (xy 118.778333 65.931421) (xy 118.778647 65.940241) (xy 118.778647 65.959765)
-				(xy 118.778333 65.968585) (xy 118.778206 65.970366) (xy 118.777258 65.979193) (xy 118.753997 66.140974)
-				(xy 118.752434 66.149645) (xy 118.752055 66.15139) (xy 118.749856 66.16001) (xy 118.744355 66.178743)
-				(xy 118.741561 66.187139) (xy 118.740937 66.188812) (xy 118.737549 66.19699) (xy 118.705489 66.267188)
-				(xy 118.819068 66.380767) (xy 119.230917 65.968917) (xy 119.228929 65.967545) (xy 119.222968 65.963162)
-				(xy 119.221778 65.962231) (xy 119.215958 65.957383) (xy 119.10552 65.859544) (xy 120.42058 65.859544)
-				(xy 120.941803 66.380767) (xy 121.827101 65.495468) (xy 122.179239 65.495468) (xy 123.064537 66.380767)
-				(xy 123.949836 65.495468) (xy 124.301973 65.495468) (xy 125.187272 66.380767) (xy 126.07257 65.495468)
-				(xy 126.424708 65.495468) (xy 127.310006 66.380767) (xy 128.195305 65.495468) (xy 128.547442 65.495468)
-				(xy 129.432741 66.380767) (xy 130.318039 65.495468) (xy 129.432741 64.61017) (xy 128.547442 65.495468)
-				(xy 128.195305 65.495468) (xy 127.310006 64.61017) (xy 126.424708 65.495468) (xy 126.07257 65.495468)
-				(xy 125.187272 64.61017) (xy 124.301973 65.495468) (xy 123.949836 65.495468) (xy 123.064537 64.61017)
-				(xy 122.179239 65.495468) (xy 121.827101 65.495468) (xy 121.202408 64.870775) (xy 121.554546 64.870775)
-				(xy 122.00317 65.319399) (xy 122.888468 64.434101) (xy 123.240606 64.434101) (xy 124.125905 65.319399)
-				(xy 125.011203 64.434101) (xy 125.36334 64.434101) (xy 126.248639 65.319399) (xy 127.133937 64.434101)
-				(xy 127.486075 64.434101) (xy 128.371374 65.319399) (xy 129.256672 64.434101) (xy 129.608809 64.434101)
-				(xy 130.494107 65.319399) (xy 131.101 64.712507) (xy 131.101 64.155694) (xy 130.494108 63.548802)
-				(xy 129.608809 64.434101) (xy 129.256672 64.434101) (xy 128.371374 63.548803) (xy 127.486075 64.434101)
-				(xy 127.133937 64.434101) (xy 126.248639 63.548802) (xy 125.36334 64.434101) (xy 125.011203 64.434101)
-				(xy 124.125905 63.548803) (xy 123.240606 64.434101) (xy 122.888468 64.434101) (xy 122.003169 63.548802)
-				(xy 121.967829 63.584143) (xy 122.038089 63.665227) (xy 122.043626 63.672097) (xy 122.044697 63.673527)
-				(xy 122.049764 63.680822) (xy 122.060318 63.697245) (xy 122.064823 63.704837) (xy 122.065679 63.706404)
-				(xy 122.069651 63.714338) (xy 122.137549 63.863013) (xy 122.140937 63.871191) (xy 122.141561 63.872864)
-				(xy 122.144355 63.88126) (xy 122.149856 63.899993) (xy 122.152055 63.908613) (xy 122.152434 63.910358)
-				(xy 122.153997 63.919029) (xy 122.177258 64.08081) (xy 122.178206 64.089637) (xy 122.178333 64.091418)
-				(xy 122.178647 64.100238) (xy 122.178647 64.119762) (xy 122.178333 64.128582) (xy 122.178206 64.130363)
-				(xy 122.177258 64.13919) (xy 122.153997 64.300971) (xy 122.152434 64.309642) (xy 122.152055 64.311387)
-				(xy 122.149856 64.320007) (xy 122.144355 64.33874) (xy 122.141561 64.347136) (xy 122.140937 64.348809)
-				(xy 122.137549 64.356987) (xy 122.069651 64.505662) (xy 122.065679 64.513596) (xy 122.064823 64.515163)
-				(xy 122.060318 64.522755) (xy 122.049764 64.539178) (xy 122.044697 64.546473) (xy 122.043626 64.547903)
-				(xy 122.038089 64.554773) (xy 121.931055 64.678297) (xy 121.925058 64.684741) (xy 121.923796 64.686004)
-				(xy 121.917282 64.692071) (xy 121.902527 64.704856) (xy 121.895658 64.710392) (xy 121.894228 64.711463)
-				(xy 121.886934 64.716529) (xy 121.749436 64.804893) (xy 121.741843 64.809399) (xy 121.740276 64.810255)
-				(xy 121.732345 64.814226) (xy 121.714586 64.822337) (xy 121.706382 64.825734) (xy 121.704708 64.826358)
-				(xy 121.696331 64.829145) (xy 121.554546 64.870775) (xy 121.202408 64.870775) (xy 121.184516 64.852883)
-				(xy 121.10367 64.829146) (xy 121.095292 64.826358) (xy 121.093618 64.825734) (xy 121.085414 64.822337)
-				(xy 121.067655 64.814226) (xy 121.059724 64.810255) (xy 121.058157 64.809399) (xy 121.050564 64.804893)
-				(xy 120.913066 64.716529) (xy 120.905772 64.711463) (xy 120.904342 64.710392) (xy 120.897473 64.704856)
-				(xy 120.882718 64.692071) (xy 120.876204 64.686004) (xy 120.874942 64.684741) (xy 120.871225 64.680746)
-				(xy 120.63881 64.913161) (xy 120.657475 64.962376) (xy 120.65991 64.969431) (xy 120.66036 64.970874)
-				(xy 120.662381 64.97812) (xy 120.666332 64.994153) (xy 120.667893 65.001417) (xy 120.668166 65.002903)
-				(xy 120.669303 65.010363) (xy 120.690334 65.183572) (xy 120.691013 65.191049) (xy 120.691104 65.192557)
-				(xy 120.691329 65.200026) (xy 120.691329 65.216538) (xy 120.691104 65.224007) (xy 120.691013 65.225515)
-				(xy 120.690334 65.232992) (xy 120.669303 65.406201) (xy 120.668166 65.413661) (xy 120.667893 65.415147)
-				(xy 120.666332 65.422411) (xy 120.662381 65.438444) (xy 120.66036 65.44569) (xy 120.65991 65.447133)
-				(xy 120.657475 65.454188) (xy 120.595603 65.617331) (xy 120.592742 65.624238) (xy 120.592122 65.625616)
-				(xy 120.58884 65.63236) (xy 120.581167 65.646981) (xy 120.577472 65.65353) (xy 120.57669 65.654823)
-				(xy 120.572636 65.661092) (xy 120.473518 65.804688) (xy 120.469131 65.810655) (xy 120.4682 65.811845)
-				(xy 120.463352 65.817665) (xy 120.452402 65.830025) (xy 120.447227 65.83552) (xy 120.446158 65.836588)
-				(xy 120.440744 65.841682) (xy 120.42058 65.859544) (xy 119.10552 65.859544) (xy 119.085357 65.841681)
-				(xy 119.079944 65.836588) (xy 119.078875 65.83552) (xy 119.0737 65.830025) (xy 119.06275 65.817665)
-				(xy 119.057902 65.811845) (xy 119.056971 65.810655) (xy 119.052584 65.804688) (xy 118.953466 65.661092)
-				(xy 118.949412 65.654823) (xy 118.94863 65.65353) (xy 118.944935 65.646981) (xy 118.937262 65.63236)
-				(xy 118.93398 65.625616) (xy 118.93336 65.624238) (xy 118.930499 65.617331) (xy 118.868627 65.454188)
-				(xy 118.866192 65.447133) (xy 118.865742 65.44569) (xy 118.863721 65.438444) (xy 118.85977 65.422411)
-				(xy 118.858209 65.415147) (xy 118.857936 65.413661) (xy 118.856799 65.406201) (xy 118.837925 65.250756)
-				(xy 118.806381 65.289193) (xy 118.789193 65.306381) (xy 118.636924 65.431346) (xy 118.616712 65.444852)
-				(xy 118.595565 65.456154) (xy 118.094615 65.456154) (xy 118.071963 65.449503) (xy 118.071961 65.449503)
-				(xy 117.928039 65.449503) (xy 117.928036 65.449503) (xy 117.789949 65.490048) (xy 117.668873 65.567859)
-				(xy 117.574623 65.676629) (xy 117.574622 65.676631) (xy 117.514834 65.807546) (xy 117.494353 65.950003)
-				(xy 117.127096 65.950003) (xy 117.2339 65.843199) (xy 117.246003 65.759031) (xy 117.247566 65.750361)
-				(xy 117.247945 65.748616) (xy 117.250144 65.739996) (xy 117.255645 65.721263) (xy 117.258439 65.712867)
-				(xy 117.259063 65.711194) (xy 117.262451 65.703016) (xy 117.330349 65.554341) (xy 117.334321 65.546407)
-				(xy 117.335177 65.54484) (xy 117.339682 65.537248) (xy 117.350236 65.520825) (xy 117.355303 65.51353)
-				(xy 117.356374 65.5121) (xy 117.361911 65.50523) (xy 117.404435 65.456154) (xy 117.383288 65.444851)
-				(xy 117.363076 65.431346) (xy 117.210807 65.306381) (xy 117.193619 65.289193) (xy 117.127216 65.208281)
-				(xy 119.107773 65.208281) (xy 119.107773 65.208282) (xy 119.126813 65.3651) (xy 119.161346 65.456154)
-				(xy 119.182831 65.512805) (xy 119.272568 65.642812) (xy 119.390811 65.747565) (xy 119.396138 65.750361)
-				(xy 119.530685 65.820978) (xy 119.684065 65.858782) (xy 119.684066 65.858782) (xy 119.842036 65.858782)
-				(xy 119.995416 65.820978) (xy 120.012817 65.811845) (xy 120.135291 65.747565) (xy 120.253534 65.642812)
-				(xy 120.343271 65.512805) (xy 120.399288 65.3651) (xy 120.418329 65.208282) (xy 120.407211 65.116712)
-				(xy 120.399288 65.051463) (xy 120.365501 64.962376) (xy 120.343271 64.903759) (xy 120.253534 64.773752)
-				(xy 120.135291 64.668999) (xy 120.135289 64.668998) (xy 120.135288 64.668997) (xy 119.995416 64.595585)
-				(xy 119.842037 64.557782) (xy 119.842036 64.557782) (xy 119.684066 64.557782) (xy 119.684065 64.557782)
-				(xy 119.530685 64.595585) (xy 119.390813 64.668997) (xy 119.272567 64.773753) (xy 119.182832 64.903757)
-				(xy 119.182831 64.903758) (xy 119.126813 65.051463) (xy 119.107773 65.208281) (xy 117.127216 65.208281)
-				(xy 117.068654 65.136924) (xy 117.055149 65.116712) (xy 116.962292 64.942988) (xy 116.952989 64.92053)
-				(xy 116.929604 64.84344) (xy 116.696334 64.61017) (xy 115.946835 65.359668) (xy 115.65736 65.359668)
-				(xy 115.587797 65.154741) (xy 115.583599 65.139074) (xy 115.556513 65.002903) (xy 115.522972 64.834281)
-				(xy 115.520857 64.818223) (xy 115.500265 64.504043) (xy 115.5 64.495933) (xy 115.5 64.317749) (xy 119.111488 64.317749)
-				(xy 119.128242 64.487846) (xy 119.128242 64.512155) (xy 119.125572 64.539255) (xy 119.215958 64.459181)
-				(xy 119.221778 64.454333) (xy 119.222968 64.453402) (xy 119.228929 64.449019) (xy 119.242518 64.439638)
-				(xy 119.248853 64.435544) (xy 119.250146 64.434763) (xy 119.256631 64.431107) (xy 119.411126 64.350021)
-				(xy 119.417843 64.346749) (xy 119.41922 64.346129) (xy 119.426155 64.343256) (xy 119.441595 64.3374)
-				(xy 119.448653 64.334964) (xy 119.450096 64.334514) (xy 119.457338 64.332494) (xy 119.626751 64.290739)
-				(xy 119.634019 64.289177) (xy 119.635505 64.288904) (xy 119.642967 64.287767) (xy 119.659359 64.285777)
-				(xy 119.666834 64.285098) (xy 119.668342 64.285007) (xy 119.675811 64.284782) (xy 119.850291 64.284782)
-				(xy 119.85776 64.285007) (xy 119.859268 64.285098) (xy 119.866743 64.285777) (xy 119.883135 64.287767)
-				(xy 119.890597 64.288904) (xy 119.892083 64.289177) (xy 119.899351 64.290739) (xy 120.068764 64.332494)
-				(xy 120.076006 64.334514) (xy 120.077449 64.334964) (xy 120.084507 64.3374) (xy 120.099947 64.343256)
-				(xy 120.106882 64.346129) (xy 120.108259 64.346749) (xy 120.114976 64.350021) (xy 120.269471 64.431107)
-				(xy 120.275956 64.434763) (xy 120.277249 64.435544) (xy 120.283584 64.439638) (xy 120.297173 64.449019)
-				(xy 120.303134 64.453402) (xy 120.304324 64.454333) (xy 120.310144 64.459181) (xy 120.440745 64.574883)
-				(xy 120.446158 64.579976) (xy 120.447227 64.581044) (xy 120.452402 64.586539) (xy 120.463352 64.598899)
-				(xy 120.4682 64.604719) (xy 120.469131 64.605909) (xy 120.473518 64.611876) (xy 120.520252 64.679581)
-				(xy 120.719007 64.480826) (xy 120.662451 64.356987) (xy 120.659063 64.348809) (xy 120.658439 64.347136)
-				(xy 120.655645 64.33874) (xy 120.650144 64.320007) (xy 120.649631 64.317998) (xy 120.441633 64.11)
-				(xy 120.894353 64.11) (xy 120.914834 64.252456) (xy 120.956302 64.343256) (xy 120.974623 64.383373)
-				(xy 121.068872 64.492143) (xy 121.189947 64.569953) (xy 121.18995 64.569954) (xy 121.189949 64.569954)
-				(xy 121.277246 64.595586) (xy 121.326915 64.61017) (xy 121.328036 64.610499) (xy 121.328038 64.6105)
-				(xy 121.328039 64.6105) (xy 121.471962 64.6105) (xy 121.471962 64.610499) (xy 121.610053 64.569953)
-				(xy 121.731128 64.492143) (xy 121.825377 64.383373) (xy 121.885165 64.252457) (xy 121.905647 64.11)
-				(xy 121.885165 63.967543) (xy 121.825377 63.836627) (xy 121.731128 63.727857) (xy 121.610053 63.650047)
-				(xy 121.610051 63.650046) (xy 121.610049 63.650045) (xy 121.61005 63.650045) (xy 121.471963 63.6095)
-				(xy 121.471961 63.6095) (xy 121.328039 63.6095) (xy 121.328036 63.6095) (xy 121.189949 63.650045)
-				(xy 121.068873 63.727856) (xy 120.974623 63.836626) (xy 120.974622 63.836628) (xy 120.914834 63.967543)
-				(xy 120.894353 64.11) (xy 120.441633 64.11) (xy 119.880435 63.548802) (xy 119.111488 64.317749)
-				(xy 115.5 64.317749) (xy 115.5 63.28477) (xy 115.899 63.28477) (xy 115.899 63.373886) (xy 116.034097 63.444791)
-				(xy 116.058698 63.461771) (xy 116.178285 63.567715) (xy 116.198108 63.590091) (xy 116.288865 63.721576)
-				(xy 116.302757 63.748045) (xy 116.35941 63.897428) (xy 116.366564 63.926454) (xy 116.366813 63.928511)
-				(xy 116.696333 64.258031) (xy 117.036856 63.917508) (xy 117.055149 63.883287) (xy 117.068654 63.863076)
-				(xy 117.193619 63.710807) (xy 117.210807 63.693619) (xy 117.363076 63.568654) (xy 117.383287 63.555149)
-				(xy 117.417508 63.536856) (xy 117.58163 63.372734) (xy 117.93377 63.372734) (xy 117.937729 63.376693)
-				(xy 117.987846 63.371758) (xy 118.012154 63.371758) (xy 118.208188 63.391066) (xy 118.232029 63.395808)
-				(xy 118.42053 63.452989) (xy 118.442988 63.462292) (xy 118.616712 63.555149) (xy 118.636924 63.568654)
-				(xy 118.789193 63.693619) (xy 118.806381 63.710807) (xy 118.931346 63.863076) (xy 118.944851 63.883288)
-				(xy 119.03157 64.045529) (xy 119.704365 63.372734) (xy 120.056505 63.372734) (xy 120.640572 63.956801)
-				(xy 120.646003 63.919029) (xy 120.647566 63.910358) (xy 120.647945 63.908613) (xy 120.650144 63.899993)
-				(xy 120.655645 63.88126) (xy 120.658439 63.872864) (xy 120.659063 63.871191) (xy 120.662451 63.863013)
-				(xy 120.730349 63.714338) (xy 120.734321 63.706404) (xy 120.735177 63.704837) (xy 120.739682 63.697245)
-				(xy 120.750236 63.680822) (xy 120.755303 63.673527) (xy 120.756374 63.672097) (xy 120.761911 63.665227)
-				(xy 120.868945 63.541703) (xy 120.874942 63.535259) (xy 120.876204 63.533996) (xy 120.882718 63.527929)
-				(xy 120.897473 63.515144) (xy 120.904342 63.509608) (xy 120.905772 63.508537) (xy 120.913066 63.503471)
-				(xy 121.050564 63.415107) (xy 121.058157 63.410601) (xy 121.059724 63.409745) (xy 121.067655 63.405774)
-				(xy 121.085414 63.397663) (xy 121.093618 63.394266) (xy 121.095292 63.393642) (xy 121.103669 63.390855)
-				(xy 121.260494 63.344808) (xy 121.269043 63.342625) (xy 121.270788 63.342245) (xy 121.279527 63.340667)
-				(xy 121.29885 63.337889) (xy 121.307676 63.336941) (xy 121.309457 63.336814) (xy 121.318277 63.3365)
-				(xy 121.481723 63.3365) (xy 121.490543 63.336814) (xy 121.492324 63.336941) (xy 121.50115 63.337889)
-				(xy 121.520473 63.340667) (xy 121.529212 63.342245) (xy 121.530957 63.342625) (xy 121.539506 63.344808)
-				(xy 121.696331 63.390855) (xy 121.704708 63.393642) (xy 121.706382 63.394266) (xy 121.714586 63.397663)
-				(xy 121.732345 63.405774) (xy 121.740276 63.409745) (xy 121.741843 63.410601) (xy 121.749436 63.415107)
-				(xy 121.77092 63.428914) (xy 121.8271 63.372733) (xy 122.179239 63.372733) (xy 123.064537 64.258032)
-				(xy 123.949836 63.372734) (xy 124.301974 63.372734) (xy 125.187272 64.258032) (xy 126.07257 63.372734)
-				(xy 126.424708 63.372734) (xy 127.310006 64.258032) (xy 128.195305 63.372734) (xy 128.547443 63.372734)
-				(xy 129.432741 64.258032) (xy 130.318039 63.372734) (xy 129.432741 62.487436) (xy 128.547443 63.372734)
-				(xy 128.195305 63.372734) (xy 127.879203 63.056632) (xy 128.231341 63.056632) (xy 128.371374 63.196665)
-				(xy 128.495299 63.072739) (xy 128.492324 63.073059) (xy 128.490543 63.073186) (xy 128.481723 63.0735)
-				(xy 128.318277 63.0735) (xy 128.309457 63.073186) (xy 128.307676 63.073059) (xy 128.29885 63.072111)
-				(xy 128.279527 63.069333) (xy 128.270788 63.067755) (xy 128.269043 63.067375) (xy 128.260494 63.065192)
-				(xy 128.231341 63.056632) (xy 127.879203 63.056632) (xy 127.310006 62.487435) (xy 126.424708 63.372734)
-				(xy 126.07257 63.372734) (xy 125.187272 62.487436) (xy 124.301974 63.372734) (xy 123.949836 63.372734)
-				(xy 123.686284 63.109182) (xy 123.516073 63.122579) (xy 123.51127 63.122863) (xy 123.510289 63.122902)
-				(xy 123.505363 63.123) (xy 123.494637 63.123) (xy 123.489711 63.122902) (xy 123.48873 63.122863)
-				(xy 123.483927 63.122579) (xy 123.222939 63.102038) (xy 123.218128 63.101565) (xy 123.217154 63.10145)
-				(xy 123.212307 63.10078) (xy 123.201713 63.099103) (xy 123.196879 63.098239) (xy 123.195915 63.098047)
-				(xy 123.191189 63.09701) (xy 122.936627 63.035896) (xy 122.931892 63.03466) (xy 122.930946 63.034393)
-				(xy 122.926294 63.032981) (xy 122.916093 63.029665) (xy 122.911554 63.028091) (xy 122.910634 63.027752)
-				(xy 122.906054 63.025961) (xy 122.664187 62.925777) (xy 122.659749 62.923836) (xy 122.658857 62.923425)
-				(xy 122.654449 62.921288) (xy 122.644892 62.916418) (xy 122.640543 62.914091) (xy 122.639687 62.913611)
-				(xy 122.638851 62.913121) (xy 122.179239 63.372733) (xy 121.8271 63.372733) (xy 120.941803 62.487436)
-				(xy 120.056505 63.372734) (xy 119.704365 63.372734) (xy 119.704366 63.372733) (xy 118.819068 62.487435)
-				(xy 117.93377 63.372734) (xy 117.58163 63.372734) (xy 117.581631 63.372733) (xy 116.696334 62.487436)
-				(xy 115.899 63.28477) (xy 115.5 63.28477) (xy 115.5 62.932632) (xy 115.899 62.932632) (xy 116.520265 62.311367)
-				(xy 116.872403 62.311367) (xy 117.757701 63.196665) (xy 118.642999 62.311367) (xy 118.995138 62.311367)
-				(xy 119.880436 63.196665) (xy 120.765734 62.311367) (xy 120.765733 62.311366) (xy 121.117871 62.311366)
-				(xy 122.003169 63.196664) (xy 122.420457 62.779376) (xy 122.412329 62.774396) (xy 122.408161 62.771727)
-				(xy 122.407345 62.771181) (xy 122.403419 62.768442) (xy 122.394742 62.762138) (xy 122.390905 62.759235)
-				(xy 122.390133 62.758627) (xy 122.386322 62.755501) (xy 122.187251 62.585478) (xy 122.183645 62.582275)
-				(xy 122.182924 62.581609) (xy 122.179381 62.578203) (xy 122.171797 62.570619) (xy 122.168391 62.567076)
-				(xy 122.167725 62.566355) (xy 122.164522 62.562749) (xy 121.994499 62.363678) (xy 121.991373 62.359867)
-				(xy 121.990765 62.359095) (xy 121.987862 62.355258) (xy 121.981558 62.346581) (xy 121.978819 62.342655)
-				(xy 121.978273 62.341839) (xy 121.975603 62.33767) (xy 121.838817 62.114454) (xy 121.836389 62.110313)
-				(xy 121.835909 62.109457) (xy 121.833582 62.105108) (xy 121.828712 62.095551) (xy 121.826575 62.091143)
-				(xy 121.826164 62.090251) (xy 121.824223 62.085813) (xy 121.724039 61.843946) (xy 121.722248 61.839366)
-				(xy 121.721909 61.838446) (xy 121.720335 61.833907) (xy 121.717019 61.823706) (xy 121.715607 61.819054)
-				(xy 121.71534 61.818108) (xy 121.714104 61.813373) (xy 121.695085 61.734152) (xy 121.117871 62.311366)
-				(xy 120.765733 62.311366) (xy 119.880436 61.426069) (xy 118.995138 62.311367) (xy 118.642999 62.311367)
-				(xy 117.757701 61.426069) (xy 116.872403 62.311367) (xy 116.520265 62.311367) (xy 115.899 61.690102)
-				(xy 115.899 62.932632) (xy 115.5 62.932632) (xy 115.5 61.162035) (xy 115.899 61.162035) (xy 115.899 61.337964)
-				(xy 116.696334 62.135298) (xy 117.581632 61.249999) (xy 117.933769 61.249999) (xy 118.819068 62.135298)
-				(xy 119.704366 61.249999) (xy 120.056504 61.249999) (xy 120.941802 62.135297) (xy 121.640816 61.436283)
-				(xy 121.627421 61.266073) (xy 121.627137 61.26127) (xy 121.627098 61.260289) (xy 121.627 61.255363)
-				(xy 121.627 61.25) (xy 121.9 61.25) (xy 121.919699 61.500298) (xy 121.978308 61.744424) (xy 122.074387 61.976381)
-				(xy 122.074389 61.976384) (xy 122.205571 62.190453) (xy 122.205574 62.190458) (xy 122.274201 62.27081)
-				(xy 122.368629 62.381371) (xy 122.440151 62.442456) (xy 122.559541 62.544425) (xy 122.559543 62.544426)
-				(xy 122.559544 62.544427) (xy 122.626533 62.585478) (xy 122.773615 62.67561) (xy 122.773618 62.675612)
-				(xy 123.005575 62.771691) (xy 123.232386 62.826143) (xy 123.249705 62.830301) (xy 123.5 62.85) (xy 123.750295 62.830301)
-				(xy 123.962413 62.779376) (xy 123.994424 62.771691) (xy 123.994425 62.77169) (xy 123.994427 62.77169)
-				(xy 124.090502 62.731894) (xy 124.226381 62.675612) (xy 124.226382 62.675611) (xy 124.226385 62.67561)
-				(xy 124.440456 62.544427) (xy 124.631371 62.381371) (xy 124.69116 62.311367) (xy 125.363341 62.311367)
-				(xy 126.248639 63.196665) (xy 127.133937 62.311367) (xy 127.486076 62.311367) (xy 127.642698 62.467989)
-				(xy 127.622742 62.32919) (xy 127.621794 62.320363) (xy 127.621667 62.318582) (xy 127.621353 62.309762)
-				(xy 127.621353 62.3) (xy 127.894353 62.3) (xy 127.914834 62.442456) (xy 127.961404 62.544428) (xy 127.974623 62.573373)
-				(xy 128.068872 62.682143) (xy 128.189947 62.759953) (xy 128.18995 62.759954) (xy 128.189949 62.759954)
-				(xy 128.328036 62.800499) (xy 128.328038 62.8005) (xy 128.328039 62.8005) (xy 128.471962 62.8005)
-				(xy 128.471962 62.800499) (xy 128.581142 62.768442) (xy 128.61005 62.759954) (xy 128.61005 62.759953)
-				(xy 128.610053 62.759953) (xy 128.731128 62.682143) (xy 128.825377 62.573373) (xy 128.885165 62.442457)
-				(xy 128.891108 62.401123) (xy 129.166915 62.401123) (xy 129.256672 62.311367) (xy 129.60881 62.311367)
-				(xy 130.494108 63.196665) (xy 131.101 62.589773) (xy 131.101 62.03296) (xy 130.494108 61.426068)
-				(xy 129.60881 62.311367) (xy 129.256672 62.311367) (xy 129.170732 62.225427) (xy 129.177258 62.27081)
-				(xy 129.178206 62.279637) (xy 129.178333 62.281418) (xy 129.178647 62.290238) (xy 129.178647 62.309762)
-				(xy 129.178333 62.318582) (xy 129.178206 62.320363) (xy 129.177258 62.32919) (xy 129.166915 62.401123)
-				(xy 128.891108 62.401123) (xy 128.905647 62.3) (xy 128.885165 62.157543) (xy 128.825377 62.026627)
-				(xy 128.731128 61.917857) (xy 128.610053 61.840047) (xy 128.610051 61.840046) (xy 128.610049 61.840045)
-				(xy 128.61005 61.840045) (xy 128.471963 61.7995) (xy 128.471961 61.7995) (xy 128.328039 61.7995)
-				(xy 128.328036 61.7995) (xy 128.189949 61.840045) (xy 128.068873 61.917856) (xy 127.974623 62.026626)
-				(xy 127.974622 62.026628) (xy 127.914834 62.157543) (xy 127.894353 62.3) (xy 127.621353 62.3) (xy 127.621353 62.290238)
-				(xy 127.621667 62.281418) (xy 127.621794 62.279637) (xy 127.622742 62.27081) (xy 127.638881 62.158561)
-				(xy 127.486076 62.311367) (xy 127.133937 62.311367) (xy 126.248639 61.426068) (xy 125.363341 62.311367)
-				(xy 124.69116 62.311367) (xy 124.794427 62.190456) (xy 124.92561 61.976385) (xy 124.949854 61.917856)
-				(xy 124.988852 61.823706) (xy 125.02169 61.744427) (xy 125.080301 61.500295) (xy 125.1 61.25) (xy 125.080301 60.999705)
-				(xy 125.034732 60.809897) (xy 125.021691 60.755575) (xy 124.925612 60.523618) (xy 124.92561 60.523615)
-				(xy 124.843026 60.388851) (xy 125.163121 60.388851) (xy 125.163611 60.389687) (xy 125.164091 60.390543)
-				(xy 125.166418 60.394892) (xy 125.171288 60.404449) (xy 125.173425 60.408857) (xy 125.173836 60.409749)
-				(xy 125.175777 60.414187) (xy 125.275961 60.656054) (xy 125.277752 60.660634) (xy 125.278091 60.661554)
-				(xy 125.279665 60.666093) (xy 125.282981 60.676294) (xy 125.284393 60.680946) (xy 125.28466 60.681892)
-				(xy 125.285896 60.686627) (xy 125.34701 60.941189) (xy 125.348047 60.945915) (xy 125.348239 60.946879)
-				(xy 125.349103 60.951713) (xy 125.35078 60.962307) (xy 125.35145 60.967154) (xy 125.351565 60.968128)
-				(xy 125.352038 60.972939) (xy 125.372579 61.233927) (xy 125.372863 61.23873) (xy 125.372902 61.239711)
-				(xy 125.373 61.244637) (xy 125.373 61.255363) (xy 125.372902 61.260289) (xy 125.372863 61.26127)
-				(xy 125.372579 61.266073) (xy 125.352038 61.527061) (xy 125.351565 61.531872) (xy 125.35145 61.532846)
-				(xy 125.35078 61.537693) (xy 125.349103 61.548287) (xy 125.348239 61.553121) (xy 125.348047 61.554085)
-				(xy 125.34701 61.558811) (xy 125.285896 61.813373) (xy 125.28466 61.818108) (xy 125.284393 61.819054)
-				(xy 125.282981 61.823706) (xy 125.279665 61.833907) (xy 125.278091 61.838446) (xy 125.277752 61.839366)
-				(xy 125.275961 61.843946) (xy 125.175777 62.085813) (xy 125.173836 62.090251) (xy 125.173425 62.091143)
-				(xy 125.171288 62.095551) (xy 125.166418 62.105108) (xy 125.164091 62.109457) (xy 125.163611 62.110313)
-				(xy 125.163121 62.111147) (xy 125.187272 62.135298) (xy 126.07257 61.249999) (xy 126.424708 61.249999)
-				(xy 127.310006 62.135298) (xy 127.911231 61.534073) (xy 128.263369 61.534073) (xy 128.269043 61.532625)
-				(xy 128.270788 61.532245) (xy 128.279527 61.530667) (xy 128.29885 61.527889) (xy 128.307676 61.526941)
-				(xy 128.309457 61.526814) (xy 128.318277 61.5265) (xy 128.471805 61.5265) (xy 128.371374 61.426069)
-				(xy 128.263369 61.534073) (xy 127.911231 61.534073) (xy 128.195305 61.249999) (xy 128.547442 61.249999)
-				(xy 129.432741 62.135298) (xy 130.318039 61.249999) (xy 129.432741 60.364701) (xy 128.547442 61.249999)
-				(xy 128.195305 61.249999) (xy 127.310006 60.364701) (xy 126.424708 61.249999) (xy 126.07257 61.249999)
-				(xy 125.187271 60.3647) (xy 125.163121 60.388851) (xy 124.843026 60.388851) (xy 124.794427 60.309544)
-				(xy 124.794426 60.309543) (xy 124.794425 60.309541) (xy 124.735743 60.240833) (xy 124.691159 60.188632)
-				(xy 125.363341 60.188632) (xy 126.248639 61.07393) (xy 127.133937 60.188632) (xy 127.486076 60.188632)
-				(xy 128.371374 61.07393) (xy 129.256672 60.188632) (xy 129.60881 60.188632) (xy 130.494108 61.07393)
-				(xy 131.101 60.467038) (xy 131.101 59.910225) (xy 130.494108 59.303333) (xy 129.60881 60.188632)
-				(xy 129.256672 60.188632) (xy 129.04154 59.9735) (xy 129.393678 59.9735) (xy 129.432741 60.012563)
-				(xy 129.471804 59.9735) (xy 129.393678 59.9735) (xy 129.04154 59.9735) (xy 128.371374 59.303334)
-				(xy 127.486076 60.188632) (xy 127.133937 60.188632) (xy 126.248639 59.303333) (xy 125.363341 60.188632)
-				(xy 124.691159 60.188632) (xy 124.631371 60.118629) (xy 124.470286 59.98105) (xy 124.440458 59.955574)
-				(xy 124.440453 59.955571) (xy 124.226384 59.824389) (xy 124.226381 59.824387) (xy 123.994424 59.728308)
-				(xy 123.750298 59.669699) (xy 123.61349 59.658932) (xy 123.526794 59.652108) (xy 123.461506 59.627225)
-				(xy 123.420036 59.570993) (xy 123.415549 59.501268) (xy 123.42373 59.476979) (xy 123.433836 59.454851)
-				(xy 123.485165 59.342457) (xy 123.505647 59.2) (xy 123.485165 59.057543) (xy 123.425377 58.926627)
-				(xy 123.38758 58.883007) (xy 123.705578 58.883007) (xy 123.737549 58.953013) (xy 123.740937 58.961191)
-				(xy 123.741561 58.962864) (xy 123.744355 58.97126) (xy 123.749856 58.989993) (xy 123.752055 58.998613)
-				(xy 123.752434 59.000358) (xy 123.753997 59.009029) (xy 123.777258 59.17081) (xy 123.778206 59.179637)
-				(xy 123.778333 59.181418) (xy 123.778647 59.190238) (xy 123.778647 59.209762) (xy 123.778333 59.218582)
-				(xy 123.778206 59.220363) (xy 123.777258 59.22919) (xy 123.765393 59.311706) (xy 123.949834 59.127265)
-				(xy 124.301974 59.127265) (xy 125.187272 60.012563) (xy 126.07257 59.127265) (xy 126.424708 59.127265)
-				(xy 127.310006 60.012563) (xy 128.195305 59.127265) (xy 128.547443 59.127265) (xy 128.621353 59.201175)
-				(xy 128.621353 59.2) (xy 128.894353 59.2) (xy 128.914834 59.342456) (xy 128.918426 59.350321) (xy 128.974623 59.473373)
-				(xy 129.068872 59.582143) (xy 129.189947 59.659953) (xy 129.18995 59.659954) (xy 129.189949 59.659954)
-				(xy 129.328036 59.700499) (xy 129.328038 59.7005) (xy 129.328039 59.7005) (xy 129.471962 59.7005)
-				(xy 129.471962 59.700499) (xy 129.610053 59.659953) (xy 129.731128 59.582143) (xy 129.825377 59.473373)
-				(xy 129.885165 59.342457) (xy 129.905647 59.2) (xy 129.885165 59.057543) (xy 129.832184 58.941531)
-				(xy 130.132305 58.941531) (xy 130.137549 58.953013) (xy 130.140937 58.961191) (xy 130.141561 58.962864)
-				(xy 130.144355 58.97126) (xy 130.149856 58.989993) (xy 130.152055 58.998613) (xy 130.152434 59.000358)
-				(xy 130.153997 59.009029) (xy 130.177258 59.17081) (xy 130.178206 59.179637) (xy 130.178333 59.181418)
-				(xy 130.178647 59.190238) (xy 130.178647 59.209762) (xy 130.178333 59.218582) (xy 130.178206 59.220363)
-				(xy 130.177258 59.22919) (xy 130.170733 59.27457) (xy 130.318039 59.127265) (xy 130.132305 58.941531)
-				(xy 129.832184 58.941531) (xy 129.825377 58.926627) (xy 129.731128 58.817857) (xy 129.610053 58.740047)
-				(xy 129.610051 58.740046) (xy 129.610049 58.740045) (xy 129.61005 58.740045) (xy 129.471963 58.6995)
-				(xy 129.471961 58.6995) (xy 129.328039 58.6995) (xy 129.328036 58.6995) (xy 129.189949 58.740045)
-				(xy 129.068873 58.817856) (xy 128.974623 58.926626) (xy 128.974622 58.926628) (xy 128.914834 59.057543)
-				(xy 128.894353 59.2) (xy 128.621353 59.2) (xy 128.621353 59.190238) (xy 128.621667 59.181418) (xy 128.621794 59.179637)
-				(xy 128.622742 59.17081) (xy 128.642698 59.032009) (xy 128.547443 59.127265) (xy 128.195305 59.127265)
-				(xy 127.310006 58.241966) (xy 126.424708 59.127265) (xy 126.07257 59.127265) (xy 125.187272 58.241967)
-				(xy 124.301974 59.127265) (xy 123.949834 59.127265) (xy 123.949835 59.127264) (xy 123.705578 58.883007)
-				(xy 123.38758 58.883007) (xy 123.331128 58.817857) (xy 123.210053 58.740047) (xy 123.210051 58.740046)
-				(xy 123.210049 58.740045) (xy 123.21005 58.740045) (xy 123.071963 58.6995) (xy 123.071961 58.6995)
-				(xy 122.928039 58.6995) (xy 122.928036 58.6995) (xy 122.789949 58.740045) (xy 122.668873 58.817856)
-				(xy 122.574623 58.926626) (xy 122.574622 58.926628) (xy 122.514834 59.057543) (xy 122.494353 59.2)
-				(xy 122.514834 59.342456) (xy 122.518426 59.350321) (xy 122.574623 59.473373) (xy 122.668872 59.582143)
-				(xy 122.746746 59.63219) (xy 122.792501 59.684993) (xy 122.802445 59.754152) (xy 122.77342 59.817707)
-				(xy 122.744497 59.842232) (xy 122.559546 59.95557) (xy 122.559541 59.955574) (xy 122.368629 60.118629)
-				(xy 122.205574 60.309541) (xy 122.205571 60.309546) (xy 122.074389 60.523615) (xy 122.074387 60.523618)
-				(xy 121.978308 60.755575) (xy 121.919699 60.999701) (xy 121.9 61.25) (xy 121.627 61.25) (xy 121.627 61.244637)
-				(xy 121.627098 61.239711) (xy 121.627137 61.23873) (xy 121.627421 61.233927) (xy 121.640816 61.063715)
-				(xy 120.941802 60.364701) (xy 120.056504 61.249999) (xy 119.704366 61.249999) (xy 118.819068 60.364701)
-				(xy 117.933769 61.249999) (xy 117.581632 61.249999) (xy 116.696333 60.364701) (xy 115.899 61.162035)
-				(xy 115.5 61.162035) (xy 115.5 60.809897) (xy 115.899 60.809897) (xy 116.520265 60.188632) (xy 116.872403 60.188632)
-				(xy 117.757701 61.07393) (xy 118.642999 60.188632) (xy 118.642998 60.188631) (xy 118.995137 60.188631)
-				(xy 119.880436 61.07393) (xy 120.765734 60.188632) (xy 121.117872 60.188632) (xy 121.695085 60.765845)
-				(xy 121.714104 60.686627) (xy 121.71534 60.681892) (xy 121.715607 60.680946) (xy 121.717019 60.676294)
-				(xy 121.720335 60.666093) (xy 121.721909 60.661554) (xy 121.722248 60.660634) (xy 121.724039 60.656054)
-				(xy 121.824223 60.414187) (xy 121.826164 60.409749) (xy 121.826575 60.408857) (xy 121.828712 60.404449)
-				(xy 121.833582 60.394892) (xy 121.835909 60.390543) (xy 121.836389 60.389687) (xy 121.838817 60.385546)
-				(xy 121.975603 60.16233) (xy 121.978273 60.158161) (xy 121.978819 60.157345) (xy 121.981558 60.153419)
-				(xy 121.987862 60.144742) (xy 121.990765 60.140905) (xy 121.991373 60.140133) (xy 121.994499 60.136322)
-				(xy 122.164522 59.937251) (xy 122.167725 59.933645) (xy 122.168391 59.932924) (xy 122.171797 59.929381)
-				(xy 122.179381 59.921797) (xy 122.182924 59.918391) (xy 122.183645 59.917725) (xy 122.187251 59.914522)
-				(xy 122.386322 59.744499) (xy 122.390133 59.741373) (xy 122.390905 59.740765) (xy 122.394742 59.737862)
-				(xy 122.403419 59.731558) (xy 122.407345 59.728819) (xy 122.408161 59.728273) (xy 122.412328 59.725604)
-				(xy 122.420457 59.720621) (xy 122.00317 59.303334) (xy 121.117872 60.188632) (xy 120.765734 60.188632)
-				(xy 120.536391 59.959289) (xy 120.489507 59.973056) (xy 120.480957 59.975239) (xy 120.479212 59.975619)
-				(xy 120.470473 59.977197) (xy 120.45115 59.979975) (xy 120.442324 59.980923) (xy 120.440543 59.98105)
-				(xy 120.431723 59.981364) (xy 120.268277 59.981364) (xy 120.259457 59.98105) (xy 120.257676 59.980923)
-				(xy 120.24885 59.979975) (xy 120.229527 59.977197) (xy 120.220788 59.975619) (xy 120.219043 59.975239)
-				(xy 120.210494 59.973056) (xy 120.053669 59.927009) (xy 120.045292 59.924222) (xy 120.043618 59.923598)
-				(xy 120.035414 59.920201) (xy 120.017655 59.91209) (xy 120.009724 59.908119) (xy 120.008157 59.907263)
-				(xy 120.000564 59.902757) (xy 119.863066 59.814393) (xy 119.855772 59.809327) (xy 119.854342 59.808256)
-				(xy 119.847473 59.80272) (xy 119.832718 59.789935) (xy 119.826204 59.783868) (xy 119.824942 59.782605)
-				(xy 119.818945 59.776161) (xy 119.711911 59.652637) (xy 119.706374 59.645767) (xy 119.705303 59.644337)
-				(xy 119.700236 59.637042) (xy 119.689682 59.620619) (xy 119.685177 59.613027) (xy 119.684321 59.61146)
-				(xy 119.680349 59.603526) (xy 119.648964 59.534804) (xy 118.995137 60.188631) (xy 118.642998 60.188631)
-				(xy 117.757701 59.303334) (xy 116.872403 60.188632) (xy 116.520265 60.188632) (xy 115.899 59.567367)
-				(xy 115.899 60.809897) (xy 115.5 60.809897) (xy 115.5 59.039301) (xy 115.899 59.039301) (xy 115.899 59.215229)
-				(xy 116.696334 60.012563) (xy 117.581632 59.127265) (xy 117.93377 59.127265) (xy 118.819068 60.012563)
-				(xy 119.575486 59.256144) (xy 119.572742 59.237054) (xy 119.571794 59.228227) (xy 119.571667 59.226446)
-				(xy 119.571353 59.217626) (xy 119.571353 59.207864) (xy 119.844353 59.207864) (xy 119.864834 59.35032)
-				(xy 119.922678 59.476979) (xy 119.924623 59.481237) (xy 120.018872 59.590007) (xy 120.139947 59.667817)
-				(xy 120.13995 59.667818) (xy 120.139949 59.667818) (xy 120.278036 59.708363) (xy 120.278038 59.708364)
-				(xy 120.278039 59.708364) (xy 120.421962 59.708364) (xy 120.421962 59.708363) (xy 120.529121 59.676899)
-				(xy 120.56005 59.667818) (xy 120.56005 59.667817) (xy 120.560053 59.667817) (xy 120.681128 59.590007)
-				(xy 120.775377 59.481237) (xy 120.835165 59.350321) (xy 120.855647 59.207864) (xy 120.835165 59.065407)
-				(xy 120.775377 58.934491) (xy 120.681128 58.825721) (xy 120.560053 58.747911) (xy 120.560051 58.74791)
-				(xy 120.560049 58.747909) (xy 120.56005 58.747909) (xy 120.421963 58.707364) (xy 120.421961 58.707364)
-				(xy 120.278039 58.707364) (xy 120.278036 58.707364) (xy 120.139949 58.747909) (xy 120.018873 58.82572)
-				(xy 119.924623 58.93449) (xy 119.924622 58.934492) (xy 119.864834 59.065407) (xy 119.844353 59.207864)
-				(xy 119.571353 59.207864) (xy 119.571353 59.198102) (xy 119.571667 59.189282) (xy 119.571794 59.187501)
-				(xy 119.572742 59.178674) (xy 119.59575 59.018648) (xy 118.819068 58.241966) (xy 117.93377 59.127265)
-				(xy 117.581632 59.127265) (xy 116.696334 58.241967) (xy 115.899 59.039301) (xy 115.5 59.039301)
-				(xy 115.5 58.687163) (xy 115.899 58.687163) (xy 116.520265 58.065898) (xy 116.872403 58.065898)
-				(xy 117.757701 58.951196) (xy 118.642999 58.065898) (xy 118.995138 58.065898) (xy 119.703388 58.774148)
-				(xy 119.705303 58.771391) (xy 119.706374 58.769961) (xy 119.711911 58.763091) (xy 119.818945 58.639567)
-				(xy 119.824942 58.633123) (xy 119.826204 58.63186) (xy 119.832718 58.625793) (xy 119.847473 58.613008)
-				(xy 119.854342 58.607472) (xy 119.855772 58.606401) (xy 119.863066 58.601335) (xy 120.000564 58.512971)
-				(xy 120.008157 58.508465) (xy 120.009724 58.507609) (xy 120.017655 58.503638) (xy 120.019177 58.502943)
-				(xy 120.680825 58.502943) (xy 120.682345 58.503638) (xy 120.690276 58.507609) (xy 120.691843 58.508465)
-				(xy 120.699436 58.512971) (xy 120.836934 58.601335) (xy 120.844228 58.606401) (xy 120.845658 58.607472)
-				(xy 120.852527 58.613008) (xy 120.867282 58.625793) (xy 120.873796 58.63186) (xy 120.875058 58.633123)
-				(xy 120.881055 58.639567) (xy 120.988089 58.763091) (xy 120.993626 58.769961) (xy 120.994697 58.771391)
-				(xy 120.999764 58.778686) (xy 121.010318 58.795109) (xy 121.014823 58.802701) (xy 121.015679 58.804268)
-				(xy 121.019651 58.812202) (xy 121.087549 58.960877) (xy 121.090937 58.969055) (xy 121.091561 58.970728)
-				(xy 121.094355 58.979124) (xy 121.099856 58.997857) (xy 121.102055 59.006477) (xy 121.102434 59.008222)
-				(xy 121.103997 59.016893) (xy 121.127258 59.178674) (xy 121.128206 59.187501) (xy 121.128333 59.189282)
-				(xy 121.128647 59.198102) (xy 121.128647 59.217626) (xy 121.128333 59.226446) (xy 121.128206 59.228227)
-				(xy 121.127258 59.237054) (xy 121.103997 59.398835) (xy 121.102434 59.407506) (xy 121.102055 59.409251)
-				(xy 121.099856 59.417871) (xy 121.094355 59.436604) (xy 121.091561 59.445) (xy 121.090937 59.446673)
-				(xy 121.087549 59.454851) (xy 121.019651 59.603526) (xy 121.015679 59.61146) (xy 121.014823 59.613027)
-				(xy 121.010318 59.620619) (xy 120.999764 59.637042) (xy 120.994697 59.644337) (xy 120.993626 59.645767)
-				(xy 120.988089 59.652637) (xy 120.881055 59.776161) (xy 120.875058 59.782605) (xy 120.873796 59.783868)
-				(xy 120.867282 59.789935) (xy 120.852527 59.80272) (xy 120.845658 59.808256) (xy 120.844228 59.809327)
-				(xy 120.836934 59.814393) (xy 120.780135 59.850895) (xy 120.941803 60.012563) (xy 121.827101 59.127265)
-				(xy 121.8271 59.127264) (xy 122.179239 59.127264) (xy 122.222747 59.170773) (xy 122.237359 59.069144)
-				(xy 122.179239 59.127264) (xy 121.8271 59.127264) (xy 120.941802 58.241966) (xy 120.680825 58.502943)
-				(xy 120.019177 58.502943) (xy 120.035414 58.495527) (xy 120.043618 58.49213) (xy 120.045292 58.491506)
-				(xy 120.053669 58.488719) (xy 120.210494 58.442672) (xy 120.219043 58.440489) (xy 120.220788 58.440109)
-				(xy 120.229527 58.438531) (xy 120.24885 58.435753) (xy 120.257676 58.434805) (xy 120.259457 58.434678)
-				(xy 120.268277 58.434364) (xy 120.397267 58.434364) (xy 120.765732 58.065898) (xy 121.117872 58.065898)
-				(xy 122.00317 58.951196) (xy 122.522887 58.431479) (xy 122.875024 58.431479) (xy 122.879527 58.430667)
-				(xy 122.89885 58.427889) (xy 122.907676 58.426941) (xy 122.909457 58.426814) (xy 122.918277 58.4265)
-				(xy 123.081723 58.4265) (xy 123.090543 58.426814) (xy 123.092324 58.426941) (xy 123.10115 58.427889)
-				(xy 123.120473 58.430667) (xy 123.129212 58.432245) (xy 123.130957 58.432625) (xy 123.139506 58.434808)
-				(xy 123.296331 58.480855) (xy 123.304708 58.483642) (xy 123.306382 58.484266) (xy 123.307158 58.484587)
-				(xy 123.064537 58.241966) (xy 122.875024 58.431479) (xy 122.522887 58.431479) (xy 122.888468 58.065898)
-				(xy 123.240607 58.065898) (xy 124.125905 58.951196) (xy 125.011203 58.065898) (xy 125.363341 58.065898)
-				(xy 126.248639 58.951196) (xy 127.133937 58.065898) (xy 127.486076 58.065898) (xy 128.371374 58.951196)
-				(xy 128.879202 58.443368) (xy 129.231339 58.443368) (xy 129.260494 58.434808) (xy 129.269043 58.432625)
-				(xy 129.270788 58.432245) (xy 129.279527 58.430667) (xy 129.29885 58.427889) (xy 129.307676 58.426941)
-				(xy 129.309457 58.426814) (xy 129.318277 58.4265) (xy 129.481723 58.4265) (xy 129.490543 58.426814)
-				(xy 129.492324 58.426941) (xy 129.50115 58.427889) (xy 129.520473 58.430667) (xy 129.529212 58.432245)
-				(xy 129.530957 58.432625) (xy 129.539506 58.434808) (xy 129.661361 58.470587) (xy 129.432741 58.241967)
-				(xy 129.231339 58.443368) (xy 128.879202 58.443368) (xy 129.256672 58.065898) (xy 129.60881 58.065898)
-				(xy 130.494108 58.951196) (xy 131.101 58.344304) (xy 131.101 57.787491) (xy 130.494108 57.180599)
-				(xy 129.60881 58.065898) (xy 129.256672 58.065898) (xy 128.371374 57.1806) (xy 127.486076 58.065898)
-				(xy 127.133937 58.065898) (xy 126.248639 57.180599) (xy 125.363341 58.065898) (xy 125.011203 58.065898)
-				(xy 124.125905 57.1806) (xy 123.240607 58.065898) (xy 122.888468 58.065898) (xy 122.00317 57.1806)
-				(xy 121.117872 58.065898) (xy 120.765732 58.065898) (xy 120.765733 58.065897) (xy 119.880436 57.1806)
-				(xy 118.995138 58.065898) (xy 118.642999 58.065898) (xy 117.757701 57.1806) (xy 116.872403 58.065898)
-				(xy 116.520265 58.065898) (xy 115.899 57.444633) (xy 115.899 58.687163) (xy 115.5 58.687163) (xy 115.5 58.004066)
-				(xy 115.500265 57.995956) (xy 115.507221 57.889828) (xy 115.520857 57.681774) (xy 115.522972 57.66572)
-				(xy 115.583599 57.360923) (xy 115.587797 57.345258) (xy 115.657361 57.140329) (xy 115.946835 57.140329)
-				(xy 116.696334 57.889828) (xy 117.581632 57.00453) (xy 117.933769 57.00453) (xy 118.819068 57.889828)
-				(xy 119.704366 57.00453) (xy 120.056504 57.00453) (xy 120.941803 57.889828) (xy 121.827101 57.00453)
-				(xy 122.179239 57.00453) (xy 123.064537 57.889828) (xy 123.949836 57.00453) (xy 124.301973 57.00453)
-				(xy 125.187272 57.889828) (xy 126.07257 57.00453) (xy 126.424708 57.00453) (xy 127.310006 57.889828)
-				(xy 128.195305 57.00453) (xy 128.547442 57.00453) (xy 129.432741 57.889828) (xy 130.318039 57.00453)
-				(xy 129.432741 56.119232) (xy 128.547442 57.00453) (xy 128.195305 57.00453) (xy 127.310006 56.119231)
-				(xy 126.424708 57.00453) (xy 126.07257 57.00453) (xy 125.187272 56.119232) (xy 124.301973 57.00453)
-				(xy 123.949836 57.00453) (xy 123.064537 56.119231) (xy 122.179239 57.00453) (xy 121.827101 57.00453)
-				(xy 120.941803 56.119232) (xy 120.056504 57.00453) (xy 119.704366 57.00453) (xy 118.819068 56.119231)
-				(xy 117.933769 57.00453) (xy 117.581632 57.00453) (xy 116.744227 56.167125) (xy 116.644644 56.233664)
-				(xy 116.425686 56.425686) (xy 116.233664 56.644644) (xy 116.071867 56.886792) (xy 115.946835 57.140329)
-				(xy 115.657361 57.140329) (xy 115.687691 57.050979) (xy 115.693889 57.036014) (xy 115.831344 56.757283)
-				(xy 115.839447 56.743248) (xy 116.012109 56.484841) (xy 116.021966 56.471995) (xy 116.226879 56.238337)
-				(xy 116.238337 56.226879) (xy 116.458146 56.034111) (xy 116.963351 56.034111) (xy 117.757701 56.828461)
-				(xy 118.642999 55.943163) (xy 118.995138 55.943163) (xy 119.880436 56.828461) (xy 120.765734 55.943163)
-				(xy 121.117872 55.943163) (xy 122.00317 56.828461) (xy 122.888468 55.943163) (xy 123.240607 55.943163)
-				(xy 124.125905 56.828461) (xy 125.011203 55.943163) (xy 125.363341 55.943163) (xy 126.248639 56.828461)
-				(xy 127.133936 55.943163) (xy 127.486076 55.943163) (xy 128.371374 56.828461) (xy 129.256672 55.943163)
-				(xy 129.60881 55.943163) (xy 130.494107 56.82846) (xy 130.725025 56.597542) (xy 130.574311 56.425686)
-				(xy 130.355353 56.233664) (xy 130.113205 56.071867) (xy 129.852006 55.943057) (xy 129.722217 55.899)
-				(xy 129.652973 55.899) (xy 129.60881 55.943163) (xy 129.256672 55.943163) (xy 129.212509 55.899)
-				(xy 127.530239 55.899) (xy 127.486076 55.943163) (xy 127.133936 55.943163) (xy 127.133937 55.943162)
-				(xy 127.089775 55.899) (xy 125.407504 55.899) (xy 125.363341 55.943163) (xy 125.011203 55.943163)
-				(xy 124.96704 55.899) (xy 123.28477 55.899) (xy 123.240607 55.943163) (xy 122.888468 55.943163)
-				(xy 122.844305 55.899) (xy 121.162035 55.899) (xy 121.117872 55.943163) (xy 120.765734 55.943163)
-				(xy 120.721571 55.899) (xy 119.039301 55.899) (xy 118.995138 55.943163) (xy 118.642999 55.943163)
-				(xy 118.598836 55.899) (xy 117.277782 55.899) (xy 117.147991 55.943057) (xy 116.963351 56.034111)
-				(xy 116.458146 56.034111) (xy 116.471995 56.021966) (xy 116.484841 56.012109) (xy 116.743248 55.839447)
-				(xy 116.757283 55.831344) (xy 117.036014 55.693889) (xy 117.050979 55.687691) (xy 117.258206 55.617346)
-				(xy 117.345258 55.587797) (xy 117.360925 55.583599) (xy 117.66572 55.522972) (xy 117.681774 55.520857)
-				(xy 117.995957 55.500265) (xy 118.004067 55.5) (xy 128.995933 55.5)
+				(xy 118.642998 66.556835) (xy 117.7577 65.671537) (xy 117.718323 65.710914) (xy 117.737549 65.753013)
+				(xy 117.740937 65.761191) (xy 117.741561 65.762864) (xy 117.744355 65.77126) (xy 117.749856 65.789993)
+				(xy 117.752055 65.798613) (xy 117.752434 65.800358) (xy 117.753997 65.809029) (xy 117.777258 65.97081)
+				(xy 117.778206 65.979637) (xy 117.778333 65.981418) (xy 117.778647 65.990238) (xy 117.778647 66.009762)
+				(xy 117.778333 66.018582) (xy 117.778206 66.020363) (xy 117.777258 66.02919) (xy 117.753997 66.190971)
+				(xy 117.752434 66.199642) (xy 117.752055 66.201387) (xy 117.749856 66.210007) (xy 117.744355 66.22874)
+				(xy 117.741561 66.237136) (xy 117.740937 66.238809) (xy 117.737549 66.246987) (xy 117.669651 66.395662)
+				(xy 117.665679 66.403596) (xy 117.664823 66.405163) (xy 117.660318 66.412755) (xy 117.649764 66.429178)
+				(xy 117.644697 66.436473) (xy 117.643626 66.437903) (xy 117.638089 66.444773) (xy 117.531055 66.568297)
+				(xy 117.525058 66.574741) (xy 117.523796 66.576004) (xy 117.517282 66.582071) (xy 117.502527 66.594856)
+				(xy 117.495658 66.600392) (xy 117.494846 66.601) (xy 116.830622 66.601) (xy 116.845829 66.554387)
+				(xy 116.89997 66.510223) (xy 116.948104 66.5005) (xy 117.071962 66.5005) (xy 117.071962 66.500499)
+				(xy 117.210053 66.459953) (xy 117.331128 66.382143) (xy 117.425377 66.273373) (xy 117.485165 66.142457)
+				(xy 117.505647 66) (xy 117.485165 65.857543) (xy 117.425377 65.726627) (xy 117.335901 65.623365)
+				(xy 118.061666 65.623365) (xy 118.819068 66.380767) (xy 119.230917 65.968917) (xy 119.228929 65.967545)
+				(xy 119.222968 65.963162) (xy 119.221778 65.962231) (xy 119.215958 65.957383) (xy 119.10552 65.859544)
+				(xy 120.42058 65.859544) (xy 120.941803 66.380767) (xy 121.827101 65.495468) (xy 122.179239 65.495468)
+				(xy 123.064537 66.380767) (xy 123.949836 65.495468) (xy 124.301973 65.495468) (xy 125.187272 66.380767)
+				(xy 126.07257 65.495468) (xy 126.424708 65.495468) (xy 127.310006 66.380767) (xy 128.195305 65.495468)
+				(xy 128.547442 65.495468) (xy 129.432741 66.380767) (xy 130.318039 65.495468) (xy 129.432741 64.61017)
+				(xy 128.547442 65.495468) (xy 128.195305 65.495468) (xy 127.310006 64.61017) (xy 126.424708 65.495468)
+				(xy 126.07257 65.495468) (xy 125.187272 64.61017) (xy 124.301973 65.495468) (xy 123.949836 65.495468)
+				(xy 123.064537 64.61017) (xy 122.179239 65.495468) (xy 121.827101 65.495468) (xy 121.202408 64.870775)
+				(xy 121.554546 64.870775) (xy 122.00317 65.319399) (xy 122.888468 64.434101) (xy 123.240606 64.434101)
+				(xy 124.125905 65.319399) (xy 125.011203 64.434101) (xy 125.36334 64.434101) (xy 126.248639 65.319399)
+				(xy 127.133937 64.434101) (xy 127.486075 64.434101) (xy 128.371374 65.319399) (xy 129.256672 64.434101)
+				(xy 129.608809 64.434101) (xy 130.494107 65.319399) (xy 131.101 64.712507) (xy 131.101 64.155694)
+				(xy 130.494108 63.548802) (xy 129.608809 64.434101) (xy 129.256672 64.434101) (xy 128.371374 63.548803)
+				(xy 127.486075 64.434101) (xy 127.133937 64.434101) (xy 126.248639 63.548802) (xy 125.36334 64.434101)
+				(xy 125.011203 64.434101) (xy 124.125905 63.548803) (xy 123.240606 64.434101) (xy 122.888468 64.434101)
+				(xy 122.003169 63.548802) (xy 121.967829 63.584143) (xy 122.038089 63.665227) (xy 122.043626 63.672097)
+				(xy 122.044697 63.673527) (xy 122.049764 63.680822) (xy 122.060318 63.697245) (xy 122.064823 63.704837)
+				(xy 122.065679 63.706404) (xy 122.069651 63.714338) (xy 122.137549 63.863013) (xy 122.140937 63.871191)
+				(xy 122.141561 63.872864) (xy 122.144355 63.88126) (xy 122.149856 63.899993) (xy 122.152055 63.908613)
+				(xy 122.152434 63.910358) (xy 122.153997 63.919029) (xy 122.177258 64.08081) (xy 122.178206 64.089637)
+				(xy 122.178333 64.091418) (xy 122.178647 64.100238) (xy 122.178647 64.119762) (xy 122.178333 64.128582)
+				(xy 122.178206 64.130363) (xy 122.177258 64.13919) (xy 122.153997 64.300971) (xy 122.152434 64.309642)
+				(xy 122.152055 64.311387) (xy 122.149856 64.320007) (xy 122.144355 64.33874) (xy 122.141561 64.347136)
+				(xy 122.140937 64.348809) (xy 122.137549 64.356987) (xy 122.069651 64.505662) (xy 122.065679 64.513596)
+				(xy 122.064823 64.515163) (xy 122.060318 64.522755) (xy 122.049764 64.539178) (xy 122.044697 64.546473)
+				(xy 122.043626 64.547903) (xy 122.038089 64.554773) (xy 121.931055 64.678297) (xy 121.925058 64.684741)
+				(xy 121.923796 64.686004) (xy 121.917282 64.692071) (xy 121.902527 64.704856) (xy 121.895658 64.710392)
+				(xy 121.894228 64.711463) (xy 121.886934 64.716529) (xy 121.749436 64.804893) (xy 121.741843 64.809399)
+				(xy 121.740276 64.810255) (xy 121.732345 64.814226) (xy 121.714586 64.822337) (xy 121.706382 64.825734)
+				(xy 121.704708 64.826358) (xy 121.696331 64.829145) (xy 121.554546 64.870775) (xy 121.202408 64.870775)
+				(xy 121.184516 64.852883) (xy 121.10367 64.829146) (xy 121.095292 64.826358) (xy 121.093618 64.825734)
+				(xy 121.085414 64.822337) (xy 121.067655 64.814226) (xy 121.059724 64.810255) (xy 121.058157 64.809399)
+				(xy 121.050564 64.804893) (xy 120.913066 64.716529) (xy 120.905772 64.711463) (xy 120.904342 64.710392)
+				(xy 120.897473 64.704856) (xy 120.882718 64.692071) (xy 120.876204 64.686004) (xy 120.874942 64.684741)
+				(xy 120.871225 64.680746) (xy 120.63881 64.913161) (xy 120.657475 64.962376) (xy 120.65991 64.969431)
+				(xy 120.66036 64.970874) (xy 120.662381 64.97812) (xy 120.666332 64.994153) (xy 120.667893 65.001417)
+				(xy 120.668166 65.002903) (xy 120.669303 65.010363) (xy 120.690334 65.183572) (xy 120.691013 65.191049)
+				(xy 120.691104 65.192557) (xy 120.691329 65.200026) (xy 120.691329 65.216538) (xy 120.691104 65.224007)
+				(xy 120.691013 65.225515) (xy 120.690334 65.232992) (xy 120.669303 65.406201) (xy 120.668166 65.413661)
+				(xy 120.667893 65.415147) (xy 120.666332 65.422411) (xy 120.662381 65.438444) (xy 120.66036 65.44569)
+				(xy 120.65991 65.447133) (xy 120.657475 65.454188) (xy 120.595603 65.617331) (xy 120.592742 65.624238)
+				(xy 120.592122 65.625616) (xy 120.58884 65.63236) (xy 120.581167 65.646981) (xy 120.577472 65.65353)
+				(xy 120.57669 65.654823) (xy 120.572636 65.661092) (xy 120.473518 65.804688) (xy 120.469131 65.810655)
+				(xy 120.4682 65.811845) (xy 120.463352 65.817665) (xy 120.452402 65.830025) (xy 120.447227 65.83552)
+				(xy 120.446158 65.836588) (xy 120.440744 65.841682) (xy 120.42058 65.859544) (xy 119.10552 65.859544)
+				(xy 119.085357 65.841681) (xy 119.079944 65.836588) (xy 119.078875 65.83552) (xy 119.0737 65.830025)
+				(xy 119.06275 65.817665) (xy 119.057902 65.811845) (xy 119.056971 65.810655) (xy 119.052584 65.804688)
+				(xy 118.953466 65.661092) (xy 118.949412 65.654823) (xy 118.94863 65.65353) (xy 118.944935 65.646981)
+				(xy 118.937262 65.63236) (xy 118.93398 65.625616) (xy 118.93336 65.624238) (xy 118.930499 65.617331)
+				(xy 118.868627 65.454188) (xy 118.866192 65.447133) (xy 118.865742 65.44569) (xy 118.863721 65.438444)
+				(xy 118.85977 65.422411) (xy 118.858209 65.415147) (xy 118.857936 65.413661) (xy 118.856799 65.406201)
+				(xy 118.837925 65.250756) (xy 118.806381 65.289193) (xy 118.789193 65.306381) (xy 118.636924 65.431346)
+				(xy 118.616712 65.444851) (xy 118.442988 65.537708) (xy 118.42053 65.547011) (xy 118.232029 65.604192)
+				(xy 118.208188 65.608934) (xy 118.061666 65.623365) (xy 117.335901 65.623365) (xy 117.331128 65.617857)
+				(xy 117.210053 65.540047) (xy 117.210051 65.540046) (xy 117.210049 65.540045) (xy 117.21005 65.540045)
+				(xy 117.071963 65.4995) (xy 117.071961 65.4995) (xy 116.928039 65.4995) (xy 116.928036 65.4995)
+				(xy 116.789949 65.540045) (xy 116.668873 65.617856) (xy 116.574623 65.726626) (xy 116.574622 65.726628)
+				(xy 116.514834 65.857543) (xy 116.494353 66) (xy 116.514834 66.142456) (xy 116.558856 66.238849)
+				(xy 116.5688 66.308008) (xy 116.539775 66.371564) (xy 116.480997 66.409338) (xy 116.411127 66.409338)
+				(xy 116.364303 66.383589) (xy 116.238343 66.273125) (xy 116.226874 66.261656) (xy 116.071135 66.08407)
+				(xy 116.021972 66.028011) (xy 116.012101 66.015146) (xy 115.977366 65.963162) (xy 115.849142 65.77126)
+				(xy 115.839451 65.756757) (xy 115.831341 65.74271) (xy 115.776922 65.63236) (xy 115.693892 65.463991)
+				(xy 115.687688 65.449012) (xy 115.68656 65.44569) (xy 115.65736 65.359668) (xy 115.946835 65.359668)
+				(xy 116.071867 65.613205) (xy 116.233664 65.855353) (xy 116.238542 65.860915) (xy 116.246003 65.809029)
+				(xy 116.247566 65.800358) (xy 116.247945 65.798613) (xy 116.250144 65.789993) (xy 116.255645 65.77126)
+				(xy 116.258439 65.762864) (xy 116.259063 65.761191) (xy 116.262451 65.753013) (xy 116.330349 65.604338)
+				(xy 116.334321 65.596404) (xy 116.335177 65.594837) (xy 116.339682 65.587245) (xy 116.350236 65.570822)
+				(xy 116.355303 65.563527) (xy 116.356374 65.562097) (xy 116.361911 65.555227) (xy 116.468945 65.431703)
+				(xy 116.474942 65.425259) (xy 116.476204 65.423996) (xy 116.482718 65.417929) (xy 116.497473 65.405144)
+				(xy 116.504342 65.399608) (xy 116.505772 65.398537) (xy 116.513066 65.393471) (xy 116.650564 65.305107)
+				(xy 116.658157 65.300601) (xy 116.659724 65.299745) (xy 116.667655 65.295774) (xy 116.685414 65.287663)
+				(xy 116.693618 65.284266) (xy 116.695292 65.283642) (xy 116.703669 65.280855) (xy 116.860494 65.234808)
+				(xy 116.869043 65.232625) (xy 116.870788 65.232245) (xy 116.879527 65.230667) (xy 116.89885 65.227889)
+				(xy 116.907676 65.226941) (xy 116.909457 65.226814) (xy 116.918277 65.2265) (xy 117.081723 65.2265)
+				(xy 117.090543 65.226814) (xy 117.092324 65.226941) (xy 117.10115 65.227889) (xy 117.120473 65.230667)
+				(xy 117.129212 65.232245) (xy 117.130957 65.232625) (xy 117.139506 65.234808) (xy 117.151995 65.238475)
+				(xy 117.127215 65.208281) (xy 119.107773 65.208281) (xy 119.107773 65.208282) (xy 119.126813 65.3651)
+				(xy 119.164318 65.463991) (xy 119.182831 65.512805) (xy 119.272568 65.642812) (xy 119.390811 65.747565)
+				(xy 119.390813 65.747566) (xy 119.530685 65.820978) (xy 119.684065 65.858782) (xy 119.684066 65.858782)
+				(xy 119.842036 65.858782) (xy 119.995416 65.820978) (xy 120.012817 65.811845) (xy 120.135291 65.747565)
+				(xy 120.253534 65.642812) (xy 120.343271 65.512805) (xy 120.399288 65.3651) (xy 120.418329 65.208282)
+				(xy 120.407211 65.116712) (xy 120.399288 65.051463) (xy 120.365501 64.962376) (xy 120.343271 64.903759)
+				(xy 120.253534 64.773752) (xy 120.135291 64.668999) (xy 120.135289 64.668998) (xy 120.135288 64.668997)
+				(xy 119.995416 64.595585) (xy 119.842037 64.557782) (xy 119.842036 64.557782) (xy 119.684066 64.557782)
+				(xy 119.684065 64.557782) (xy 119.530685 64.595585) (xy 119.390813 64.668997) (xy 119.272567 64.773753)
+				(xy 119.182832 64.903757) (xy 119.182831 64.903758) (xy 119.126813 65.051463) (xy 119.107773 65.208281)
+				(xy 117.127215 65.208281) (xy 117.068654 65.136924) (xy 117.055149 65.116712) (xy 116.962292 64.942988)
+				(xy 116.952989 64.92053) (xy 116.929604 64.84344) (xy 116.696334 64.61017) (xy 115.946835 65.359668)
+				(xy 115.65736 65.359668) (xy 115.587797 65.154741) (xy 115.583599 65.139074) (xy 115.575525 65.098486)
+				(xy 115.566948 65.055366) (xy 115.899 65.055366) (xy 116.520265 64.434101) (xy 116.403913 64.317749)
+				(xy 119.111488 64.317749) (xy 119.128242 64.487846) (xy 119.128242 64.512155) (xy 119.125572 64.539255)
+				(xy 119.215958 64.459181) (xy 119.221778 64.454333) (xy 119.222968 64.453402) (xy 119.228929 64.449019)
+				(xy 119.242518 64.439638) (xy 119.248853 64.435544) (xy 119.250146 64.434763) (xy 119.256631 64.431107)
+				(xy 119.411126 64.350021) (xy 119.417843 64.346749) (xy 119.41922 64.346129) (xy 119.426155 64.343256)
+				(xy 119.441595 64.3374) (xy 119.448653 64.334964) (xy 119.450096 64.334514) (xy 119.457338 64.332494)
+				(xy 119.626751 64.290739) (xy 119.634019 64.289177) (xy 119.635505 64.288904) (xy 119.642967 64.287767)
+				(xy 119.659359 64.285777) (xy 119.666834 64.285098) (xy 119.668342 64.285007) (xy 119.675811 64.284782)
+				(xy 119.850291 64.284782) (xy 119.85776 64.285007) (xy 119.859268 64.285098) (xy 119.866743 64.285777)
+				(xy 119.883135 64.287767) (xy 119.890597 64.288904) (xy 119.892083 64.289177) (xy 119.899351 64.290739)
+				(xy 120.068764 64.332494) (xy 120.076006 64.334514) (xy 120.077449 64.334964) (xy 120.084507 64.3374)
+				(xy 120.099947 64.343256) (xy 120.106882 64.346129) (xy 120.108259 64.346749) (xy 120.114976 64.350021)
+				(xy 120.269471 64.431107) (xy 120.275956 64.434763) (xy 120.277249 64.435544) (xy 120.283584 64.439638)
+				(xy 120.297173 64.449019) (xy 120.303134 64.453402) (xy 120.304324 64.454333) (xy 120.310144 64.459181)
+				(xy 120.440745 64.574883) (xy 120.446158 64.579976) (xy 120.447227 64.581044) (xy 120.452402 64.586539)
+				(xy 120.463352 64.598899) (xy 120.4682 64.604719) (xy 120.469131 64.605909) (xy 120.473518 64.611876)
+				(xy 120.520252 64.679581) (xy 120.719007 64.480826) (xy 120.662451 64.356987) (xy 120.659063 64.348809)
+				(xy 120.658439 64.347136) (xy 120.655645 64.33874) (xy 120.650144 64.320007) (xy 120.649631 64.317998)
+				(xy 120.441633 64.11) (xy 120.894353 64.11) (xy 120.914834 64.252456) (xy 120.956302 64.343256)
+				(xy 120.974623 64.383373) (xy 121.068872 64.492143) (xy 121.189947 64.569953) (xy 121.18995 64.569954)
+				(xy 121.189949 64.569954) (xy 121.277246 64.595586) (xy 121.326915 64.61017) (xy 121.328036 64.610499)
+				(xy 121.328038 64.6105) (xy 121.328039 64.6105) (xy 121.471962 64.6105) (xy 121.471962 64.610499)
+				(xy 121.610053 64.569953) (xy 121.731128 64.492143) (xy 121.825377 64.383373) (xy 121.885165 64.252457)
+				(xy 121.905647 64.11) (xy 121.885165 63.967543) (xy 121.825377 63.836627) (xy 121.731128 63.727857)
+				(xy 121.610053 63.650047) (xy 121.610051 63.650046) (xy 121.610049 63.650045) (xy 121.61005 63.650045)
+				(xy 121.471963 63.6095) (xy 121.471961 63.6095) (xy 121.328039 63.6095) (xy 121.328036 63.6095)
+				(xy 121.189949 63.650045) (xy 121.068873 63.727856) (xy 120.974623 63.836626) (xy 120.974622 63.836628)
+				(xy 120.914834 63.967543) (xy 120.894353 64.11) (xy 120.441633 64.11) (xy 119.880435 63.548802)
+				(xy 119.111488 64.317749) (xy 116.403913 64.317749) (xy 115.899 63.812836) (xy 115.899 65.055366)
+				(xy 115.566948 65.055366) (xy 115.522972 64.834281) (xy 115.520857 64.818223) (xy 115.500265 64.504043)
+				(xy 115.5 64.495933) (xy 115.5 63.400752) (xy 115.899 63.400752) (xy 115.899 63.460698) (xy 116.696333 64.258031)
+				(xy 117.036856 63.917508) (xy 117.055149 63.883287) (xy 117.068654 63.863076) (xy 117.193619 63.710807)
+				(xy 117.210807 63.693619) (xy 117.363076 63.568654) (xy 117.383287 63.555149) (xy 117.417508 63.536856)
+				(xy 117.58163 63.372734) (xy 117.93377 63.372734) (xy 117.937729 63.376693) (xy 117.987846 63.371758)
+				(xy 118.012154 63.371758) (xy 118.208188 63.391066) (xy 118.232029 63.395808) (xy 118.42053 63.452989)
+				(xy 118.442988 63.462292) (xy 118.616712 63.555149) (xy 118.636924 63.568654) (xy 118.789193 63.693619)
+				(xy 118.806381 63.710807) (xy 118.931346 63.863076) (xy 118.944851 63.883288) (xy 119.03157 64.045529)
+				(xy 119.704365 63.372734) (xy 120.056505 63.372734) (xy 120.640572 63.956801) (xy 120.646003 63.919029)
+				(xy 120.647566 63.910358) (xy 120.647945 63.908613) (xy 120.650144 63.899993) (xy 120.655645 63.88126)
+				(xy 120.658439 63.872864) (xy 120.659063 63.871191) (xy 120.662451 63.863013) (xy 120.730349 63.714338)
+				(xy 120.734321 63.706404) (xy 120.735177 63.704837) (xy 120.739682 63.697245) (xy 120.750236 63.680822)
+				(xy 120.755303 63.673527) (xy 120.756374 63.672097) (xy 120.761911 63.665227) (xy 120.868945 63.541703)
+				(xy 120.874942 63.535259) (xy 120.876204 63.533996) (xy 120.882718 63.527929) (xy 120.897473 63.515144)
+				(xy 120.904342 63.509608) (xy 120.905772 63.508537) (xy 120.913066 63.503471) (xy 121.050564 63.415107)
+				(xy 121.058157 63.410601) (xy 121.059724 63.409745) (xy 121.067655 63.405774) (xy 121.085414 63.397663)
+				(xy 121.093618 63.394266) (xy 121.095292 63.393642) (xy 121.103669 63.390855) (xy 121.260494 63.344808)
+				(xy 121.269043 63.342625) (xy 121.270788 63.342245) (xy 121.279527 63.340667) (xy 121.29885 63.337889)
+				(xy 121.307676 63.336941) (xy 121.309457 63.336814) (xy 121.318277 63.3365) (xy 121.481723 63.3365)
+				(xy 121.490543 63.336814) (xy 121.492324 63.336941) (xy 121.50115 63.337889) (xy 121.520473 63.340667)
+				(xy 121.529212 63.342245) (xy 121.530957 63.342625) (xy 121.539506 63.344808) (xy 121.696331 63.390855)
+				(xy 121.704708 63.393642) (xy 121.706382 63.394266) (xy 121.714586 63.397663) (xy 121.732345 63.405774)
+				(xy 121.740276 63.409745) (xy 121.741843 63.410601) (xy 121.749436 63.415107) (xy 121.77092 63.428914)
+				(xy 121.8271 63.372733) (xy 122.179239 63.372733) (xy 123.064537 64.258032) (xy 123.949836 63.372734)
+				(xy 124.301974 63.372734) (xy 125.187272 64.258032) (xy 126.07257 63.372734) (xy 126.424708 63.372734)
+				(xy 127.310006 64.258032) (xy 128.195305 63.372734) (xy 128.547443 63.372734) (xy 129.432741 64.258032)
+				(xy 130.318039 63.372734) (xy 129.432741 62.487436) (xy 128.547443 63.372734) (xy 128.195305 63.372734)
+				(xy 127.879203 63.056632) (xy 128.231341 63.056632) (xy 128.371374 63.196665) (xy 128.495299 63.072739)
+				(xy 128.492324 63.073059) (xy 128.490543 63.073186) (xy 128.481723 63.0735) (xy 128.318277 63.0735)
+				(xy 128.309457 63.073186) (xy 128.307676 63.073059) (xy 128.29885 63.072111) (xy 128.279527 63.069333)
+				(xy 128.270788 63.067755) (xy 128.269043 63.067375) (xy 128.260494 63.065192) (xy 128.231341 63.056632)
+				(xy 127.879203 63.056632) (xy 127.310006 62.487435) (xy 126.424708 63.372734) (xy 126.07257 63.372734)
+				(xy 125.187272 62.487436) (xy 124.301974 63.372734) (xy 123.949836 63.372734) (xy 123.686284 63.109182)
+				(xy 123.516073 63.122579) (xy 123.51127 63.122863) (xy 123.510289 63.122902) (xy 123.505363 63.123)
+				(xy 123.494637 63.123) (xy 123.489711 63.122902) (xy 123.48873 63.122863) (xy 123.483927 63.122579)
+				(xy 123.222939 63.102038) (xy 123.218128 63.101565) (xy 123.217154 63.10145) (xy 123.212307 63.10078)
+				(xy 123.201713 63.099103) (xy 123.196879 63.098239) (xy 123.195915 63.098047) (xy 123.191189 63.09701)
+				(xy 122.936627 63.035896) (xy 122.931892 63.03466) (xy 122.930946 63.034393) (xy 122.926294 63.032981)
+				(xy 122.916093 63.029665) (xy 122.911554 63.028091) (xy 122.910634 63.027752) (xy 122.906054 63.025961)
+				(xy 122.664187 62.925777) (xy 122.659749 62.923836) (xy 122.658857 62.923425) (xy 122.654449 62.921288)
+				(xy 122.644892 62.916418) (xy 122.640543 62.914091) (xy 122.639687 62.913611) (xy 122.638851 62.913121)
+				(xy 122.179239 63.372733) (xy 121.8271 63.372733) (xy 120.941803 62.487436) (xy 120.056505 63.372734)
+				(xy 119.704365 63.372734) (xy 119.704366 63.372733) (xy 118.819068 62.487435) (xy 117.93377 63.372734)
+				(xy 117.58163 63.372734) (xy 117.581631 63.372733) (xy 117.168283 62.959385) (xy 117.166564 62.973548)
+				(xy 117.15941 63.002572) (xy 117.102757 63.151955) (xy 117.088865 63.178424) (xy 116.998108 63.309909)
+				(xy 116.978285 63.332285) (xy 116.858698 63.438229) (xy 116.834097 63.455209) (xy 116.692632 63.529456)
+				(xy 116.664681 63.540057) (xy 116.509558 63.578291) (xy 116.479883 63.581894) (xy 116.320117 63.581894)
+				(xy 116.290442 63.578291) (xy 116.135319 63.540057) (xy 116.107368 63.529456) (xy 115.965903 63.455209)
+				(xy 115.941302 63.438229) (xy 115.899 63.400752) (xy 115.5 63.400752) (xy 115.5 62.238481) (xy 116.945287 62.238481)
+				(xy 116.978285 62.267715) (xy 116.998108 62.290091) (xy 117.088865 62.421576) (xy 117.102757 62.448045)
+				(xy 117.15941 62.597428) (xy 117.159719 62.598683) (xy 117.757701 63.196665) (xy 118.642999 62.311367)
+				(xy 118.995138 62.311367) (xy 119.880436 63.196665) (xy 120.765734 62.311367) (xy 120.765733 62.311366)
+				(xy 121.117871 62.311366) (xy 122.003169 63.196664) (xy 122.420457 62.779376) (xy 122.412329 62.774396)
+				(xy 122.408161 62.771727) (xy 122.407345 62.771181) (xy 122.403419 62.768442) (xy 122.394742 62.762138)
+				(xy 122.390905 62.759235) (xy 122.390133 62.758627) (xy 122.386322 62.755501) (xy 122.187251 62.585478)
+				(xy 122.183645 62.582275) (xy 122.182924 62.581609) (xy 122.179381 62.578203) (xy 122.171797 62.570619)
+				(xy 122.168391 62.567076) (xy 122.167725 62.566355) (xy 122.164522 62.562749) (xy 121.994499 62.363678)
+				(xy 121.991373 62.359867) (xy 121.990765 62.359095) (xy 121.987862 62.355258) (xy 121.981558 62.346581)
+				(xy 121.978819 62.342655) (xy 121.978273 62.341839) (xy 121.975603 62.33767) (xy 121.838817 62.114454)
+				(xy 121.836389 62.110313) (xy 121.835909 62.109457) (xy 121.833582 62.105108) (xy 121.828712 62.095551)
+				(xy 121.826575 62.091143) (xy 121.826164 62.090251) (xy 121.824223 62.085813) (xy 121.724039 61.843946)
+				(xy 121.722248 61.839366) (xy 121.721909 61.838446) (xy 121.720335 61.833907) (xy 121.717019 61.823706)
+				(xy 121.715607 61.819054) (xy 121.71534 61.818108) (xy 121.714104 61.813373) (xy 121.695085 61.734152)
+				(xy 121.117871 62.311366) (xy 120.765733 62.311366) (xy 119.880436 61.426069) (xy 118.995138 62.311367)
+				(xy 118.642999 62.311367) (xy 117.7577 61.426068) (xy 116.945287 62.238481) (xy 115.5 62.238481)
+				(xy 115.5 61.162035) (xy 115.899 61.162035) (xy 115.899 61.337964) (xy 116.606683 62.045647) (xy 116.664682 62.059943)
+				(xy 116.692632 62.070544) (xy 116.737525 62.094105) (xy 117.581631 61.249999) (xy 117.933769 61.249999)
+				(xy 118.819068 62.135298) (xy 119.704366 61.249999) (xy 120.056504 61.249999) (xy 120.941802 62.135297)
+				(xy 121.640816 61.436283) (xy 121.627421 61.266073) (xy 121.627137 61.26127) (xy 121.627098 61.260289)
+				(xy 121.627 61.255363) (xy 121.627 61.25) (xy 121.9 61.25) (xy 121.919699 61.500298) (xy 121.978308 61.744424)
+				(xy 122.074387 61.976381) (xy 122.074389 61.976384) (xy 122.205571 62.190453) (xy 122.205574 62.190458)
+				(xy 122.24659 62.238481) (xy 122.368629 62.381371) (xy 122.440151 62.442456) (xy 122.559541 62.544425)
+				(xy 122.559543 62.544426) (xy 122.559544 62.544427) (xy 122.626533 62.585478) (xy 122.773615 62.67561)
+				(xy 122.773618 62.675612) (xy 123.005575 62.771691) (xy 123.232386 62.826143) (xy 123.249705 62.830301)
+				(xy 123.5 62.85) (xy 123.750295 62.830301) (xy 123.962413 62.779376) (xy 123.994424 62.771691) (xy 123.994425 62.77169)
+				(xy 123.994427 62.77169) (xy 124.090502 62.731894) (xy 124.226381 62.675612) (xy 124.226382 62.675611)
+				(xy 124.226385 62.67561) (xy 124.440456 62.544427) (xy 124.631371 62.381371) (xy 124.69116 62.311367)
+				(xy 125.363341 62.311367) (xy 126.248639 63.196665) (xy 127.133937 62.311367) (xy 127.486076 62.311367)
+				(xy 127.642698 62.467989) (xy 127.622742 62.32919) (xy 127.621794 62.320363) (xy 127.621667 62.318582)
+				(xy 127.621353 62.309762) (xy 127.621353 62.3) (xy 127.894353 62.3) (xy 127.914834 62.442456) (xy 127.961404 62.544428)
+				(xy 127.974623 62.573373) (xy 128.068872 62.682143) (xy 128.189947 62.759953) (xy 128.18995 62.759954)
+				(xy 128.189949 62.759954) (xy 128.328036 62.800499) (xy 128.328038 62.8005) (xy 128.328039 62.8005)
+				(xy 128.471962 62.8005) (xy 128.471962 62.800499) (xy 128.581142 62.768442) (xy 128.61005 62.759954)
+				(xy 128.61005 62.759953) (xy 128.610053 62.759953) (xy 128.731128 62.682143) (xy 128.825377 62.573373)
+				(xy 128.885165 62.442457) (xy 128.891108 62.401123) (xy 129.166915 62.401123) (xy 129.256672 62.311367)
+				(xy 129.60881 62.311367) (xy 130.494108 63.196665) (xy 131.101 62.589773) (xy 131.101 62.03296)
+				(xy 130.494108 61.426068) (xy 129.60881 62.311367) (xy 129.256672 62.311367) (xy 129.170732 62.225427)
+				(xy 129.177258 62.27081) (xy 129.178206 62.279637) (xy 129.178333 62.281418) (xy 129.178647 62.290238)
+				(xy 129.178647 62.309762) (xy 129.178333 62.318582) (xy 129.178206 62.320363) (xy 129.177258 62.32919)
+				(xy 129.166915 62.401123) (xy 128.891108 62.401123) (xy 128.905647 62.3) (xy 128.885165 62.157543)
+				(xy 128.825377 62.026627) (xy 128.731128 61.917857) (xy 128.610053 61.840047) (xy 128.610051 61.840046)
+				(xy 128.610049 61.840045) (xy 128.61005 61.840045) (xy 128.471963 61.7995) (xy 128.471961 61.7995)
+				(xy 128.328039 61.7995) (xy 128.328036 61.7995) (xy 128.189949 61.840045) (xy 128.068873 61.917856)
+				(xy 127.974623 62.026626) (xy 127.974622 62.026628) (xy 127.914834 62.157543) (xy 127.894353 62.3)
+				(xy 127.621353 62.3) (xy 127.621353 62.290238) (xy 127.621667 62.281418) (xy 127.621794 62.279637)
+				(xy 127.622742 62.27081) (xy 127.638881 62.158561) (xy 127.486076 62.311367) (xy 127.133937 62.311367)
+				(xy 126.248639 61.426068) (xy 125.363341 62.311367) (xy 124.69116 62.311367) (xy 124.794427 62.190456)
+				(xy 124.92561 61.976385) (xy 124.949854 61.917856) (xy 124.988852 61.823706) (xy 125.02169 61.744427)
+				(xy 125.080301 61.500295) (xy 125.1 61.25) (xy 125.080301 60.999705) (xy 125.034732 60.809897) (xy 125.021691 60.755575)
+				(xy 124.925612 60.523618) (xy 124.92561 60.523615) (xy 124.843026 60.388851) (xy 125.163121 60.388851)
+				(xy 125.163611 60.389687) (xy 125.164091 60.390543) (xy 125.166418 60.394892) (xy 125.171288 60.404449)
+				(xy 125.173425 60.408857) (xy 125.173836 60.409749) (xy 125.175777 60.414187) (xy 125.275961 60.656054)
+				(xy 125.277752 60.660634) (xy 125.278091 60.661554) (xy 125.279665 60.666093) (xy 125.282981 60.676294)
+				(xy 125.284393 60.680946) (xy 125.28466 60.681892) (xy 125.285896 60.686627) (xy 125.34701 60.941189)
+				(xy 125.348047 60.945915) (xy 125.348239 60.946879) (xy 125.349103 60.951713) (xy 125.35078 60.962307)
+				(xy 125.35145 60.967154) (xy 125.351565 60.968128) (xy 125.352038 60.972939) (xy 125.372579 61.233927)
+				(xy 125.372863 61.23873) (xy 125.372902 61.239711) (xy 125.373 61.244637) (xy 125.373 61.255363)
+				(xy 125.372902 61.260289) (xy 125.372863 61.26127) (xy 125.372579 61.266073) (xy 125.352038 61.527061)
+				(xy 125.351565 61.531872) (xy 125.35145 61.532846) (xy 125.35078 61.537693) (xy 125.349103 61.548287)
+				(xy 125.348239 61.553121) (xy 125.348047 61.554085) (xy 125.34701 61.558811) (xy 125.285896 61.813373)
+				(xy 125.28466 61.818108) (xy 125.284393 61.819054) (xy 125.282981 61.823706) (xy 125.279665 61.833907)
+				(xy 125.278091 61.838446) (xy 125.277752 61.839366) (xy 125.275961 61.843946) (xy 125.175777 62.085813)
+				(xy 125.173836 62.090251) (xy 125.173425 62.091143) (xy 125.171288 62.095551) (xy 125.166418 62.105108)
+				(xy 125.164091 62.109457) (xy 125.163611 62.110313) (xy 125.163121 62.111147) (xy 125.187272 62.135298)
+				(xy 126.07257 61.249999) (xy 126.424708 61.249999) (xy 127.310006 62.135298) (xy 127.911231 61.534073)
+				(xy 128.263369 61.534073) (xy 128.269043 61.532625) (xy 128.270788 61.532245) (xy 128.279527 61.530667)
+				(xy 128.29885 61.527889) (xy 128.307676 61.526941) (xy 128.309457 61.526814) (xy 128.318277 61.5265)
+				(xy 128.471805 61.5265) (xy 128.371374 61.426069) (xy 128.263369 61.534073) (xy 127.911231 61.534073)
+				(xy 128.195305 61.249999) (xy 128.547442 61.249999) (xy 129.432741 62.135298) (xy 130.318039 61.249999)
+				(xy 129.432741 60.364701) (xy 128.547442 61.249999) (xy 128.195305 61.249999) (xy 127.310006 60.364701)
+				(xy 126.424708 61.249999) (xy 126.07257 61.249999) (xy 125.187271 60.3647) (xy 125.163121 60.388851)
+				(xy 124.843026 60.388851) (xy 124.794427 60.309544) (xy 124.794426 60.309543) (xy 124.794425 60.309541)
+				(xy 124.735743 60.240833) (xy 124.691159 60.188632) (xy 125.363341 60.188632) (xy 126.248639 61.07393)
+				(xy 127.133937 60.188632) (xy 127.486076 60.188632) (xy 128.371374 61.07393) (xy 129.256672 60.188632)
+				(xy 129.60881 60.188632) (xy 130.494108 61.07393) (xy 131.101 60.467038) (xy 131.101 59.910225)
+				(xy 130.494108 59.303333) (xy 129.60881 60.188632) (xy 129.256672 60.188632) (xy 129.04154 59.9735)
+				(xy 129.393678 59.9735) (xy 129.432741 60.012563) (xy 129.471804 59.9735) (xy 129.393678 59.9735)
+				(xy 129.04154 59.9735) (xy 128.371374 59.303334) (xy 127.486076 60.188632) (xy 127.133937 60.188632)
+				(xy 126.248639 59.303333) (xy 125.363341 60.188632) (xy 124.691159 60.188632) (xy 124.631371 60.118629)
+				(xy 124.470286 59.98105) (xy 124.440458 59.955574) (xy 124.440453 59.955571) (xy 124.226384 59.824389)
+				(xy 124.226381 59.824387) (xy 123.994424 59.728308) (xy 123.750298 59.669699) (xy 123.61349 59.658932)
+				(xy 123.526794 59.652108) (xy 123.461506 59.627225) (xy 123.420036 59.570993) (xy 123.415549 59.501268)
+				(xy 123.42373 59.476979) (xy 123.433836 59.454851) (xy 123.485165 59.342457) (xy 123.505647 59.2)
+				(xy 123.485165 59.057543) (xy 123.425377 58.926627) (xy 123.38758 58.883007) (xy 123.705578 58.883007)
+				(xy 123.737549 58.953013) (xy 123.740937 58.961191) (xy 123.741561 58.962864) (xy 123.744355 58.97126)
+				(xy 123.749856 58.989993) (xy 123.752055 58.998613) (xy 123.752434 59.000358) (xy 123.753997 59.009029)
+				(xy 123.777258 59.17081) (xy 123.778206 59.179637) (xy 123.778333 59.181418) (xy 123.778647 59.190238)
+				(xy 123.778647 59.209762) (xy 123.778333 59.218582) (xy 123.778206 59.220363) (xy 123.777258 59.22919)
+				(xy 123.765393 59.311706) (xy 123.949834 59.127265) (xy 124.301974 59.127265) (xy 125.187272 60.012563)
+				(xy 126.07257 59.127265) (xy 126.424708 59.127265) (xy 127.310006 60.012563) (xy 128.195305 59.127265)
+				(xy 128.547443 59.127265) (xy 128.621353 59.201175) (xy 128.621353 59.2) (xy 128.894353 59.2) (xy 128.914834 59.342456)
+				(xy 128.918426 59.350321) (xy 128.974623 59.473373) (xy 129.068872 59.582143) (xy 129.189947 59.659953)
+				(xy 129.18995 59.659954) (xy 129.189949 59.659954) (xy 129.328036 59.700499) (xy 129.328038 59.7005)
+				(xy 129.328039 59.7005) (xy 129.471962 59.7005) (xy 129.471962 59.700499) (xy 129.610053 59.659953)
+				(xy 129.731128 59.582143) (xy 129.825377 59.473373) (xy 129.885165 59.342457) (xy 129.905647 59.2)
+				(xy 129.885165 59.057543) (xy 129.832184 58.941531) (xy 130.132305 58.941531) (xy 130.137549 58.953013)
+				(xy 130.140937 58.961191) (xy 130.141561 58.962864) (xy 130.144355 58.97126) (xy 130.149856 58.989993)
+				(xy 130.152055 58.998613) (xy 130.152434 59.000358) (xy 130.153997 59.009029) (xy 130.177258 59.17081)
+				(xy 130.178206 59.179637) (xy 130.178333 59.181418) (xy 130.178647 59.190238) (xy 130.178647 59.209762)
+				(xy 130.178333 59.218582) (xy 130.178206 59.220363) (xy 130.177258 59.22919) (xy 130.170733 59.27457)
+				(xy 130.318039 59.127265) (xy 130.132305 58.941531) (xy 129.832184 58.941531) (xy 129.825377 58.926627)
+				(xy 129.731128 58.817857) (xy 129.610053 58.740047) (xy 129.610051 58.740046) (xy 129.610049 58.740045)
+				(xy 129.61005 58.740045) (xy 129.471963 58.6995) (xy 129.471961 58.6995) (xy 129.328039 58.6995)
+				(xy 129.328036 58.6995) (xy 129.189949 58.740045) (xy 129.068873 58.817856) (xy 128.974623 58.926626)
+				(xy 128.974622 58.926628) (xy 128.914834 59.057543) (xy 128.894353 59.2) (xy 128.621353 59.2) (xy 128.621353 59.190238)
+				(xy 128.621667 59.181418) (xy 128.621794 59.179637) (xy 128.622742 59.17081) (xy 128.642698 59.032009)
+				(xy 128.547443 59.127265) (xy 128.195305 59.127265) (xy 127.310006 58.241966) (xy 126.424708 59.127265)
+				(xy 126.07257 59.127265) (xy 125.187272 58.241967) (xy 124.301974 59.127265) (xy 123.949834 59.127265)
+				(xy 123.949835 59.127264) (xy 123.705578 58.883007) (xy 123.38758 58.883007) (xy 123.331128 58.817857)
+				(xy 123.210053 58.740047) (xy 123.210051 58.740046) (xy 123.210049 58.740045) (xy 123.21005 58.740045)
+				(xy 123.071963 58.6995) (xy 123.071961 58.6995) (xy 122.928039 58.6995) (xy 122.928036 58.6995)
+				(xy 122.789949 58.740045) (xy 122.668873 58.817856) (xy 122.574623 58.926626) (xy 122.574622 58.926628)
+				(xy 122.514834 59.057543) (xy 122.494353 59.2) (xy 122.514834 59.342456) (xy 122.518426 59.350321)
+				(xy 122.574623 59.473373) (xy 122.668872 59.582143) (xy 122.746746 59.63219) (xy 122.792501 59.684993)
+				(xy 122.802445 59.754152) (xy 122.77342 59.817707) (xy 122.744497 59.842232) (xy 122.559546 59.95557)
+				(xy 122.559541 59.955574) (xy 122.368629 60.118629) (xy 122.205574 60.309541) (xy 122.205571 60.309546)
+				(xy 122.074389 60.523615) (xy 122.074387 60.523618) (xy 121.978308 60.755575) (xy 121.919699 60.999701)
+				(xy 121.9 61.25) (xy 121.627 61.25) (xy 121.627 61.244637) (xy 121.627098 61.239711) (xy 121.627137 61.23873)
+				(xy 121.627421 61.233927) (xy 121.640816 61.063715) (xy 120.941802 60.364701) (xy 120.056504 61.249999)
+				(xy 119.704366 61.249999) (xy 118.819068 60.364701) (xy 117.933769 61.249999) (xy 117.581631 61.249999)
+				(xy 116.696333 60.364701) (xy 115.899 61.162035) (xy 115.5 61.162035) (xy 115.5 60.809897) (xy 115.899 60.809897)
+				(xy 116.520265 60.188632) (xy 116.872403 60.188632) (xy 117.757701 61.07393) (xy 118.642999 60.188632)
+				(xy 118.642998 60.188631) (xy 118.995137 60.188631) (xy 119.880436 61.07393) (xy 120.765734 60.188632)
+				(xy 121.117872 60.188632) (xy 121.695085 60.765845) (xy 121.714104 60.686627) (xy 121.71534 60.681892)
+				(xy 121.715607 60.680946) (xy 121.717019 60.676294) (xy 121.720335 60.666093) (xy 121.721909 60.661554)
+				(xy 121.722248 60.660634) (xy 121.724039 60.656054) (xy 121.824223 60.414187) (xy 121.826164 60.409749)
+				(xy 121.826575 60.408857) (xy 121.828712 60.404449) (xy 121.833582 60.394892) (xy 121.835909 60.390543)
+				(xy 121.836389 60.389687) (xy 121.838817 60.385546) (xy 121.975603 60.16233) (xy 121.978273 60.158161)
+				(xy 121.978819 60.157345) (xy 121.981558 60.153419) (xy 121.987862 60.144742) (xy 121.990765 60.140905)
+				(xy 121.991373 60.140133) (xy 121.994499 60.136322) (xy 122.164522 59.937251) (xy 122.167725 59.933645)
+				(xy 122.168391 59.932924) (xy 122.171797 59.929381) (xy 122.179381 59.921797) (xy 122.182924 59.918391)
+				(xy 122.183645 59.917725) (xy 122.187251 59.914522) (xy 122.386322 59.744499) (xy 122.390133 59.741373)
+				(xy 122.390905 59.740765) (xy 122.394742 59.737862) (xy 122.403419 59.731558) (xy 122.407345 59.728819)
+				(xy 122.408161 59.728273) (xy 122.412328 59.725604) (xy 122.420457 59.720621) (xy 122.00317 59.303334)
+				(xy 121.117872 60.188632) (xy 120.765734 60.188632) (xy 120.536391 59.959289) (xy 120.489507 59.973056)
+				(xy 120.480957 59.975239) (xy 120.479212 59.975619) (xy 120.470473 59.977197) (xy 120.45115 59.979975)
+				(xy 120.442324 59.980923) (xy 120.440543 59.98105) (xy 120.431723 59.981364) (xy 120.268277 59.981364)
+				(xy 120.259457 59.98105) (xy 120.257676 59.980923) (xy 120.24885 59.979975) (xy 120.229527 59.977197)
+				(xy 120.220788 59.975619) (xy 120.219043 59.975239) (xy 120.210494 59.973056) (xy 120.053669 59.927009)
+				(xy 120.045292 59.924222) (xy 120.043618 59.923598) (xy 120.035414 59.920201) (xy 120.017655 59.91209)
+				(xy 120.009724 59.908119) (xy 120.008157 59.907263) (xy 120.000564 59.902757) (xy 119.863066 59.814393)
+				(xy 119.855772 59.809327) (xy 119.854342 59.808256) (xy 119.847473 59.80272) (xy 119.832718 59.789935)
+				(xy 119.826204 59.783868) (xy 119.824942 59.782605) (xy 119.818945 59.776161) (xy 119.711911 59.652637)
+				(xy 119.706374 59.645767) (xy 119.705303 59.644337) (xy 119.700236 59.637042) (xy 119.689682 59.620619)
+				(xy 119.685177 59.613027) (xy 119.684321 59.61146) (xy 119.680349 59.603526) (xy 119.648964 59.534804)
+				(xy 118.995137 60.188631) (xy 118.642998 60.188631) (xy 117.757701 59.303334) (xy 116.872403 60.188632)
+				(xy 116.520265 60.188632) (xy 115.899 59.567367) (xy 115.899 60.809897) (xy 115.5 60.809897) (xy 115.5 59.039301)
+				(xy 115.899 59.039301) (xy 115.899 59.215229) (xy 116.696334 60.012563) (xy 117.581632 59.127265)
+				(xy 117.93377 59.127265) (xy 118.819068 60.012563) (xy 119.575486 59.256144) (xy 119.572742 59.237054)
+				(xy 119.571794 59.228227) (xy 119.571667 59.226446) (xy 119.571353 59.217626) (xy 119.571353 59.207864)
+				(xy 119.844353 59.207864) (xy 119.864834 59.35032) (xy 119.922678 59.476979) (xy 119.924623 59.481237)
+				(xy 120.018872 59.590007) (xy 120.139947 59.667817) (xy 120.13995 59.667818) (xy 120.139949 59.667818)
+				(xy 120.278036 59.708363) (xy 120.278038 59.708364) (xy 120.278039 59.708364) (xy 120.421962 59.708364)
+				(xy 120.421962 59.708363) (xy 120.529121 59.676899) (xy 120.56005 59.667818) (xy 120.56005 59.667817)
+				(xy 120.560053 59.667817) (xy 120.681128 59.590007) (xy 120.775377 59.481237) (xy 120.835165 59.350321)
+				(xy 120.855647 59.207864) (xy 120.835165 59.065407) (xy 120.775377 58.934491) (xy 120.681128 58.825721)
+				(xy 120.560053 58.747911) (xy 120.560051 58.74791) (xy 120.560049 58.747909) (xy 120.56005 58.747909)
+				(xy 120.421963 58.707364) (xy 120.421961 58.707364) (xy 120.278039 58.707364) (xy 120.278036 58.707364)
+				(xy 120.139949 58.747909) (xy 120.018873 58.82572) (xy 119.924623 58.93449) (xy 119.924622 58.934492)
+				(xy 119.864834 59.065407) (xy 119.844353 59.207864) (xy 119.571353 59.207864) (xy 119.571353 59.198102)
+				(xy 119.571667 59.189282) (xy 119.571794 59.187501) (xy 119.572742 59.178674) (xy 119.59575 59.018648)
+				(xy 118.819068 58.241966) (xy 117.93377 59.127265) (xy 117.581632 59.127265) (xy 116.696334 58.241967)
+				(xy 115.899 59.039301) (xy 115.5 59.039301) (xy 115.5 58.687163) (xy 115.899 58.687163) (xy 116.520265 58.065898)
+				(xy 116.872403 58.065898) (xy 117.757701 58.951196) (xy 118.642999 58.065898) (xy 118.995138 58.065898)
+				(xy 119.703388 58.774148) (xy 119.705303 58.771391) (xy 119.706374 58.769961) (xy 119.711911 58.763091)
+				(xy 119.818945 58.639567) (xy 119.824942 58.633123) (xy 119.826204 58.63186) (xy 119.832718 58.625793)
+				(xy 119.847473 58.613008) (xy 119.854342 58.607472) (xy 119.855772 58.606401) (xy 119.863066 58.601335)
+				(xy 120.000564 58.512971) (xy 120.008157 58.508465) (xy 120.009724 58.507609) (xy 120.017655 58.503638)
+				(xy 120.019177 58.502943) (xy 120.680825 58.502943) (xy 120.682345 58.503638) (xy 120.690276 58.507609)
+				(xy 120.691843 58.508465) (xy 120.699436 58.512971) (xy 120.836934 58.601335) (xy 120.844228 58.606401)
+				(xy 120.845658 58.607472) (xy 120.852527 58.613008) (xy 120.867282 58.625793) (xy 120.873796 58.63186)
+				(xy 120.875058 58.633123) (xy 120.881055 58.639567) (xy 120.988089 58.763091) (xy 120.993626 58.769961)
+				(xy 120.994697 58.771391) (xy 120.999764 58.778686) (xy 121.010318 58.795109) (xy 121.014823 58.802701)
+				(xy 121.015679 58.804268) (xy 121.019651 58.812202) (xy 121.087549 58.960877) (xy 121.090937 58.969055)
+				(xy 121.091561 58.970728) (xy 121.094355 58.979124) (xy 121.099856 58.997857) (xy 121.102055 59.006477)
+				(xy 121.102434 59.008222) (xy 121.103997 59.016893) (xy 121.127258 59.178674) (xy 121.128206 59.187501)
+				(xy 121.128333 59.189282) (xy 121.128647 59.198102) (xy 121.128647 59.217626) (xy 121.128333 59.226446)
+				(xy 121.128206 59.228227) (xy 121.127258 59.237054) (xy 121.103997 59.398835) (xy 121.102434 59.407506)
+				(xy 121.102055 59.409251) (xy 121.099856 59.417871) (xy 121.094355 59.436604) (xy 121.091561 59.445)
+				(xy 121.090937 59.446673) (xy 121.087549 59.454851) (xy 121.019651 59.603526) (xy 121.015679 59.61146)
+				(xy 121.014823 59.613027) (xy 121.010318 59.620619) (xy 120.999764 59.637042) (xy 120.994697 59.644337)
+				(xy 120.993626 59.645767) (xy 120.988089 59.652637) (xy 120.881055 59.776161) (xy 120.875058 59.782605)
+				(xy 120.873796 59.783868) (xy 120.867282 59.789935) (xy 120.852527 59.80272) (xy 120.845658 59.808256)
+				(xy 120.844228 59.809327) (xy 120.836934 59.814393) (xy 120.780135 59.850895) (xy 120.941803 60.012563)
+				(xy 121.827101 59.127265) (xy 121.8271 59.127264) (xy 122.179239 59.127264) (xy 122.222747 59.170773)
+				(xy 122.237359 59.069144) (xy 122.179239 59.127264) (xy 121.8271 59.127264) (xy 120.941802 58.241966)
+				(xy 120.680825 58.502943) (xy 120.019177 58.502943) (xy 120.035414 58.495527) (xy 120.043618 58.49213)
+				(xy 120.045292 58.491506) (xy 120.053669 58.488719) (xy 120.210494 58.442672) (xy 120.219043 58.440489)
+				(xy 120.220788 58.440109) (xy 120.229527 58.438531) (xy 120.24885 58.435753) (xy 120.257676 58.434805)
+				(xy 120.259457 58.434678) (xy 120.268277 58.434364) (xy 120.397267 58.434364) (xy 120.765732 58.065898)
+				(xy 121.117872 58.065898) (xy 122.00317 58.951196) (xy 122.522887 58.431479) (xy 122.875024 58.431479)
+				(xy 122.879527 58.430667) (xy 122.89885 58.427889) (xy 122.907676 58.426941) (xy 122.909457 58.426814)
+				(xy 122.918277 58.4265) (xy 123.081723 58.4265) (xy 123.090543 58.426814) (xy 123.092324 58.426941)
+				(xy 123.10115 58.427889) (xy 123.120473 58.430667) (xy 123.129212 58.432245) (xy 123.130957 58.432625)
+				(xy 123.139506 58.434808) (xy 123.296331 58.480855) (xy 123.304708 58.483642) (xy 123.306382 58.484266)
+				(xy 123.307158 58.484587) (xy 123.064537 58.241966) (xy 122.875024 58.431479) (xy 122.522887 58.431479)
+				(xy 122.888468 58.065898) (xy 123.240607 58.065898) (xy 124.125905 58.951196) (xy 125.011203 58.065898)
+				(xy 125.363341 58.065898) (xy 126.248639 58.951196) (xy 127.133937 58.065898) (xy 127.486076 58.065898)
+				(xy 128.371374 58.951196) (xy 128.879202 58.443368) (xy 129.231339 58.443368) (xy 129.260494 58.434808)
+				(xy 129.269043 58.432625) (xy 129.270788 58.432245) (xy 129.279527 58.430667) (xy 129.29885 58.427889)
+				(xy 129.307676 58.426941) (xy 129.309457 58.426814) (xy 129.318277 58.4265) (xy 129.481723 58.4265)
+				(xy 129.490543 58.426814) (xy 129.492324 58.426941) (xy 129.50115 58.427889) (xy 129.520473 58.430667)
+				(xy 129.529212 58.432245) (xy 129.530957 58.432625) (xy 129.539506 58.434808) (xy 129.661361 58.470587)
+				(xy 129.432741 58.241967) (xy 129.231339 58.443368) (xy 128.879202 58.443368) (xy 129.256672 58.065898)
+				(xy 129.60881 58.065898) (xy 130.494108 58.951196) (xy 131.101 58.344304) (xy 131.101 57.787491)
+				(xy 130.494108 57.180599) (xy 129.60881 58.065898) (xy 129.256672 58.065898) (xy 128.371374 57.1806)
+				(xy 127.486076 58.065898) (xy 127.133937 58.065898) (xy 126.248639 57.180599) (xy 125.363341 58.065898)
+				(xy 125.011203 58.065898) (xy 124.125905 57.1806) (xy 123.240607 58.065898) (xy 122.888468 58.065898)
+				(xy 122.00317 57.1806) (xy 121.117872 58.065898) (xy 120.765732 58.065898) (xy 120.765733 58.065897)
+				(xy 119.880436 57.1806) (xy 118.995138 58.065898) (xy 118.642999 58.065898) (xy 117.757701 57.1806)
+				(xy 116.872403 58.065898) (xy 116.520265 58.065898) (xy 115.899 57.444633) (xy 115.899 58.687163)
+				(xy 115.5 58.687163) (xy 115.5 58.004066) (xy 115.500265 57.995956) (xy 115.507221 57.889828) (xy 115.520857 57.681774)
+				(xy 115.522972 57.66572) (xy 115.583599 57.360923) (xy 115.587797 57.345258) (xy 115.657361 57.140329)
+				(xy 115.946835 57.140329) (xy 116.696334 57.889828) (xy 117.581632 57.00453) (xy 117.933769 57.00453)
+				(xy 118.819068 57.889828) (xy 119.704366 57.00453) (xy 120.056504 57.00453) (xy 120.941803 57.889828)
+				(xy 121.827101 57.00453) (xy 122.179239 57.00453) (xy 123.064537 57.889828) (xy 123.949836 57.00453)
+				(xy 124.301973 57.00453) (xy 125.187272 57.889828) (xy 126.07257 57.00453) (xy 126.424708 57.00453)
+				(xy 127.310006 57.889828) (xy 128.195305 57.00453) (xy 128.547442 57.00453) (xy 129.432741 57.889828)
+				(xy 130.318039 57.00453) (xy 129.432741 56.119232) (xy 128.547442 57.00453) (xy 128.195305 57.00453)
+				(xy 127.310006 56.119231) (xy 126.424708 57.00453) (xy 126.07257 57.00453) (xy 125.187272 56.119232)
+				(xy 124.301973 57.00453) (xy 123.949836 57.00453) (xy 123.064537 56.119231) (xy 122.179239 57.00453)
+				(xy 121.827101 57.00453) (xy 120.941803 56.119232) (xy 120.056504 57.00453) (xy 119.704366 57.00453)
+				(xy 118.819068 56.119231) (xy 117.933769 57.00453) (xy 117.581632 57.00453) (xy 116.744227 56.167125)
+				(xy 116.644644 56.233664) (xy 116.425686 56.425686) (xy 116.233664 56.644644) (xy 116.071867 56.886792)
+				(xy 115.946835 57.140329) (xy 115.657361 57.140329) (xy 115.687691 57.050979) (xy 115.693889 57.036014)
+				(xy 115.831344 56.757283) (xy 115.839447 56.743248) (xy 116.012109 56.484841) (xy 116.021966 56.471995)
+				(xy 116.226879 56.238337) (xy 116.238337 56.226879) (xy 116.458146 56.034111) (xy 116.963351 56.034111)
+				(xy 117.757701 56.828461) (xy 118.642999 55.943163) (xy 118.995138 55.943163) (xy 119.880436 56.828461)
+				(xy 120.765734 55.943163) (xy 121.117872 55.943163) (xy 122.00317 56.828461) (xy 122.888468 55.943163)
+				(xy 123.240607 55.943163) (xy 124.125905 56.828461) (xy 125.011203 55.943163) (xy 125.363341 55.943163)
+				(xy 126.248639 56.828461) (xy 127.133936 55.943163) (xy 127.486076 55.943163) (xy 128.371374 56.828461)
+				(xy 129.256672 55.943163) (xy 129.60881 55.943163) (xy 130.494107 56.82846) (xy 130.725025 56.597542)
+				(xy 130.574311 56.425686) (xy 130.355353 56.233664) (xy 130.113205 56.071867) (xy 129.852006 55.943057)
+				(xy 129.722217 55.899) (xy 129.652973 55.899) (xy 129.60881 55.943163) (xy 129.256672 55.943163)
+				(xy 129.212509 55.899) (xy 127.530239 55.899) (xy 127.486076 55.943163) (xy 127.133936 55.943163)
+				(xy 127.133937 55.943162) (xy 127.089775 55.899) (xy 125.407504 55.899) (xy 125.363341 55.943163)
+				(xy 125.011203 55.943163) (xy 124.96704 55.899) (xy 123.28477 55.899) (xy 123.240607 55.943163)
+				(xy 122.888468 55.943163) (xy 122.844305 55.899) (xy 121.162035 55.899) (xy 121.117872 55.943163)
+				(xy 120.765734 55.943163) (xy 120.721571 55.899) (xy 119.039301 55.899) (xy 118.995138 55.943163)
+				(xy 118.642999 55.943163) (xy 118.598836 55.899) (xy 117.277782 55.899) (xy 117.147991 55.943057)
+				(xy 116.963351 56.034111) (xy 116.458146 56.034111) (xy 116.471995 56.021966) (xy 116.484841 56.012109)
+				(xy 116.743248 55.839447) (xy 116.757283 55.831344) (xy 117.036014 55.693889) (xy 117.050979 55.687691)
+				(xy 117.258206 55.617346) (xy 117.345258 55.587797) (xy 117.360925 55.583599) (xy 117.66572 55.522972)
+				(xy 117.681774 55.520857) (xy 117.995957 55.500265) (xy 118.004067 55.5) (xy 128.995933 55.5)
 			)
 		)
 	)
@@ -44268,7 +44340,7 @@
 				(xy 109.295825 89.421332) (xy 109.294469 89.414514) (xy 109.294234 89.413131) (xy 109.293262 89.406244)
 				(xy 109.287586 89.355874) (xy 109.239577 89.307865) (xy 108.354279 90.193163) (xy 108.002141 90.193163)
 				(xy 107.116843 89.307865) (xy 106.231545 90.193163) (xy 105.879406 90.193163) (xy 104.994108 89.307864)
-				(xy 104.10881 90.193163) (xy 103 90.193163) (xy 103 88.895234) (xy 103.399 88.895234) (xy 103.399 89.483352)
+				(xy 104.10881 90.193163) (xy 103 90.193163) (xy 103 88.797529) (xy 103.399 88.797529) (xy 103.399 89.483352)
 				(xy 103.932741 90.017093) (xy 104.818039 89.131795) (xy 105.170177 89.131795) (xy 106.055475 90.017093)
 				(xy 106.940774 89.131795) (xy 107.292911 89.131795) (xy 108.17821 90.017093) (xy 108.995306 89.199997)
 				(xy 109.544751 89.199997) (xy 109.544751 89.200002) (xy 109.563685 89.368056) (xy 109.619545 89.527694)
@@ -44353,266 +44425,260 @@
 				(xy 109.829109 88.609523) (xy 109.709523 88.729109) (xy 109.709518 88.729115) (xy 109.619547 88.872302)
 				(xy 109.619545 88.872305) (xy 109.563685 89.031943) (xy 109.544751 89.199997) (xy 108.995306 89.199997)
 				(xy 109.063508 89.131795) (xy 108.17821 88.246497) (xy 107.292911 89.131795) (xy 106.940774 89.131795)
-				(xy 106.055475 88.246496) (xy 105.170177 89.131795) (xy 104.818039 89.131795) (xy 103.932741 88.246497)
-				(xy 103.87945 88.299787) (xy 103.835605 88.425091) (xy 103.83315 88.431527) (xy 103.832614 88.432823)
-				(xy 103.829747 88.439234) (xy 103.823095 88.453047) (xy 103.819891 88.459247) (xy 103.819212 88.460475)
-				(xy 103.81569 88.466445) (xy 103.717555 88.622625) (xy 103.713679 88.628425) (xy 103.712867 88.629569)
-				(xy 103.708694 88.635112) (xy 103.699135 88.647098) (xy 103.694683 88.652372) (xy 103.693749 88.653418)
-				(xy 103.688937 88.65851) (xy 103.55851 88.788937) (xy 103.553418 88.793749) (xy 103.552372 88.794683)
-				(xy 103.547098 88.799135) (xy 103.535112 88.808694) (xy 103.529569 88.812867) (xy 103.528425 88.813679)
-				(xy 103.522625 88.817555) (xy 103.399 88.895234) (xy 103 88.895234) (xy 103 88.84811) (xy 103.019685 88.781071)
-				(xy 103.072489 88.735316) (xy 103.083029 88.731074) (xy 103.22769 88.680456) (xy 103.227692 88.680455)
-				(xy 103.227697 88.680452) (xy 103.370884 88.590481) (xy 103.370885 88.59048) (xy 103.37089 88.590477)
-				(xy 103.490477 88.47089) (xy 103.531093 88.406251) (xy 103.580452 88.327697) (xy 103.580454 88.327694)
-				(xy 103.580454 88.327692) (xy 103.580456 88.32769) (xy 103.636313 88.168059) (xy 103.636313 88.168058)
-				(xy 103.636314 88.168056) (xy 103.647314 88.070428) (xy 104.10881 88.070428) (xy 104.994108 88.955726)
-				(xy 105.879406 88.070428) (xy 106.231545 88.070428) (xy 107.116843 88.955726) (xy 108.002141 88.070428)
-				(xy 108.354279 88.070428) (xy 109.239577 88.955726) (xy 109.334253 88.861049) (xy 109.364396 88.774909)
-				(xy 109.36685 88.768473) (xy 109.367386 88.767177) (xy 109.370253 88.760766) (xy 109.376905 88.746953)
-				(xy 109.380109 88.740753) (xy 109.380788 88.739525) (xy 109.38431 88.733555) (xy 109.482445 88.577375)
-				(xy 109.486321 88.571575) (xy 109.487133 88.570431) (xy 109.491306 88.564888) (xy 109.500865 88.552902)
-				(xy 109.505317 88.547628) (xy 109.506251 88.546582) (xy 109.511063 88.54149) (xy 109.64149 88.411063)
-				(xy 109.646582 88.406251) (xy 109.647628 88.405317) (xy 109.652902 88.400865) (xy 109.664888 88.391306)
-				(xy 109.670431 88.387133) (xy 109.671575 88.386321) (xy 109.677375 88.382445) (xy 109.833555 88.28431)
-				(xy 109.839525 88.280788) (xy 109.840753 88.280109) (xy 109.846953 88.276905) (xy 109.860766 88.270253)
-				(xy 109.867177 88.267386) (xy 109.868473 88.26685) (xy 109.874908 88.264396) (xy 109.961047 88.234253)
-				(xy 109.972589 88.222712) (xy 109.972027 88.216047) (xy 109.971948 88.214646) (xy 109.971751 88.207665)
-				(xy 109.971751 88.192335) (xy 109.971948 88.185354) (xy 109.972027 88.183953) (xy 109.97261 88.177051)
-				(xy 109.993262 87.993758) (xy 109.994234 87.986869) (xy 109.994469 87.985486) (xy 109.995825 87.978668)
-				(xy 109.999236 87.963722) (xy 110.000966 87.957013) (xy 110.001354 87.955665) (xy 110.00347 87.949022)
-				(xy 109.239577 87.185129) (xy 108.354279 88.070428) (xy 108.002141 88.070428) (xy 107.116843 87.18513)
-				(xy 106.231545 88.070428) (xy 105.879406 88.070428) (xy 104.994108 87.185129) (xy 104.10881 88.070428)
-				(xy 103.647314 88.070428) (xy 103.655249 88.000002) (xy 103.655249 87.999997) (xy 103.636314 87.831943)
-				(xy 103.580454 87.672305) (xy 103.580452 87.672302) (xy 103.490481 87.529115) (xy 103.490476 87.529109)
-				(xy 103.37089 87.409523) (xy 103.370884 87.409518) (xy 103.227697 87.319547) (xy 103.227694 87.319545)
-				(xy 103.115982 87.280456) (xy 103.083044 87.26893) (xy 103.026269 87.228209) (xy 103.000522 87.163256)
-				(xy 103 87.151889) (xy 103 86.657504) (xy 103.399 86.657504) (xy 103.399 87.104765) (xy 103.522625 87.182445)
-				(xy 103.528425 87.186321) (xy 103.529569 87.187133) (xy 103.535112 87.191306) (xy 103.547098 87.200865)
-				(xy 103.552372 87.205317) (xy 103.553418 87.206251) (xy 103.55851 87.211063) (xy 103.688937 87.34149)
-				(xy 103.693749 87.346582) (xy 103.694683 87.347628) (xy 103.699135 87.352902) (xy 103.708694 87.364888)
-				(xy 103.712867 87.370431) (xy 103.713679 87.371575) (xy 103.717555 87.377375) (xy 103.81569 87.533555)
-				(xy 103.819212 87.539525) (xy 103.819891 87.540753) (xy 103.823095 87.546953) (xy 103.829747 87.560766)
-				(xy 103.832614 87.567177) (xy 103.83315 87.568473) (xy 103.835604 87.574909) (xy 103.896525 87.749009)
-				(xy 103.898646 87.755665) (xy 103.899034 87.757013) (xy 103.900764 87.763722) (xy 103.904175 87.778668)
-				(xy 103.905531 87.785486) (xy 103.905766 87.786869) (xy 103.906738 87.793758) (xy 103.91621 87.877828)
-				(xy 103.932741 87.894359) (xy 104.818039 87.009061) (xy 105.170177 87.009061) (xy 106.055475 87.894359)
-				(xy 106.940774 87.009061) (xy 107.292912 87.009061) (xy 108.17821 87.894359) (xy 109.063508 87.009061)
-				(xy 109.415647 87.009061) (xy 110.105854 87.699268) (xy 110.182445 87.577375) (xy 110.186321 87.571575)
-				(xy 110.187133 87.570431) (xy 110.191306 87.564888) (xy 110.200865 87.552902) (xy 110.205317 87.547628)
-				(xy 110.206251 87.546582) (xy 110.211063 87.54149) (xy 110.34149 87.411063) (xy 110.346582 87.406251)
-				(xy 110.347628 87.405317) (xy 110.352902 87.400865) (xy 110.364888 87.391306) (xy 110.370431 87.387133)
-				(xy 110.371575 87.386321) (xy 110.377375 87.382445) (xy 110.533555 87.28431) (xy 110.539525 87.280788)
-				(xy 110.540753 87.280109) (xy 110.546953 87.276905) (xy 110.560766 87.270253) (xy 110.567177 87.267386)
-				(xy 110.568473 87.26685) (xy 110.574909 87.264396) (xy 110.749009 87.203475) (xy 110.755665 87.201354)
-				(xy 110.757013 87.200966) (xy 110.763722 87.199236) (xy 110.778668 87.195825) (xy 110.785486 87.194469)
-				(xy 110.786869 87.194234) (xy 110.793758 87.193262) (xy 110.977051 87.17261) (xy 110.983953 87.172027)
-				(xy 110.985354 87.171948) (xy 110.992335 87.171751) (xy 111.007665 87.171751) (xy 111.014646 87.171948)
-				(xy 111.016047 87.172027) (xy 111.022713 87.172589) (xy 111.186241 87.009061) (xy 111.538381 87.009061)
-				(xy 112.423679 87.894359) (xy 113.308977 87.009061) (xy 113.661116 87.009061) (xy 114.546413 87.894358)
-				(xy 114.928351 87.51242) (xy 114.777375 87.417555) (xy 114.771575 87.413679) (xy 114.770431 87.412867)
-				(xy 114.764888 87.408694) (xy 114.752902 87.399135) (xy 114.747628 87.394683) (xy 114.746582 87.393749)
-				(xy 114.74149 87.388937) (xy 114.611063 87.25851) (xy 114.606251 87.253418) (xy 114.605317 87.252372)
-				(xy 114.600865 87.247098) (xy 114.591306 87.235112) (xy 114.587133 87.229569) (xy 114.586321 87.228425)
-				(xy 114.582445 87.222625) (xy 114.48431 87.066445) (xy 114.480788 87.060475) (xy 114.480109 87.059247)
-				(xy 114.476905 87.053047) (xy 114.470253 87.039234) (xy 114.467386 87.032823) (xy 114.46685 87.031527)
-				(xy 114.464396 87.025091) (xy 114.403475 86.850991) (xy 114.401354 86.844335) (xy 114.400966 86.842987)
-				(xy 114.399236 86.836278) (xy 114.395825 86.821332) (xy 114.394469 86.814514) (xy 114.394234 86.813131)
-				(xy 114.393262 86.806242) (xy 114.37261 86.622949) (xy 114.372027 86.616047) (xy 114.371948 86.614646)
-				(xy 114.371751 86.607665) (xy 114.371751 86.599997) (xy 114.644751 86.599997) (xy 114.644751 86.600002)
-				(xy 114.663685 86.768056) (xy 114.719545 86.927694) (xy 114.719547 86.927697) (xy 114.809518 87.070884)
-				(xy 114.809523 87.07089) (xy 114.929109 87.190476) (xy 114.929115 87.190481) (xy 115.072302 87.280452)
-				(xy 115.072305 87.280454) (xy 115.072309 87.280455) (xy 115.07231 87.280456) (xy 115.144913 87.30586)
-				(xy 115.231943 87.336314) (xy 115.399997 87.355249) (xy 115.4 87.355249) (xy 115.400003 87.355249)
-				(xy 115.567923 87.336329) (xy 116.111118 87.336329) (xy 116.669148 87.894359) (xy 116.87388 87.689627)
-				(xy 117.226018 87.689627) (xy 117.377051 87.67261) (xy 117.383953 87.672027) (xy 117.385354 87.671948)
-				(xy 117.392335 87.671751) (xy 117.407665 87.671751) (xy 117.414646 87.671948) (xy 117.416047 87.672027)
-				(xy 117.422949 87.67261) (xy 117.606242 87.693262) (xy 117.613131 87.694234) (xy 117.614514 87.694469)
-				(xy 117.621332 87.695825) (xy 117.636278 87.699236) (xy 117.642987 87.700966) (xy 117.644335 87.701354)
-				(xy 117.650991 87.703475) (xy 117.825091 87.764396) (xy 117.831527 87.76685) (xy 117.832823 87.767386)
-				(xy 117.839234 87.770253) (xy 117.853047 87.776905) (xy 117.859247 87.780109) (xy 117.860475 87.780788)
-				(xy 117.866445 87.78431) (xy 118.022625 87.882445) (xy 118.028425 87.886321) (xy 118.029569 87.887133)
-				(xy 118.035112 87.891306) (xy 118.047098 87.900865) (xy 118.052372 87.905317) (xy 118.053418 87.906251)
-				(xy 118.05851 87.911063) (xy 118.188937 88.04149) (xy 118.193749 88.046582) (xy 118.194683 88.047628)
-				(xy 118.199135 88.052902) (xy 118.208694 88.064888) (xy 118.212867 88.070431) (xy 118.213679 88.071575)
-				(xy 118.217555 88.077375) (xy 118.31569 88.233555) (xy 118.319212 88.239525) (xy 118.319891 88.240753)
-				(xy 118.323095 88.246953) (xy 118.329747 88.260766) (xy 118.332614 88.267177) (xy 118.33315 88.268473)
-				(xy 118.335604 88.274909) (xy 118.355233 88.331007) (xy 118.615812 88.070428) (xy 118.967952 88.070428)
-				(xy 119.85325 88.955726) (xy 120.738548 88.070428) (xy 121.090687 88.070428) (xy 121.801 88.780741)
-				(xy 121.801 87.360115) (xy 121.090687 88.070428) (xy 120.738548 88.070428) (xy 119.85325 87.18513)
-				(xy 118.967952 88.070428) (xy 118.615812 88.070428) (xy 118.615813 88.070427) (xy 117.730516 87.18513)
-				(xy 117.226018 87.689627) (xy 116.87388 87.689627) (xy 117.554446 87.009061) (xy 117.554445 87.00906)
-				(xy 117.906584 87.00906) (xy 118.791883 87.894359) (xy 119.677181 87.009061) (xy 119.67718 87.00906)
-				(xy 120.029319 87.00906) (xy 120.914617 87.894359) (xy 121.799916 87.009061) (xy 121.135455 86.3446)
-				(xy 121.042372 86.367543) (xy 121.035103 86.369105) (xy 121.033617 86.369378) (xy 121.026156 86.370515)
-				(xy 121.009765 86.372505) (xy 121.002289 86.373184) (xy 121.000781 86.373275) (xy 120.993312 86.3735)
-				(xy 120.806688 86.3735) (xy 120.799219 86.373275) (xy 120.797711 86.373184) (xy 120.790235 86.372505)
-				(xy 120.773844 86.370515) (xy 120.766383 86.369378) (xy 120.764897 86.369105) (xy 120.757629 86.367543)
-				(xy 120.687998 86.350381) (xy 120.029319 87.00906) (xy 119.67718 87.00906) (xy 119.078036 86.409916)
-				(xy 118.922949 86.42739) (xy 118.916047 86.427973) (xy 118.914646 86.428052) (xy 118.907665 86.428249)
-				(xy 118.892335 86.428249) (xy 118.885354 86.428052) (xy 118.883953 86.427973) (xy 118.877051 86.42739)
-				(xy 118.693758 86.406738) (xy 118.686869 86.405766) (xy 118.685486 86.405531) (xy 118.678668 86.404175)
-				(xy 118.663722 86.400764) (xy 118.657013 86.399034) (xy 118.655665 86.398646) (xy 118.649009 86.396525)
-				(xy 118.552789 86.362855) (xy 117.906584 87.00906) (xy 117.554445 87.00906) (xy 116.669147 86.123762)
-				(xy 116.4058 86.38711) (xy 116.406738 86.393758) (xy 116.42739 86.577051) (xy 116.427973 86.583953)
-				(xy 116.428052 86.585354) (xy 116.428249 86.592335) (xy 116.428249 86.607665) (xy 116.428052 86.614646)
-				(xy 116.427973 86.616047) (xy 116.42739 86.622949) (xy 116.406738 86.806242) (xy 116.405766 86.813131)
-				(xy 116.405531 86.814514) (xy 116.404175 86.821332) (xy 116.400764 86.836278) (xy 116.399034 86.842987)
-				(xy 116.398646 86.844335) (xy 116.396525 86.850991) (xy 116.335604 87.025091) (xy 116.33315 87.031527)
-				(xy 116.332614 87.032823) (xy 116.329747 87.039234) (xy 116.323095 87.053047) (xy 116.319891 87.059247)
-				(xy 116.319212 87.060475) (xy 116.31569 87.066445) (xy 116.217555 87.222625) (xy 116.213679 87.228425)
-				(xy 116.212867 87.229569) (xy 116.208694 87.235112) (xy 116.199135 87.247098) (xy 116.194683 87.252372)
-				(xy 116.193749 87.253418) (xy 116.188937 87.25851) (xy 116.111118 87.336329) (xy 115.567923 87.336329)
-				(xy 115.568056 87.336314) (xy 115.568059 87.336313) (xy 115.72769 87.280456) (xy 115.727692 87.280454)
-				(xy 115.727694 87.280454) (xy 115.727697 87.280452) (xy 115.870884 87.190481) (xy 115.870885 87.19048)
-				(xy 115.87089 87.190477) (xy 115.990477 87.07089) (xy 116.080452 86.927697) (xy 116.080454 86.927694)
-				(xy 116.080454 86.927692) (xy 116.080456 86.92769) (xy 116.136313 86.768059) (xy 116.136313 86.768058)
-				(xy 116.136314 86.768056) (xy 116.155249 86.600002) (xy 116.155249 86.599997) (xy 116.136314 86.431943)
-				(xy 116.080454 86.272305) (xy 116.080452 86.272302) (xy 115.990481 86.129115) (xy 115.990476 86.129109)
-				(xy 115.87089 86.009523) (xy 115.870884 86.009518) (xy 115.727697 85.919547) (xy 115.727694 85.919545)
-				(xy 115.568056 85.863685) (xy 115.400003 85.844751) (xy 115.399997 85.844751) (xy 115.231943 85.863685)
-				(xy 115.072305 85.919545) (xy 115.072302 85.919547) (xy 114.929115 86.009518) (xy 114.929109 86.009523)
-				(xy 114.809523 86.129109) (xy 114.809518 86.129115) (xy 114.719547 86.272302) (xy 114.719545 86.272305)
-				(xy 114.663685 86.431943) (xy 114.644751 86.599997) (xy 114.371751 86.599997) (xy 114.371751 86.592335)
-				(xy 114.371948 86.585354) (xy 114.372027 86.583953) (xy 114.37261 86.577051) (xy 114.393262 86.393758)
-				(xy 114.394234 86.386869) (xy 114.394469 86.385486) (xy 114.395825 86.378668) (xy 114.399236 86.363722)
-				(xy 114.400966 86.357013) (xy 114.401354 86.355665) (xy 114.403475 86.349009) (xy 114.447778 86.222398)
-				(xy 113.661116 87.009061) (xy 113.308977 87.009061) (xy 112.423679 86.123763) (xy 111.538381 87.009061)
-				(xy 111.186241 87.009061) (xy 111.186242 87.00906) (xy 110.300945 86.123763) (xy 109.415647 87.009061)
-				(xy 109.063508 87.009061) (xy 108.17821 86.123763) (xy 107.292912 87.009061) (xy 106.940774 87.009061)
-				(xy 106.055475 86.123762) (xy 105.170177 87.009061) (xy 104.818039 87.009061) (xy 103.932741 86.123763)
-				(xy 103.399 86.657504) (xy 103 86.657504) (xy 103 85.947693) (xy 104.108809 85.947693) (xy 104.994108 86.832992)
-				(xy 105.879406 85.947693) (xy 106.231544 85.947693) (xy 107.116843 86.832992) (xy 108.002141 85.947693)
-				(xy 108.354278 85.947693) (xy 109.239577 86.832992) (xy 110.124875 85.947693) (xy 110.477013 85.947693)
-				(xy 111.362312 86.832992) (xy 112.24761 85.947694) (xy 112.247609 85.947693) (xy 112.599748 85.947693)
-				(xy 113.485046 86.832992) (xy 114.370345 85.947693) (xy 113.485046 85.062395) (xy 112.599748 85.947693)
-				(xy 112.247609 85.947693) (xy 111.873416 85.5735) (xy 111.818277 85.5735) (xy 111.809457 85.573186)
-				(xy 111.807676 85.573059) (xy 111.79885 85.572111) (xy 111.779527 85.569333) (xy 111.770788 85.567755)
-				(xy 111.769043 85.567375) (xy 111.760494 85.565192) (xy 111.623095 85.524849) (xy 112.176903 85.524849)
-				(xy 112.423678 85.771624) (xy 113.308977 84.886326) (xy 113.661115 84.886326) (xy 114.546414 85.771624)
-				(xy 114.67026 85.647778) (xy 115.022397 85.647778) (xy 115.149009 85.603475) (xy 115.155665 85.601354)
-				(xy 115.157013 85.600966) (xy 115.163722 85.599236) (xy 115.178668 85.595825) (xy 115.185486 85.594469)
-				(xy 115.186869 85.594234) (xy 115.193758 85.593262) (xy 115.377051 85.57261) (xy 115.383953 85.572027)
-				(xy 115.385354 85.571948) (xy 115.392335 85.571751) (xy 115.407665 85.571751) (xy 115.414646 85.571948)
-				(xy 115.416047 85.572027) (xy 115.422949 85.57261) (xy 115.606242 85.593262) (xy 115.613131 85.594234)
-				(xy 115.614514 85.594469) (xy 115.621332 85.595825) (xy 115.636278 85.599236) (xy 115.642987 85.600966)
-				(xy 115.644335 85.601354) (xy 115.650991 85.603475) (xy 115.825091 85.664396) (xy 115.831527 85.66685)
-				(xy 115.832823 85.667386) (xy 115.839234 85.670253) (xy 115.853047 85.676905) (xy 115.859247 85.680109)
-				(xy 115.860475 85.680788) (xy 115.866445 85.68431) (xy 116.022625 85.782445) (xy 116.028425 85.786321)
-				(xy 116.029569 85.787133) (xy 116.035112 85.791306) (xy 116.047098 85.800865) (xy 116.052372 85.805317)
-				(xy 116.053418 85.806251) (xy 116.05851 85.811063) (xy 116.188937 85.94149) (xy 116.193749 85.946582)
-				(xy 116.194683 85.947628) (xy 116.199135 85.952902) (xy 116.208694 85.964888) (xy 116.212867 85.970431)
-				(xy 116.213679 85.971575) (xy 116.217555 85.977375) (xy 116.31242 86.128351) (xy 116.493078 85.947693)
-				(xy 116.845217 85.947693) (xy 117.730515 86.832991) (xy 118.319489 86.244017) (xy 118.277375 86.217555)
-				(xy 118.271575 86.213679) (xy 118.270431 86.212867) (xy 118.264888 86.208694) (xy 118.252902 86.199135)
-				(xy 118.247628 86.194683) (xy 118.246582 86.193749) (xy 118.24149 86.188937) (xy 118.111063 86.05851)
-				(xy 118.106251 86.053418) (xy 118.105317 86.052372) (xy 118.100865 86.047098) (xy 118.091306 86.035112)
-				(xy 118.087133 86.029569) (xy 118.086321 86.028425) (xy 118.082445 86.022625) (xy 117.98431 85.866445)
-				(xy 117.980788 85.860475) (xy 117.980109 85.859247) (xy 117.976905 85.853047) (xy 117.970253 85.839234)
-				(xy 117.967386 85.832823) (xy 117.96685 85.831527) (xy 117.964396 85.825091) (xy 117.903475 85.650991)
-				(xy 117.901354 85.644335) (xy 117.900966 85.642987) (xy 117.899236 85.636278) (xy 117.895825 85.621332)
-				(xy 117.894469 85.614514) (xy 117.894234 85.613131) (xy 117.893262 85.606242) (xy 117.87261 85.422949)
-				(xy 117.872027 85.416047) (xy 117.871948 85.414646) (xy 117.871751 85.407665) (xy 117.871751 85.399997)
-				(xy 118.144751 85.399997) (xy 118.144751 85.400002) (xy 118.163685 85.568056) (xy 118.219545 85.727694)
-				(xy 118.219547 85.727697) (xy 118.309518 85.870884) (xy 118.309523 85.87089) (xy 118.429109 85.990476)
-				(xy 118.429115 85.990481) (xy 118.572302 86.080452) (xy 118.572305 86.080454) (xy 118.572309 86.080455)
-				(xy 118.57231 86.080456) (xy 118.629593 86.1005) (xy 118.731943 86.136314) (xy 118.899997 86.155249)
-				(xy 118.9 86.155249) (xy 118.900003 86.155249) (xy 119.068056 86.136314) (xy 119.068059 86.136313)
-				(xy 119.22769 86.080456) (xy 119.334028 86.013638) (xy 119.401263 85.994638) (xy 119.46597 86.013638)
-				(xy 119.500146 86.035112) (xy 119.572306 86.080454) (xy 119.572307 86.080454) (xy 119.57231 86.080456)
-				(xy 119.67873 86.117694) (xy 119.731943 86.136314) (xy 119.899997 86.155249) (xy 119.9 86.155249)
-				(xy 119.900003 86.155249) (xy 120.068056 86.136314) (xy 120.068059 86.136313) (xy 120.22769 86.080456)
-				(xy 120.37089 85.990477) (xy 120.370889 85.990477) (xy 120.376787 85.986772) (xy 120.37842 85.989372)
-				(xy 120.430454 85.968069) (xy 120.499162 85.980757) (xy 120.500828 85.981616) (xy 120.625593 86.047098)
-				(xy 120.649775 86.05979) (xy 120.814944 86.1005) (xy 120.985056 86.1005) (xy 121.150225 86.05979)
-				(xy 121.229692 86.018081) (xy 121.300849 85.980736) (xy 121.30085 85.980734) (xy 121.300852 85.980734)
-				(xy 121.428183 85.867929) (xy 121.524818 85.72793) (xy 121.58514 85.568872) (xy 121.605645 85.4)
-				(xy 121.58514 85.231128) (xy 121.5844 85.229178) (xy 121.524817 85.072068) (xy 121.454978 84.97089)
-				(xy 121.428183 84.932071) (xy 121.310369 84.827697) (xy 121.300849 84.819263) (xy 121.150226 84.74021)
-				(xy 120.985056 84.6995) (xy 120.814944 84.6995) (xy 120.649774 84.740209) (xy 120.500826 84.818384)
-				(xy 120.432318 84.832109) (xy 120.378238 84.810916) (xy 120.376786 84.813227) (xy 120.227697 84.719547)
-				(xy 120.227694 84.719545) (xy 120.068056 84.663685) (xy 119.900003 84.644751) (xy 119.899997 84.644751)
-				(xy 119.731943 84.663685) (xy 119.572307 84.719545) (xy 119.465972 84.786361) (xy 119.398736 84.805361)
-				(xy 119.334028 84.786361) (xy 119.227692 84.719545) (xy 119.227691 84.719544) (xy 119.22769 84.719544)
-				(xy 119.18937 84.706135) (xy 119.068056 84.663685) (xy 118.900003 84.644751) (xy 118.899997 84.644751)
-				(xy 118.731943 84.663685) (xy 118.572305 84.719545) (xy 118.572302 84.719547) (xy 118.429115 84.809518)
-				(xy 118.429109 84.809523) (xy 118.309523 84.929109) (xy 118.309518 84.929115) (xy 118.219547 85.072302)
-				(xy 118.219545 85.072305) (xy 118.163685 85.231943) (xy 118.144751 85.399997) (xy 117.871751 85.399997)
-				(xy 117.871751 85.392335) (xy 117.871948 85.385354) (xy 117.872027 85.383953) (xy 117.87261 85.377051)
-				(xy 117.890083 85.221963) (xy 117.730515 85.062395) (xy 116.845217 85.947693) (xy 116.493078 85.947693)
-				(xy 115.607781 85.062395) (xy 115.022397 85.647778) (xy 114.67026 85.647778) (xy 115.431712 84.886326)
-				(xy 115.783849 84.886326) (xy 116.669148 85.771624) (xy 117.554446 84.886326) (xy 117.906585 84.886326)
-				(xy 117.973754 84.953495) (xy 117.976905 84.946953) (xy 117.980109 84.940753) (xy 117.980788 84.939525)
-				(xy 117.98431 84.933555) (xy 118.082445 84.777375) (xy 118.086321 84.771575) (xy 118.087133 84.770431)
-				(xy 118.091306 84.764888) (xy 118.100865 84.752902) (xy 118.105317 84.747628) (xy 118.106251 84.746582)
-				(xy 118.111063 84.74149) (xy 118.24149 84.611063) (xy 118.246582 84.606251) (xy 118.247628 84.605317)
-				(xy 118.252902 84.600865) (xy 118.264888 84.591306) (xy 118.270431 84.587133) (xy 118.271575 84.586321)
-				(xy 118.277375 84.582445) (xy 118.393706 84.509349) (xy 120.406295 84.509349) (xy 120.449941 84.536774)
-				(xy 120.530216 84.494644) (xy 120.536932 84.491373) (xy 120.538309 84.490753) (xy 120.545244 84.48788)
-				(xy 120.560684 84.482024) (xy 120.567742 84.479588) (xy 120.569185 84.479138) (xy 120.576427 84.477118)
-				(xy 120.757629 84.432457) (xy 120.764897 84.430895) (xy 120.766383 84.430622) (xy 120.773844 84.429485)
-				(xy 120.790235 84.427495) (xy 120.797711 84.426816) (xy 120.799219 84.426725) (xy 120.806688 84.4265)
-				(xy 120.993312 84.4265) (xy 121.000781 84.426725) (xy 121.002289 84.426816) (xy 121.009765 84.427495)
-				(xy 121.026156 84.429485) (xy 121.033617 84.430622) (xy 121.035103 84.430895) (xy 121.042371 84.432457)
-				(xy 121.223573 84.477118) (xy 121.230815 84.479138) (xy 121.232258 84.479588) (xy 121.239316 84.482024)
-				(xy 121.254756 84.48788) (xy 121.261691 84.490753) (xy 121.263068 84.491373) (xy 121.269785 84.494645)
-				(xy 121.435032 84.581374) (xy 121.441517 84.58503) (xy 121.44281 84.585811) (xy 121.449145 84.589905)
-				(xy 121.462734 84.599286) (xy 121.468695 84.603669) (xy 121.469885 84.6046) (xy 121.475705 84.609448)
-				(xy 121.615394 84.733202) (xy 121.620848 84.738336) (xy 121.621917 84.739405) (xy 121.627048 84.744855)
-				(xy 121.637998 84.757214) (xy 121.642849 84.763038) (xy 121.64378 84.764228) (xy 121.648166 84.770194)
-				(xy 121.754182 84.923782) (xy 121.757432 84.928808) (xy 121.799915 84.886325) (xy 120.914617 84.001027)
-				(xy 120.406295 84.509349) (xy 118.393706 84.509349) (xy 118.433555 84.48431) (xy 118.439525 84.480788)
-				(xy 118.440753 84.480109) (xy 118.446953 84.476905) (xy 118.460766 84.470253) (xy 118.467177 84.467386)
-				(xy 118.468473 84.46685) (xy 118.474909 84.464396) (xy 118.649009 84.403475) (xy 118.655665 84.401354)
-				(xy 118.657013 84.400966) (xy 118.663722 84.399236) (xy 118.678668 84.395825) (xy 118.685486 84.394469)
-				(xy 118.686869 84.394234) (xy 118.693758 84.393262) (xy 118.877051 84.37261) (xy 118.883953 84.372027)
-				(xy 118.885354 84.371948) (xy 118.892335 84.371751) (xy 118.907665 84.371751) (xy 118.914646 84.371948)
-				(xy 118.916047 84.372027) (xy 118.922949 84.37261) (xy 119.106242 84.393262) (xy 119.113131 84.394234)
-				(xy 119.114514 84.394469) (xy 119.121332 84.395825) (xy 119.136278 84.399236) (xy 119.142987 84.400966)
-				(xy 119.144335 84.401354) (xy 119.150991 84.403475) (xy 119.217658 84.426803) (xy 118.791883 84.001028)
-				(xy 117.906585 84.886326) (xy 117.554446 84.886326) (xy 116.669148 84.001027) (xy 115.783849 84.886326)
-				(xy 115.431712 84.886326) (xy 114.546414 84.001028) (xy 113.661115 84.886326) (xy 113.308977 84.886326)
-				(xy 112.423678 84.001027) (xy 112.292149 84.132557) (xy 112.386934 84.193471) (xy 112.394228 84.198537)
-				(xy 112.395658 84.199608) (xy 112.402527 84.205144) (xy 112.417282 84.217929) (xy 112.423796 84.223996)
-				(xy 112.425058 84.225259) (xy 112.431055 84.231703) (xy 112.538089 84.355227) (xy 112.543626 84.362097)
-				(xy 112.544697 84.363527) (xy 112.549764 84.370822) (xy 112.560318 84.387245) (xy 112.564823 84.394837)
-				(xy 112.565679 84.396404) (xy 112.569651 84.404338) (xy 112.637549 84.553013) (xy 112.640937 84.561191)
-				(xy 112.641561 84.562864) (xy 112.644355 84.57126) (xy 112.649856 84.589993) (xy 112.652055 84.598613)
-				(xy 112.652434 84.600358) (xy 112.653997 84.609029) (xy 112.677258 84.77081) (xy 112.678206 84.779637)
-				(xy 112.678333 84.781418) (xy 112.678647 84.790238) (xy 112.678647 84.809762) (xy 112.678333 84.818582)
-				(xy 112.678206 84.820363) (xy 112.677258 84.82919) (xy 112.653997 84.990971) (xy 112.652434 84.999642)
-				(xy 112.652055 85.001387) (xy 112.649856 85.010007) (xy 112.644355 85.02874) (xy 112.641561 85.037136)
-				(xy 112.640937 85.038809) (xy 112.637549 85.046987) (xy 112.569651 85.195662) (xy 112.565679 85.203596)
-				(xy 112.564823 85.205163) (xy 112.560318 85.212755) (xy 112.549764 85.229178) (xy 112.544697 85.236473)
-				(xy 112.543626 85.237903) (xy 112.538089 85.244773) (xy 112.431055 85.368297) (xy 112.425058 85.374741)
-				(xy 112.423796 85.376004) (xy 112.417282 85.382071) (xy 112.402527 85.394856) (xy 112.395658 85.400392)
-				(xy 112.394228 85.401463) (xy 112.386934 85.406529) (xy 112.249436 85.494893) (xy 112.241843 85.499399)
-				(xy 112.240276 85.500255) (xy 112.232345 85.504226) (xy 112.214586 85.512337) (xy 112.206382 85.515734)
-				(xy 112.204708 85.516358) (xy 112.196331 85.519145) (xy 112.176903 85.524849) (xy 111.623095 85.524849)
-				(xy 111.603669 85.519145) (xy 111.595292 85.516358) (xy 111.593618 85.515734) (xy 111.585414 85.512337)
-				(xy 111.567655 85.504226) (xy 111.559724 85.500255) (xy 111.558157 85.499399) (xy 111.550564 85.494893)
-				(xy 111.413066 85.406529) (xy 111.405772 85.401463) (xy 111.404342 85.400392) (xy 111.397473 85.394856)
-				(xy 111.382718 85.382071) (xy 111.376204 85.376004) (xy 111.374942 85.374741) (xy 111.368945 85.368297)
-				(xy 111.261911 85.244773) (xy 111.256374 85.237903) (xy 111.255303 85.236473) (xy 111.250236 85.229178)
-				(xy 111.239682 85.212755) (xy 111.235177 85.205163) (xy 111.234321 85.203596) (xy 111.230349 85.195662)
-				(xy 111.229939 85.194766) (xy 110.477013 85.947693) (xy 110.124875 85.947693) (xy 109.239577 85.062395)
-				(xy 108.354278 85.947693) (xy 108.002141 85.947693) (xy 107.116843 85.062395) (xy 106.231544 85.947693)
-				(xy 105.879406 85.947693) (xy 104.994108 85.062395) (xy 104.108809 85.947693) (xy 103 85.947693)
-				(xy 103 84.534769) (xy 103.399 84.534769) (xy 103.399 85.237883) (xy 103.932741 85.771624) (xy 104.818039 84.886326)
-				(xy 105.170177 84.886326) (xy 106.055475 85.771624) (xy 106.940774 84.886326) (xy 106.055475 84.001027)
-				(xy 105.170177 84.886326) (xy 104.818039 84.886326) (xy 103.932741 84.001028) (xy 103.399 84.534769)
-				(xy 103 84.534769) (xy 103 83.824958) (xy 104.108809 83.824958) (xy 104.994108 84.710257) (xy 105.879405 83.824959)
-				(xy 106.231545 83.824959) (xy 107.116842 84.710256) (xy 107.275803 84.551295) (xy 107.27261 84.522948)
-				(xy 107.272027 84.516047) (xy 107.271948 84.514646) (xy 107.271751 84.507665) (xy 107.271751 84.499997)
-				(xy 107.544751 84.499997) (xy 107.544751 84.500002) (xy 107.563685 84.668056) (xy 107.619545 84.827694)
-				(xy 107.619547 84.827697) (xy 107.709518 84.970884) (xy 107.709523 84.97089) (xy 107.829109 85.090476)
-				(xy 107.829115 85.090481) (xy 107.972302 85.180452) (xy 107.972305 85.180454) (xy 107.972309 85.180455)
-				(xy 107.97231 85.180456) (xy 108.038441 85.203596) (xy 108.131943 85.236314) (xy 108.299997 85.255249)
-				(xy 108.3 85.255249) (xy 108.300003 85.255249) (xy 108.468056 85.236314) (xy 108.480548 85.231943)
-				(xy 108.62769 85.180456) (xy 108.627692 85.180454) (xy 108.627694 85.180454) (xy 108.627697 85.180452)
-				(xy 108.770884 85.090481) (xy 108.770885 85.09048) (xy 108.77089 85.090477) (xy 108.890477 84.97089)
-				(xy 108.908343 84.942457) (xy 108.943613 84.886326) (xy 109.415646 84.886326) (xy 110.300944 85.771624)
-				(xy 111.137906 84.934661) (xy 111.122742 84.82919) (xy 111.121976 84.822059) (xy 111.099917 84.8)
-				(xy 111.394353 84.8) (xy 111.414834 84.942456) (xy 111.474622 85.073371) (xy 111.474623 85.073373)
+				(xy 106.055475 88.246496) (xy 105.170177 89.131795) (xy 104.818039 89.131795) (xy 103.93274 88.246496)
+				(xy 103.586055 88.593181) (xy 103.567556 88.622624) (xy 103.563679 88.628425) (xy 103.562867 88.629569)
+				(xy 103.558694 88.635112) (xy 103.549135 88.647098) (xy 103.544683 88.652372) (xy 103.543749 88.653418)
+				(xy 103.538937 88.65851) (xy 103.40851 88.788937) (xy 103.403418 88.793749) (xy 103.402372 88.794683)
+				(xy 103.399 88.797529) (xy 103 88.797529) (xy 103 88.795623) (xy 103.019685 88.728584) (xy 103.071512 88.683675)
+				(xy 103.071417 88.683477) (xy 103.072146 88.683125) (xy 103.072489 88.682829) (xy 103.074145 88.682162)
+				(xy 103.077685 88.680457) (xy 103.07769 88.680456) (xy 103.077694 88.680453) (xy 103.077697 88.680452)
+				(xy 103.220884 88.590481) (xy 103.220885 88.59048) (xy 103.22089 88.590477) (xy 103.340477 88.47089)
+				(xy 103.381093 88.406251) (xy 103.430452 88.327697) (xy 103.430454 88.327694) (xy 103.430454 88.327692)
+				(xy 103.430456 88.32769) (xy 103.486313 88.168059) (xy 103.486313 88.168058) (xy 103.486314 88.168056)
+				(xy 103.497314 88.070428) (xy 104.10881 88.070428) (xy 104.994108 88.955726) (xy 105.879406 88.070428)
+				(xy 106.231545 88.070428) (xy 107.116843 88.955726) (xy 108.002141 88.070428) (xy 108.354279 88.070428)
+				(xy 109.239577 88.955726) (xy 109.334253 88.861049) (xy 109.364396 88.774909) (xy 109.36685 88.768473)
+				(xy 109.367386 88.767177) (xy 109.370253 88.760766) (xy 109.376905 88.746953) (xy 109.380109 88.740753)
+				(xy 109.380788 88.739525) (xy 109.38431 88.733555) (xy 109.482445 88.577375) (xy 109.486321 88.571575)
+				(xy 109.487133 88.570431) (xy 109.491306 88.564888) (xy 109.500865 88.552902) (xy 109.505317 88.547628)
+				(xy 109.506251 88.546582) (xy 109.511063 88.54149) (xy 109.64149 88.411063) (xy 109.646582 88.406251)
+				(xy 109.647628 88.405317) (xy 109.652902 88.400865) (xy 109.664888 88.391306) (xy 109.670431 88.387133)
+				(xy 109.671575 88.386321) (xy 109.677375 88.382445) (xy 109.833555 88.28431) (xy 109.839525 88.280788)
+				(xy 109.840753 88.280109) (xy 109.846953 88.276905) (xy 109.860766 88.270253) (xy 109.867177 88.267386)
+				(xy 109.868473 88.26685) (xy 109.874908 88.264396) (xy 109.961047 88.234253) (xy 109.972589 88.222712)
+				(xy 109.972027 88.216047) (xy 109.971948 88.214646) (xy 109.971751 88.207665) (xy 109.971751 88.192335)
+				(xy 109.971948 88.185354) (xy 109.972027 88.183953) (xy 109.97261 88.177051) (xy 109.993262 87.993758)
+				(xy 109.994234 87.986869) (xy 109.994469 87.985486) (xy 109.995825 87.978668) (xy 109.999236 87.963722)
+				(xy 110.000966 87.957013) (xy 110.001354 87.955665) (xy 110.00347 87.949022) (xy 109.239577 87.185129)
+				(xy 108.354279 88.070428) (xy 108.002141 88.070428) (xy 107.116843 87.18513) (xy 106.231545 88.070428)
+				(xy 105.879406 88.070428) (xy 104.994108 87.185129) (xy 104.10881 88.070428) (xy 103.497314 88.070428)
+				(xy 103.505249 88.000002) (xy 103.505249 87.999997) (xy 103.486314 87.831943) (xy 103.430454 87.672305)
+				(xy 103.430452 87.672302) (xy 103.340481 87.529115) (xy 103.340476 87.529109) (xy 103.22089 87.409523)
+				(xy 103.220884 87.409518) (xy 103.077691 87.319543) (xy 103.071415 87.316521) (xy 103.072643 87.31397)
+				(xy 103.026225 87.280637) (xy 103.000515 87.21567) (xy 103 87.204375) (xy 103 86.657504) (xy 103.399 86.657504)
+				(xy 103.399 87.20247) (xy 103.402372 87.205317) (xy 103.403418 87.206251) (xy 103.40851 87.211063)
+				(xy 103.538937 87.34149) (xy 103.543749 87.346582) (xy 103.544683 87.347628) (xy 103.549135 87.352902)
+				(xy 103.558694 87.364888) (xy 103.562867 87.370431) (xy 103.563679 87.371575) (xy 103.567555 87.377375)
+				(xy 103.66569 87.533555) (xy 103.669212 87.539525) (xy 103.669891 87.540753) (xy 103.673095 87.546953)
+				(xy 103.679747 87.560766) (xy 103.682614 87.567177) (xy 103.68315 87.568473) (xy 103.685604 87.574909)
+				(xy 103.724527 87.686145) (xy 103.932741 87.894359) (xy 104.818039 87.009061) (xy 105.170177 87.009061)
+				(xy 106.055475 87.894359) (xy 106.940774 87.009061) (xy 107.292912 87.009061) (xy 108.17821 87.894359)
+				(xy 109.063508 87.009061) (xy 109.415647 87.009061) (xy 110.105854 87.699268) (xy 110.182445 87.577375)
+				(xy 110.186321 87.571575) (xy 110.187133 87.570431) (xy 110.191306 87.564888) (xy 110.200865 87.552902)
+				(xy 110.205317 87.547628) (xy 110.206251 87.546582) (xy 110.211063 87.54149) (xy 110.34149 87.411063)
+				(xy 110.346582 87.406251) (xy 110.347628 87.405317) (xy 110.352902 87.400865) (xy 110.364888 87.391306)
+				(xy 110.370431 87.387133) (xy 110.371575 87.386321) (xy 110.377375 87.382445) (xy 110.533555 87.28431)
+				(xy 110.539525 87.280788) (xy 110.540753 87.280109) (xy 110.546953 87.276905) (xy 110.560766 87.270253)
+				(xy 110.567177 87.267386) (xy 110.568473 87.26685) (xy 110.574909 87.264396) (xy 110.749009 87.203475)
+				(xy 110.755665 87.201354) (xy 110.757013 87.200966) (xy 110.763722 87.199236) (xy 110.778668 87.195825)
+				(xy 110.785486 87.194469) (xy 110.786869 87.194234) (xy 110.793758 87.193262) (xy 110.977051 87.17261)
+				(xy 110.983953 87.172027) (xy 110.985354 87.171948) (xy 110.992335 87.171751) (xy 111.007665 87.171751)
+				(xy 111.014646 87.171948) (xy 111.016047 87.172027) (xy 111.022713 87.172589) (xy 111.186241 87.009061)
+				(xy 111.538381 87.009061) (xy 112.423679 87.894359) (xy 113.308977 87.009061) (xy 113.661116 87.009061)
+				(xy 114.546413 87.894358) (xy 114.928351 87.51242) (xy 114.777375 87.417555) (xy 114.771575 87.413679)
+				(xy 114.770431 87.412867) (xy 114.764888 87.408694) (xy 114.752902 87.399135) (xy 114.747628 87.394683)
+				(xy 114.746582 87.393749) (xy 114.74149 87.388937) (xy 114.611063 87.25851) (xy 114.606251 87.253418)
+				(xy 114.605317 87.252372) (xy 114.600865 87.247098) (xy 114.591306 87.235112) (xy 114.587133 87.229569)
+				(xy 114.586321 87.228425) (xy 114.582445 87.222625) (xy 114.48431 87.066445) (xy 114.480788 87.060475)
+				(xy 114.480109 87.059247) (xy 114.476905 87.053047) (xy 114.470253 87.039234) (xy 114.467386 87.032823)
+				(xy 114.46685 87.031527) (xy 114.464396 87.025091) (xy 114.403475 86.850991) (xy 114.401354 86.844335)
+				(xy 114.400966 86.842987) (xy 114.399236 86.836278) (xy 114.395825 86.821332) (xy 114.394469 86.814514)
+				(xy 114.394234 86.813131) (xy 114.393262 86.806242) (xy 114.37261 86.622949) (xy 114.372027 86.616047)
+				(xy 114.371948 86.614646) (xy 114.371751 86.607665) (xy 114.371751 86.599997) (xy 114.644751 86.599997)
+				(xy 114.644751 86.600002) (xy 114.663685 86.768056) (xy 114.719545 86.927694) (xy 114.719547 86.927697)
+				(xy 114.809518 87.070884) (xy 114.809523 87.07089) (xy 114.929109 87.190476) (xy 114.929115 87.190481)
+				(xy 115.072302 87.280452) (xy 115.072305 87.280454) (xy 115.072309 87.280455) (xy 115.07231 87.280456)
+				(xy 115.105827 87.292184) (xy 115.231943 87.336314) (xy 115.399997 87.355249) (xy 115.4 87.355249)
+				(xy 115.400003 87.355249) (xy 115.567923 87.336329) (xy 116.111118 87.336329) (xy 116.669148 87.894359)
+				(xy 116.87388 87.689627) (xy 117.226018 87.689627) (xy 117.377051 87.67261) (xy 117.383953 87.672027)
+				(xy 117.385354 87.671948) (xy 117.392335 87.671751) (xy 117.407665 87.671751) (xy 117.414646 87.671948)
+				(xy 117.416047 87.672027) (xy 117.422949 87.67261) (xy 117.606242 87.693262) (xy 117.613131 87.694234)
+				(xy 117.614514 87.694469) (xy 117.621332 87.695825) (xy 117.636278 87.699236) (xy 117.642987 87.700966)
+				(xy 117.644335 87.701354) (xy 117.650991 87.703475) (xy 117.825091 87.764396) (xy 117.831527 87.76685)
+				(xy 117.832823 87.767386) (xy 117.839234 87.770253) (xy 117.853047 87.776905) (xy 117.859247 87.780109)
+				(xy 117.860475 87.780788) (xy 117.866445 87.78431) (xy 118.022625 87.882445) (xy 118.028425 87.886321)
+				(xy 118.029569 87.887133) (xy 118.035112 87.891306) (xy 118.047098 87.900865) (xy 118.052372 87.905317)
+				(xy 118.053418 87.906251) (xy 118.05851 87.911063) (xy 118.188937 88.04149) (xy 118.193749 88.046582)
+				(xy 118.194683 88.047628) (xy 118.199135 88.052902) (xy 118.208694 88.064888) (xy 118.212867 88.070431)
+				(xy 118.213679 88.071575) (xy 118.217555 88.077375) (xy 118.31569 88.233555) (xy 118.319212 88.239525)
+				(xy 118.319891 88.240753) (xy 118.323095 88.246953) (xy 118.329747 88.260766) (xy 118.332614 88.267177)
+				(xy 118.33315 88.268473) (xy 118.335604 88.274909) (xy 118.355233 88.331007) (xy 118.615812 88.070428)
+				(xy 118.967952 88.070428) (xy 119.85325 88.955726) (xy 120.738548 88.070428) (xy 121.090687 88.070428)
+				(xy 121.801 88.780741) (xy 121.801 87.360115) (xy 121.090687 88.070428) (xy 120.738548 88.070428)
+				(xy 119.85325 87.18513) (xy 118.967952 88.070428) (xy 118.615812 88.070428) (xy 118.615813 88.070427)
+				(xy 117.730516 87.18513) (xy 117.226018 87.689627) (xy 116.87388 87.689627) (xy 117.554446 87.009061)
+				(xy 117.554445 87.00906) (xy 117.906584 87.00906) (xy 118.791883 87.894359) (xy 119.677181 87.009061)
+				(xy 119.67718 87.00906) (xy 120.029319 87.00906) (xy 120.914617 87.894359) (xy 121.799916 87.009061)
+				(xy 121.135455 86.3446) (xy 121.042372 86.367543) (xy 121.035103 86.369105) (xy 121.033617 86.369378)
+				(xy 121.026156 86.370515) (xy 121.009765 86.372505) (xy 121.002289 86.373184) (xy 121.000781 86.373275)
+				(xy 120.993312 86.3735) (xy 120.806688 86.3735) (xy 120.799219 86.373275) (xy 120.797711 86.373184)
+				(xy 120.790235 86.372505) (xy 120.773844 86.370515) (xy 120.766383 86.369378) (xy 120.764897 86.369105)
+				(xy 120.757629 86.367543) (xy 120.687998 86.350381) (xy 120.029319 87.00906) (xy 119.67718 87.00906)
+				(xy 119.078036 86.409916) (xy 118.922949 86.42739) (xy 118.916047 86.427973) (xy 118.914646 86.428052)
+				(xy 118.907665 86.428249) (xy 118.892335 86.428249) (xy 118.885354 86.428052) (xy 118.883953 86.427973)
+				(xy 118.877051 86.42739) (xy 118.693758 86.406738) (xy 118.686869 86.405766) (xy 118.685486 86.405531)
+				(xy 118.678668 86.404175) (xy 118.663722 86.400764) (xy 118.657013 86.399034) (xy 118.655665 86.398646)
+				(xy 118.649009 86.396525) (xy 118.552789 86.362855) (xy 117.906584 87.00906) (xy 117.554445 87.00906)
+				(xy 116.669147 86.123762) (xy 116.4058 86.38711) (xy 116.406738 86.393758) (xy 116.42739 86.577051)
+				(xy 116.427973 86.583953) (xy 116.428052 86.585354) (xy 116.428249 86.592335) (xy 116.428249 86.607665)
+				(xy 116.428052 86.614646) (xy 116.427973 86.616047) (xy 116.42739 86.622949) (xy 116.406738 86.806242)
+				(xy 116.405766 86.813131) (xy 116.405531 86.814514) (xy 116.404175 86.821332) (xy 116.400764 86.836278)
+				(xy 116.399034 86.842987) (xy 116.398646 86.844335) (xy 116.396525 86.850991) (xy 116.335604 87.025091)
+				(xy 116.33315 87.031527) (xy 116.332614 87.032823) (xy 116.329747 87.039234) (xy 116.323095 87.053047)
+				(xy 116.319891 87.059247) (xy 116.319212 87.060475) (xy 116.31569 87.066445) (xy 116.217555 87.222625)
+				(xy 116.213679 87.228425) (xy 116.212867 87.229569) (xy 116.208694 87.235112) (xy 116.199135 87.247098)
+				(xy 116.194683 87.252372) (xy 116.193749 87.253418) (xy 116.188937 87.25851) (xy 116.111118 87.336329)
+				(xy 115.567923 87.336329) (xy 115.568056 87.336314) (xy 115.615985 87.319543) (xy 115.72769 87.280456)
+				(xy 115.727692 87.280454) (xy 115.727694 87.280454) (xy 115.727697 87.280452) (xy 115.870884 87.190481)
+				(xy 115.870885 87.19048) (xy 115.87089 87.190477) (xy 115.990477 87.07089) (xy 116.080452 86.927697)
+				(xy 116.080454 86.927694) (xy 116.080454 86.927692) (xy 116.080456 86.92769) (xy 116.136313 86.768059)
+				(xy 116.136313 86.768058) (xy 116.136314 86.768056) (xy 116.155249 86.600002) (xy 116.155249 86.599997)
+				(xy 116.136314 86.431943) (xy 116.080454 86.272305) (xy 116.080452 86.272302) (xy 115.990481 86.129115)
+				(xy 115.990476 86.129109) (xy 115.87089 86.009523) (xy 115.870884 86.009518) (xy 115.727697 85.919547)
+				(xy 115.727694 85.919545) (xy 115.568056 85.863685) (xy 115.400003 85.844751) (xy 115.399997 85.844751)
+				(xy 115.231943 85.863685) (xy 115.072305 85.919545) (xy 115.072302 85.919547) (xy 114.929115 86.009518)
+				(xy 114.929109 86.009523) (xy 114.809523 86.129109) (xy 114.809518 86.129115) (xy 114.719547 86.272302)
+				(xy 114.719545 86.272305) (xy 114.663685 86.431943) (xy 114.644751 86.599997) (xy 114.371751 86.599997)
+				(xy 114.371751 86.592335) (xy 114.371948 86.585354) (xy 114.372027 86.583953) (xy 114.37261 86.577051)
+				(xy 114.393262 86.393758) (xy 114.394234 86.386869) (xy 114.394469 86.385486) (xy 114.395825 86.378668)
+				(xy 114.399236 86.363722) (xy 114.400966 86.357013) (xy 114.401354 86.355665) (xy 114.403475 86.349009)
+				(xy 114.447778 86.222398) (xy 113.661116 87.009061) (xy 113.308977 87.009061) (xy 112.423679 86.123763)
+				(xy 111.538381 87.009061) (xy 111.186241 87.009061) (xy 111.186242 87.00906) (xy 110.300945 86.123763)
+				(xy 109.415647 87.009061) (xy 109.063508 87.009061) (xy 108.17821 86.123763) (xy 107.292912 87.009061)
+				(xy 106.940774 87.009061) (xy 106.055475 86.123762) (xy 105.170177 87.009061) (xy 104.818039 87.009061)
+				(xy 103.932741 86.123763) (xy 103.399 86.657504) (xy 103 86.657504) (xy 103 85.947693) (xy 104.108809 85.947693)
+				(xy 104.994108 86.832992) (xy 105.879406 85.947693) (xy 106.231544 85.947693) (xy 107.116843 86.832992)
+				(xy 108.002141 85.947693) (xy 108.354278 85.947693) (xy 109.239577 86.832992) (xy 110.124875 85.947693)
+				(xy 110.477013 85.947693) (xy 111.362312 86.832992) (xy 112.24761 85.947694) (xy 112.247609 85.947693)
+				(xy 112.599748 85.947693) (xy 113.485046 86.832992) (xy 114.370345 85.947693) (xy 113.485046 85.062395)
+				(xy 112.599748 85.947693) (xy 112.247609 85.947693) (xy 111.873416 85.5735) (xy 111.818277 85.5735)
+				(xy 111.809457 85.573186) (xy 111.807676 85.573059) (xy 111.79885 85.572111) (xy 111.779527 85.569333)
+				(xy 111.770788 85.567755) (xy 111.769043 85.567375) (xy 111.760494 85.565192) (xy 111.623095 85.524849)
+				(xy 112.176903 85.524849) (xy 112.423678 85.771624) (xy 113.308977 84.886326) (xy 113.661115 84.886326)
+				(xy 114.546414 85.771624) (xy 114.67026 85.647778) (xy 115.022397 85.647778) (xy 115.149009 85.603475)
+				(xy 115.155665 85.601354) (xy 115.157013 85.600966) (xy 115.163722 85.599236) (xy 115.178668 85.595825)
+				(xy 115.185486 85.594469) (xy 115.186869 85.594234) (xy 115.193758 85.593262) (xy 115.377051 85.57261)
+				(xy 115.383953 85.572027) (xy 115.385354 85.571948) (xy 115.392335 85.571751) (xy 115.407665 85.571751)
+				(xy 115.414646 85.571948) (xy 115.416047 85.572027) (xy 115.422949 85.57261) (xy 115.606242 85.593262)
+				(xy 115.613131 85.594234) (xy 115.614514 85.594469) (xy 115.621332 85.595825) (xy 115.636278 85.599236)
+				(xy 115.642987 85.600966) (xy 115.644335 85.601354) (xy 115.650991 85.603475) (xy 115.825091 85.664396)
+				(xy 115.831527 85.66685) (xy 115.832823 85.667386) (xy 115.839234 85.670253) (xy 115.853047 85.676905)
+				(xy 115.859247 85.680109) (xy 115.860475 85.680788) (xy 115.866445 85.68431) (xy 116.022625 85.782445)
+				(xy 116.028425 85.786321) (xy 116.029569 85.787133) (xy 116.035112 85.791306) (xy 116.047098 85.800865)
+				(xy 116.052372 85.805317) (xy 116.053418 85.806251) (xy 116.05851 85.811063) (xy 116.188937 85.94149)
+				(xy 116.193749 85.946582) (xy 116.194683 85.947628) (xy 116.199135 85.952902) (xy 116.208694 85.964888)
+				(xy 116.212867 85.970431) (xy 116.213679 85.971575) (xy 116.217555 85.977375) (xy 116.31242 86.128351)
+				(xy 116.493078 85.947693) (xy 116.845217 85.947693) (xy 117.730515 86.832991) (xy 118.319489 86.244017)
+				(xy 118.277375 86.217555) (xy 118.271575 86.213679) (xy 118.270431 86.212867) (xy 118.264888 86.208694)
+				(xy 118.252902 86.199135) (xy 118.247628 86.194683) (xy 118.246582 86.193749) (xy 118.24149 86.188937)
+				(xy 118.111063 86.05851) (xy 118.106251 86.053418) (xy 118.105317 86.052372) (xy 118.100865 86.047098)
+				(xy 118.091306 86.035112) (xy 118.087133 86.029569) (xy 118.086321 86.028425) (xy 118.082445 86.022625)
+				(xy 117.98431 85.866445) (xy 117.980788 85.860475) (xy 117.980109 85.859247) (xy 117.976905 85.853047)
+				(xy 117.970253 85.839234) (xy 117.967386 85.832823) (xy 117.96685 85.831527) (xy 117.964396 85.825091)
+				(xy 117.903475 85.650991) (xy 117.901354 85.644335) (xy 117.900966 85.642987) (xy 117.899236 85.636278)
+				(xy 117.895825 85.621332) (xy 117.894469 85.614514) (xy 117.894234 85.613131) (xy 117.893262 85.606242)
+				(xy 117.87261 85.422949) (xy 117.872027 85.416047) (xy 117.871948 85.414646) (xy 117.871751 85.407665)
+				(xy 117.871751 85.399997) (xy 118.144751 85.399997) (xy 118.144751 85.400002) (xy 118.163685 85.568056)
+				(xy 118.219545 85.727694) (xy 118.219547 85.727697) (xy 118.309518 85.870884) (xy 118.309523 85.87089)
+				(xy 118.429109 85.990476) (xy 118.429115 85.990481) (xy 118.572302 86.080452) (xy 118.572305 86.080454)
+				(xy 118.572309 86.080455) (xy 118.57231 86.080456) (xy 118.629593 86.1005) (xy 118.731943 86.136314)
+				(xy 118.899997 86.155249) (xy 118.9 86.155249) (xy 118.900003 86.155249) (xy 119.068056 86.136314)
+				(xy 119.068059 86.136313) (xy 119.22769 86.080456) (xy 119.334028 86.013638) (xy 119.401263 85.994638)
+				(xy 119.46597 86.013638) (xy 119.500146 86.035112) (xy 119.572306 86.080454) (xy 119.572307 86.080454)
+				(xy 119.57231 86.080456) (xy 119.67873 86.117694) (xy 119.731943 86.136314) (xy 119.899997 86.155249)
+				(xy 119.9 86.155249) (xy 119.900003 86.155249) (xy 120.068056 86.136314) (xy 120.068059 86.136313)
+				(xy 120.22769 86.080456) (xy 120.37089 85.990477) (xy 120.370889 85.990477) (xy 120.376787 85.986772)
+				(xy 120.37842 85.989372) (xy 120.430454 85.968069) (xy 120.499162 85.980757) (xy 120.500828 85.981616)
+				(xy 120.625593 86.047098) (xy 120.649775 86.05979) (xy 120.814944 86.1005) (xy 120.985056 86.1005)
+				(xy 121.150225 86.05979) (xy 121.229692 86.018081) (xy 121.300849 85.980736) (xy 121.30085 85.980734)
+				(xy 121.300852 85.980734) (xy 121.428183 85.867929) (xy 121.524818 85.72793) (xy 121.58514 85.568872)
+				(xy 121.605645 85.4) (xy 121.58514 85.231128) (xy 121.5844 85.229178) (xy 121.524817 85.072068)
+				(xy 121.454978 84.97089) (xy 121.428183 84.932071) (xy 121.310369 84.827697) (xy 121.300849 84.819263)
+				(xy 121.150226 84.74021) (xy 120.985056 84.6995) (xy 120.814944 84.6995) (xy 120.649774 84.740209)
+				(xy 120.500826 84.818384) (xy 120.432318 84.832109) (xy 120.378238 84.810916) (xy 120.376786 84.813227)
+				(xy 120.227697 84.719547) (xy 120.227694 84.719545) (xy 120.068056 84.663685) (xy 119.900003 84.644751)
+				(xy 119.899997 84.644751) (xy 119.731943 84.663685) (xy 119.572307 84.719545) (xy 119.465972 84.786361)
+				(xy 119.398736 84.805361) (xy 119.334028 84.786361) (xy 119.227692 84.719545) (xy 119.227691 84.719544)
+				(xy 119.22769 84.719544) (xy 119.18937 84.706135) (xy 119.068056 84.663685) (xy 118.900003 84.644751)
+				(xy 118.899997 84.644751) (xy 118.731943 84.663685) (xy 118.572305 84.719545) (xy 118.572302 84.719547)
+				(xy 118.429115 84.809518) (xy 118.429109 84.809523) (xy 118.309523 84.929109) (xy 118.309518 84.929115)
+				(xy 118.219547 85.072302) (xy 118.219545 85.072305) (xy 118.163685 85.231943) (xy 118.144751 85.399997)
+				(xy 117.871751 85.399997) (xy 117.871751 85.392335) (xy 117.871948 85.385354) (xy 117.872027 85.383953)
+				(xy 117.87261 85.377051) (xy 117.890083 85.221963) (xy 117.730515 85.062395) (xy 116.845217 85.947693)
+				(xy 116.493078 85.947693) (xy 115.607781 85.062395) (xy 115.022397 85.647778) (xy 114.67026 85.647778)
+				(xy 115.431712 84.886326) (xy 115.783849 84.886326) (xy 116.669148 85.771624) (xy 117.554446 84.886326)
+				(xy 117.906585 84.886326) (xy 117.973754 84.953495) (xy 117.976905 84.946953) (xy 117.980109 84.940753)
+				(xy 117.980788 84.939525) (xy 117.98431 84.933555) (xy 118.082445 84.777375) (xy 118.086321 84.771575)
+				(xy 118.087133 84.770431) (xy 118.091306 84.764888) (xy 118.100865 84.752902) (xy 118.105317 84.747628)
+				(xy 118.106251 84.746582) (xy 118.111063 84.74149) (xy 118.24149 84.611063) (xy 118.246582 84.606251)
+				(xy 118.247628 84.605317) (xy 118.252902 84.600865) (xy 118.264888 84.591306) (xy 118.270431 84.587133)
+				(xy 118.271575 84.586321) (xy 118.277375 84.582445) (xy 118.393706 84.509349) (xy 120.406295 84.509349)
+				(xy 120.449941 84.536774) (xy 120.530216 84.494644) (xy 120.536932 84.491373) (xy 120.538309 84.490753)
+				(xy 120.545244 84.48788) (xy 120.560684 84.482024) (xy 120.567742 84.479588) (xy 120.569185 84.479138)
+				(xy 120.576427 84.477118) (xy 120.757629 84.432457) (xy 120.764897 84.430895) (xy 120.766383 84.430622)
+				(xy 120.773844 84.429485) (xy 120.790235 84.427495) (xy 120.797711 84.426816) (xy 120.799219 84.426725)
+				(xy 120.806688 84.4265) (xy 120.993312 84.4265) (xy 121.000781 84.426725) (xy 121.002289 84.426816)
+				(xy 121.009765 84.427495) (xy 121.026156 84.429485) (xy 121.033617 84.430622) (xy 121.035103 84.430895)
+				(xy 121.042371 84.432457) (xy 121.223573 84.477118) (xy 121.230815 84.479138) (xy 121.232258 84.479588)
+				(xy 121.239316 84.482024) (xy 121.254756 84.48788) (xy 121.261691 84.490753) (xy 121.263068 84.491373)
+				(xy 121.269785 84.494645) (xy 121.435032 84.581374) (xy 121.441517 84.58503) (xy 121.44281 84.585811)
+				(xy 121.449145 84.589905) (xy 121.462734 84.599286) (xy 121.468695 84.603669) (xy 121.469885 84.6046)
+				(xy 121.475705 84.609448) (xy 121.615394 84.733202) (xy 121.620848 84.738336) (xy 121.621917 84.739405)
+				(xy 121.627048 84.744855) (xy 121.637998 84.757214) (xy 121.642849 84.763038) (xy 121.64378 84.764228)
+				(xy 121.648166 84.770194) (xy 121.754182 84.923782) (xy 121.757432 84.928808) (xy 121.799915 84.886325)
+				(xy 120.914617 84.001027) (xy 120.406295 84.509349) (xy 118.393706 84.509349) (xy 118.433555 84.48431)
+				(xy 118.439525 84.480788) (xy 118.440753 84.480109) (xy 118.446953 84.476905) (xy 118.460766 84.470253)
+				(xy 118.467177 84.467386) (xy 118.468473 84.46685) (xy 118.474909 84.464396) (xy 118.649009 84.403475)
+				(xy 118.655665 84.401354) (xy 118.657013 84.400966) (xy 118.663722 84.399236) (xy 118.678668 84.395825)
+				(xy 118.685486 84.394469) (xy 118.686869 84.394234) (xy 118.693758 84.393262) (xy 118.877051 84.37261)
+				(xy 118.883953 84.372027) (xy 118.885354 84.371948) (xy 118.892335 84.371751) (xy 118.907665 84.371751)
+				(xy 118.914646 84.371948) (xy 118.916047 84.372027) (xy 118.922949 84.37261) (xy 119.106242 84.393262)
+				(xy 119.113131 84.394234) (xy 119.114514 84.394469) (xy 119.121332 84.395825) (xy 119.136278 84.399236)
+				(xy 119.142987 84.400966) (xy 119.144335 84.401354) (xy 119.150991 84.403475) (xy 119.217658 84.426803)
+				(xy 118.791883 84.001028) (xy 117.906585 84.886326) (xy 117.554446 84.886326) (xy 116.669148 84.001027)
+				(xy 115.783849 84.886326) (xy 115.431712 84.886326) (xy 114.546414 84.001028) (xy 113.661115 84.886326)
+				(xy 113.308977 84.886326) (xy 112.423678 84.001027) (xy 112.292149 84.132557) (xy 112.386934 84.193471)
+				(xy 112.394228 84.198537) (xy 112.395658 84.199608) (xy 112.402527 84.205144) (xy 112.417282 84.217929)
+				(xy 112.423796 84.223996) (xy 112.425058 84.225259) (xy 112.431055 84.231703) (xy 112.538089 84.355227)
+				(xy 112.543626 84.362097) (xy 112.544697 84.363527) (xy 112.549764 84.370822) (xy 112.560318 84.387245)
+				(xy 112.564823 84.394837) (xy 112.565679 84.396404) (xy 112.569651 84.404338) (xy 112.637549 84.553013)
+				(xy 112.640937 84.561191) (xy 112.641561 84.562864) (xy 112.644355 84.57126) (xy 112.649856 84.589993)
+				(xy 112.652055 84.598613) (xy 112.652434 84.600358) (xy 112.653997 84.609029) (xy 112.677258 84.77081)
+				(xy 112.678206 84.779637) (xy 112.678333 84.781418) (xy 112.678647 84.790238) (xy 112.678647 84.809762)
+				(xy 112.678333 84.818582) (xy 112.678206 84.820363) (xy 112.677258 84.82919) (xy 112.653997 84.990971)
+				(xy 112.652434 84.999642) (xy 112.652055 85.001387) (xy 112.649856 85.010007) (xy 112.644355 85.02874)
+				(xy 112.641561 85.037136) (xy 112.640937 85.038809) (xy 112.637549 85.046987) (xy 112.569651 85.195662)
+				(xy 112.565679 85.203596) (xy 112.564823 85.205163) (xy 112.560318 85.212755) (xy 112.549764 85.229178)
+				(xy 112.544697 85.236473) (xy 112.543626 85.237903) (xy 112.538089 85.244773) (xy 112.431055 85.368297)
+				(xy 112.425058 85.374741) (xy 112.423796 85.376004) (xy 112.417282 85.382071) (xy 112.402527 85.394856)
+				(xy 112.395658 85.400392) (xy 112.394228 85.401463) (xy 112.386934 85.406529) (xy 112.249436 85.494893)
+				(xy 112.241843 85.499399) (xy 112.240276 85.500255) (xy 112.232345 85.504226) (xy 112.214586 85.512337)
+				(xy 112.206382 85.515734) (xy 112.204708 85.516358) (xy 112.196331 85.519145) (xy 112.176903 85.524849)
+				(xy 111.623095 85.524849) (xy 111.603669 85.519145) (xy 111.595292 85.516358) (xy 111.593618 85.515734)
+				(xy 111.585414 85.512337) (xy 111.567655 85.504226) (xy 111.559724 85.500255) (xy 111.558157 85.499399)
+				(xy 111.550564 85.494893) (xy 111.413066 85.406529) (xy 111.405772 85.401463) (xy 111.404342 85.400392)
+				(xy 111.397473 85.394856) (xy 111.382718 85.382071) (xy 111.376204 85.376004) (xy 111.374942 85.374741)
+				(xy 111.368945 85.368297) (xy 111.261911 85.244773) (xy 111.256374 85.237903) (xy 111.255303 85.236473)
+				(xy 111.250236 85.229178) (xy 111.239682 85.212755) (xy 111.235177 85.205163) (xy 111.234321 85.203596)
+				(xy 111.230349 85.195662) (xy 111.229939 85.194766) (xy 110.477013 85.947693) (xy 110.124875 85.947693)
+				(xy 109.239577 85.062395) (xy 108.354278 85.947693) (xy 108.002141 85.947693) (xy 107.116843 85.062395)
+				(xy 106.231544 85.947693) (xy 105.879406 85.947693) (xy 104.994108 85.062395) (xy 104.108809 85.947693)
+				(xy 103 85.947693) (xy 103 84.534769) (xy 103.399 84.534769) (xy 103.399 85.237883) (xy 103.932741 85.771624)
+				(xy 104.818039 84.886326) (xy 105.170177 84.886326) (xy 106.055475 85.771624) (xy 106.940774 84.886326)
+				(xy 106.055475 84.001027) (xy 105.170177 84.886326) (xy 104.818039 84.886326) (xy 103.932741 84.001028)
+				(xy 103.399 84.534769) (xy 103 84.534769) (xy 103 83.824958) (xy 104.108809 83.824958) (xy 104.994108 84.710257)
+				(xy 105.879405 83.824959) (xy 106.231545 83.824959) (xy 107.116842 84.710256) (xy 107.275803 84.551295)
+				(xy 107.27261 84.522948) (xy 107.272027 84.516047) (xy 107.271948 84.514646) (xy 107.271751 84.507665)
+				(xy 107.271751 84.499997) (xy 107.544751 84.499997) (xy 107.544751 84.500002) (xy 107.563685 84.668056)
+				(xy 107.619545 84.827694) (xy 107.619547 84.827697) (xy 107.709518 84.970884) (xy 107.709523 84.97089)
+				(xy 107.829109 85.090476) (xy 107.829115 85.090481) (xy 107.972302 85.180452) (xy 107.972305 85.180454)
+				(xy 107.972309 85.180455) (xy 107.97231 85.180456) (xy 108.038441 85.203596) (xy 108.131943 85.236314)
+				(xy 108.299997 85.255249) (xy 108.3 85.255249) (xy 108.300003 85.255249) (xy 108.468056 85.236314)
+				(xy 108.480548 85.231943) (xy 108.62769 85.180456) (xy 108.627692 85.180454) (xy 108.627694 85.180454)
+				(xy 108.627697 85.180452) (xy 108.770884 85.090481) (xy 108.770885 85.09048) (xy 108.77089 85.090477)
+				(xy 108.890477 84.97089) (xy 108.908343 84.942457) (xy 108.943613 84.886326) (xy 109.415646 84.886326)
+				(xy 110.300944 85.771624) (xy 111.137906 84.934661) (xy 111.122742 84.82919) (xy 111.121976 84.822059)
+				(xy 111.099917 84.8) (xy 111.394353 84.8) (xy 111.414834 84.942456) (xy 111.474622 85.073371) (xy 111.474623 85.073373)
 				(xy 111.568872 85.182143) (xy 111.689947 85.259953) (xy 111.68995 85.259954) (xy 111.689949 85.259954)
 				(xy 111.828036 85.300499) (xy 111.828038 85.3005) (xy 111.828039 85.3005) (xy 111.971962 85.3005)
 				(xy 111.971962 85.300499) (xy 112.110053 85.259953) (xy 112.231128 85.182143) (xy 112.325377 85.073373)

--- a/pcb/oe-commutator-controller.kicad_pro
+++ b/pcb/oe-commutator-controller.kicad_pro
@@ -48,7 +48,7 @@
         "silk_text_thickness": 0.15,
         "silk_text_upright": false,
         "zones": {
-          "min_clearance": 0.25
+          "min_clearance": 0.0
         }
       },
       "diff_pair_dimensions": [

--- a/pcb/oe-commutator-controller.kicad_sch
+++ b/pcb/oe-commutator-controller.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Open Ephys Commutator Controller")
-		(rev "F")
+		(rev "G")
 		(company "Open Ephys, Inc.")
 		(comment 1 "Cris Sharp")
 		(comment 2 "Jonathan P. Newman")
@@ -2532,16 +2532,6 @@
 			)
 			(uuid "efe01cad-11ab-400c-a220-de392e7bae84")
 		)
-		(pin "LTC44_{CURR}" output
-			(at 139.7 92.71 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-			(uuid "4e7ef4b8-cc54-484d-81fd-f9f918d6c9d1")
-		)
 		(pin "LTC44_{~{PFO}}" input
 			(at 139.7 95.25 0)
 			(effects
@@ -2631,6 +2621,16 @@
 				(justify right)
 			)
 			(uuid "307008af-19c7-4a41-9e7c-f2fcc2b1866f")
+		)
+		(pin "LTC44_{CURR}" input
+			(at 139.7 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+			(uuid "eb774405-5b55-4630-97f2-1b8bd14eaf81")
 		)
 		(instances
 			(project "oe-commutator-controller"


### PR DESCRIPTION
- Move R10 & R13 silk screen designators closer to their respective resistors
- Add specific part numbers to C15 & C15 which are xtal caps w/ NP0 temp coefficient
- Update libraries to remove solder paste from big caps' footprint
- Made boot select button footprint to datasheet spec (had to move some traces to do this)
- Remove solder paste from LED footprint
- Update revision f-->g in sch, pcb, & pcb's silk screen
- No solder paste in the LED footprint