### PR TITLE
Remove newline requirement for serial json parsing

### DIFF
--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -170,8 +170,20 @@ static int process_serial_commands(context_t *ctx)
 {
     static char serial_buffer[MAX_SERIAL_BUFFER_LENGTH] = {0};
     static uint16_t serial_buffer_index = 0;
+    static bool accept_serial_commands_previous = false;
+    static bool accept_serial_commands = false;
 
-    if(!remote_available(ctx))
+    accept_serial_commands = remote_available(ctx);
+
+    if (accept_serial_commands && !accept_serial_commands_previous) {
+        while (getchar_timeout_us(0) != PICO_ERROR_TIMEOUT);
+        serial_buffer_index = 0;
+        memset(serial_buffer, 0, MAX_SERIAL_BUFFER_LENGTH);
+    }
+
+    accept_serial_commands_previous = accept_serial_commands;
+
+    if (!accept_serial_commands)
         return ERROR_REMOTE_INTERFACE_LOCKED;
 
     if (tud_cdc_available()) {


### PR DESCRIPTION
- Rewrite serial buffer builder to not need newline termination:
  - Let ArduinoJson decide if serial buffer is terminated
  - Ignore characters preceding `{`
    - This prevents `DeserializeJson` from parsing strings or arrays instead of JSON objects (i.e. handles the case when a double quotes `"` or open square bracket `[` precedes your JSON which would otherwise brick serial inputs until the string or array is terminated)
    - An alternative is to rollback ArduinoJson to v5 and instead use the `ParseObject` method
  - Restart buffer if new `{` is received 
    - This prevents a singular open curly bracket '{' from bricking serial inputs. This is a proposed improvement from 

---

I tried using `std::cin` instead of constructing our own buffer. There were some problems associated with that.

Originally, the `process_serial_commands` was only called when a new character was received from the serial port. This meant that if I sent a message like "a{turn:1}" or "{enable:true}{turn:1}", only the first item would be parses (in the first case, an invalid input "a"; in the second case, a valid JSON), and the second item wouldn't be parsed until another character was received. If I remove the guard, `std::cin` would block when it's empty, and there doesn't seem to be any standard way to check if `std::cin` is empty without blocking.