### PR TITLE
Read TMC2130 registers from correct address

### DIFF
--- a/firmware/tmc2130.cpp
+++ b/firmware/tmc2130.cpp
@@ -38,14 +38,23 @@ static void tmc2130_write(uint8_t reg, uint32_t data)
 
 static uint32_t tmc2130_read(uint8_t reg)
 {
-    uint8_t dst[5];
+    // Refer to 4.1.1 of datasheet for clarification regarding this
+    // implementation
+    uint8_t rx[5];
+    uint8_t tx[5] = {(uint8_t)(READ_FLAG | reg), 0, 0, 0, 0};
 
     cs_select();
-    spi_read_blocking(TMC2130_SPI_PORT, (uint8_t)(READ_FLAG | reg), dst, 5);
+    spi_write_read_blocking(TMC2130_SPI_PORT, tx, rx, 5);
     cs_deselect();
 
-    return  (uint32_t)dst[1] << 24 | (uint32_t)dst[2] << 16 | (uint32_t)dst[3] << 8 | (uint32_t)dst[4] << 0;
+    sleep_us(1);
 
+    tx[0] = 0;
+    cs_select();
+    spi_write_read_blocking(TMC2130_SPI_PORT, tx, rx, 5);
+    cs_deselect();
+
+    return (uint32_t)rx[1] << 24 | (uint32_t)rx[2] << 16 | (uint32_t)rx[3] << 8  | (uint32_t)rx[4];
 }
 
 void tmc2130_init()


### PR DESCRIPTION
The current implementation can lead to confusion wherein data is read from a different register than is expected (and might also risks reading out latched/stale data).

[datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/TMC2130_datasheet_rev1.16.pdf)

<img width="802" height="364" alt="image" src="https://github.com/user-attachments/assets/214a8711-58e2-4be3-8d76-1aae5bda8de5" />

I noticed this problem when I ran into issues detecting stall and reading the TSTEP register from the TMC2130