### PR TITLE
add startup delay that some commutators need to boot reliably

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -78,5 +78,4 @@ target_sources(commutator PRIVATE
 add_subdirectory(arduinojson)
 
 add_compile_options(-Wall -Wextra -Wpedantic)
-
-
+add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)


### PR DESCRIPTION
I found one commutator that works immediately after flashing with firmware, but it doesn't properly boot after being power cycled. I was able to fix this by increasing the startup delay in the CMakeLists.txt file.

Before this PR:

https://github.com/user-attachments/assets/169e3105-a10e-487f-b395-003a565387b9

The same commutator controller, after making the change in this PR:

https://github.com/user-attachments/assets/bb065857-7ee8-479b-91f6-52deed8fb7a3

I found another commutator that booted unreliably. This PR fixed this one as well. 

Both of the commutators controllers that expressed this behavior were revision H.