### PR TITLE
Enable double-tapping reset button to enter bootloader

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(commutator PRIVATE
     pico_stdlib
     pico_time
     pico_multicore
+    pico_bootsel_via_double_reset
     hardware_adc
     hardware_i2c
     hardware_spi
@@ -71,7 +72,6 @@ target_sources(commutator PRIVATE
         cap1296.cpp
         accelstepper/AccelStepper.cpp
         io.cpp
-        pico_bootsel_via_double_reset
         )
 
 


### PR DESCRIPTION
Fix #36 so that users don't have to disassemble commutator to update firmware.